### PR TITLE
feat: add carousel card for 2024-10-30 webinar (#141)

### DIFF
--- a/app/components/Home/components/Section/components/SectionHero/components/Carousel/cards/constants.ts
+++ b/app/components/Home/components/Section/components/SectionHero/components/Carousel/cards/constants.ts
@@ -6,6 +6,9 @@ export const CAROUSEL_CARDS: Pick<CardProps, "text">[] = [
   //   text: MDX.Webinars({}),
   // },
   {
+    text: MDX.Webinar20241030({}),
+  },
+  {
     text: MDX.Webinar20241004({}),
   },
   {

--- a/app/components/Home/components/Section/components/SectionHero/components/Carousel/content/index.tsx
+++ b/app/components/Home/components/Section/components/SectionHero/components/Carousel/content/index.tsx
@@ -1,4 +1,5 @@
 export { default as LearnToAnalyzeData } from "./learnToAnalyzeData.mdx";
 export { default as ShareUsageAndJoinAdvisoryPanel } from "./shareUsageAndJoinAdvisoryPanel.mdx";
 export { default as Webinar20241004 } from "./webinar20241004.mdx";
+export { default as Webinar20241030 } from "./webinar20241030.mdx";
 export { default as Webinars } from "./webinars.mdx";

--- a/app/components/Home/components/Section/components/SectionHero/components/Carousel/content/webinar20241030.mdx
+++ b/app/components/Home/components/Section/components/SectionHero/components/Carousel/content/webinar20241030.mdx
@@ -1,6 +1,6 @@
 ### Q&A Webinar on Wednesday, October 30th
 
-Please join us for another Q&A webinar on October 30th at 1 PM EDT/10 AM PDT/1700 UTC. We will focus primarily on the actual “analytics” part of the website: the Analyze buttons that will take users to workflows specific to the genome being worked on for various analysis types. Please join in and give feedback on our direction, as this is still early in development.
+Please join us for another Q&A webinar on October 30th at 1 PM EDT/10 AM PDT/1700 UTC. We'll focus primarily on the actual “analytics” part of the website: the Analyze buttons that will take users to workflows specific to the genome being worked on for various analysis types. Please join in and give feedback on our direction, as this is still early in development.
 
 <CardActions>
   <Link

--- a/app/components/Home/components/Section/components/SectionHero/components/Carousel/content/webinar20241030.mdx
+++ b/app/components/Home/components/Section/components/SectionHero/components/Carousel/content/webinar20241030.mdx
@@ -1,0 +1,10 @@
+### Q&A Webinar on Wednesday, October 30th
+
+Please join us for another Q&A webinar on October 30th at 1 PM EDT/10 AM PDT/1700 UTC. We will focus primarily on the actual “analytics” part of the website: the Analyze buttons that will take users to workflows specific to the genome being worked on for various analysis types. Please join in and give feedback on our direction, as this is still early in development.
+
+<CardActions>
+  <Link
+    label="Zoom Link"
+    url="https://psu.zoom.us/j/99331380856?pwd=ktUUark52KveSfI824OPn5Rglfb3Wi.1"
+  />
+</CardActions>


### PR DESCRIPTION
~~Note: the card text seems to be just long enough to get awkwardly low down on the card (not enough to overflow though)~~

Changing "We will" to "We'll" seems to make it fit better