### PR TITLE
feat: add carousel card for webinar video (#127)

### DIFF
--- a/app/components/Home/components/Section/components/SectionHero/components/Carousel/cards/constants.ts
+++ b/app/components/Home/components/Section/components/SectionHero/components/Carousel/cards/constants.ts
@@ -6,6 +6,9 @@ export const CAROUSEL_CARDS: Pick<CardProps, "text">[] = [
   //   text: MDX.Webinars({}),
   // },
   {
+    text: MDX.Webinar20241004({}),
+  },
+  {
     text: MDX.ShareUsageAndJoinAdvisoryPanel({}),
   },
   {

--- a/app/components/Home/components/Section/components/SectionHero/components/Carousel/content/index.tsx
+++ b/app/components/Home/components/Section/components/SectionHero/components/Carousel/content/index.tsx
@@ -1,3 +1,4 @@
 export { default as LearnToAnalyzeData } from "./learnToAnalyzeData.mdx";
 export { default as ShareUsageAndJoinAdvisoryPanel } from "./shareUsageAndJoinAdvisoryPanel.mdx";
+export { default as Webinar20241004 } from "./webinar20241004.mdx";
 export { default as Webinars } from "./webinars.mdx";

--- a/app/components/Home/components/Section/components/SectionHero/components/Carousel/content/webinar20241004.mdx
+++ b/app/components/Home/components/Section/components/SectionHero/components/Carousel/content/webinar20241004.mdx
@@ -1,0 +1,7 @@
+### BRC Q&A webinar video available
+
+On Friday, October 4, we hosted a video webinar Q&A about BRC Analytics where we discussed the future of the project and encouraged interested people to get involved in planning for next steps. A video of that webinar (w/auto-generated captions) is available on YouTube.
+
+<CardActions>
+  <Link label="View on YouTube" url="https://youtu.be/dWK8AAk-Wns" />
+</CardActions>


### PR DESCRIPTION
Closes #127.

<img width="1517" alt="image" src="https://github.com/user-attachments/assets/a34edf27-106a-45e9-878a-94db552e06d3">
