### PR TITLE
Fix UCSC hyperlink markdown in about.mdx

### DIFF
--- a/app/components/About/components/Section/components/SectionAbout/components/MDX/about.mdx
+++ b/app/components/About/components/Section/components/SectionAbout/components/MDX/about.mdx
@@ -4,7 +4,7 @@
 
 ## UCSC Genome Browser
 
-[The UCSC Genome Browser](https://genome.ucsc.edu, maintained by the University of California, Santa Cruz (UCSC), is a widely used and highly regarded online tool for visualizing and exploring genomic information. It is one of the most widely used sources of genomic data in the world, with more than 150,000 monthly users, spread over 200 countries and the majority of usage coming from outside the United States. The Browser team has been generating and distributing multiple alignments for genomes distributed on the site.
+[The UCSC Genome Browser](https://genome.ucsc.edu, maintained by the University of California, Santa Cruz (UCSC)), is a widely used and highly regarded online tool for visualizing and exploring genomic information. It is one of the most widely used sources of genomic data in the world, with more than 150,000 monthly users, spread over 200 countries and the majority of usage coming from outside the United States. The Browser team has been generating and distributing multiple alignments for genomes distributed on the site.
 
 ## HyPhy
 


### PR DESCRIPTION
Was missing closing parens for the hyperlink to the UCSC genome browser.