### PR TITLE
fix: add space between fig caption on about page for mobile viewport (#119)

### DIFF
--- a/app/components/content/sectionAbout.mdx
+++ b/app/components/content/sectionAbout.mdx
@@ -171,7 +171,7 @@
               annotations stored and distributed by the UCSC Table Browser. This
               data will include annotations that were previously available from
               the VEuPathDb resource. Users will be able to view, download and
-              visualize the data.
+              visualize the data.{" "}
             </span>
             <span>
               The Galaxy platform will be used for the analysis of genomic,


### PR DESCRIPTION
Closes #119.