### PR TITLE
feat: added discourse header/footer button (#88)

### DIFF
--- a/app/components/index.ts
+++ b/app/components/index.ts
@@ -1,5 +1,6 @@
 export { Alert } from "@databiosphere/findable-ui/lib/components/common/Alert/alert";
 export { Breadcrumbs } from "@databiosphere/findable-ui/lib/components/common/Breadcrumbs/breadcrumbs";
+export { DiscourseIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/DiscourseIcon/discourseIcon";
 export { Grid } from "@databiosphere/findable-ui/lib/components/common/Grid/grid";
 export { KeyElType } from "@databiosphere/findable-ui/lib/components/common/KeyValuePairs/components/KeyElType/keyElType";
 export { KeyValueElType } from "@databiosphere/findable-ui/lib/components/common/KeyValuePairs/components/KeyValueElType/keyValueElType";

--- a/site-config/brc-analytics/local/config.ts
+++ b/site-config/brc-analytics/local/config.ts
@@ -5,6 +5,7 @@ import * as C from "../../../app/components";
 import { ROUTES } from "../../../routes/constants";
 import { floating } from "./floating/floating";
 import { genomeEntityConfig } from "./index/genomeEntityConfig";
+import { socialMedia } from "./socialMedia";
 
 const LOCALHOST = "http://localhost:3000";
 const APP_TITLE = "BRC Analytics";
@@ -68,6 +69,7 @@ export function makeConfig(browserUrl: string, gitHubUrl: string): SiteConfig {
           ],
           undefined,
         ],
+        socialMedia: socialMedia,
       },
     },
     redirectRootToPath: "/",

--- a/site-config/brc-analytics/local/config.ts
+++ b/site-config/brc-analytics/local/config.ts
@@ -1,3 +1,4 @@
+import { ANCHOR_TARGET } from "@databiosphere/findable-ui/lib/components/Links/common/entities";
 import { SiteConfig } from "@databiosphere/findable-ui/lib/config/entities";
 import { EntityConfig } from "@databiosphere/findable-ui/src/config/entities";
 import { BRCDataCatalogGenome } from "../../../app/apis/catalog/brc-analytics-catalog/common/entities";
@@ -44,10 +45,12 @@ export function makeConfig(browserUrl: string, gitHubUrl: string): SiteConfig {
         navLinks: [
           {
             label: "BV-BRC",
+            target: ANCHOR_TARGET.BLANK,
             url: "https://www.bv-brc.org/",
           },
           {
             label: "Pathogen Data Network",
+            target: ANCHOR_TARGET.BLANK,
             url: "https://pathogendatanetwork.org/",
           },
         ],

--- a/site-config/brc-analytics/local/config.ts
+++ b/site-config/brc-analytics/local/config.ts
@@ -51,6 +51,7 @@ export function makeConfig(browserUrl: string, gitHubUrl: string): SiteConfig {
             url: "https://pathogendatanetwork.org/",
           },
         ],
+        socials: socialMedia.socials,
         versionInfo: true,
       },
       header: {

--- a/site-config/brc-analytics/local/socialMedia.ts
+++ b/site-config/brc-analytics/local/socialMedia.ts
@@ -1,0 +1,18 @@
+import { SocialMedia } from "@databiosphere/findable-ui/lib/components/Layout/components/Header/common/entities";
+import * as C from "../../../app/components";
+
+export const SOCIALS = {
+  DISCOURSE: {
+    label: "Discourse",
+    url: "https://help.brc-analytics.org/",
+  },
+};
+
+export const socialMedia: SocialMedia = {
+  socials: [
+    {
+      ...SOCIALS.DISCOURSE,
+      Icon: C.DiscourseIcon,
+    },
+  ],
+};


### PR DESCRIPTION
- Added [Discourse](https://help.brc-analytics.org/) link to the site header and footer with the appropriate icon
- Resolved issue where navlinks opened in the same tab