### PR TITLE
feat: support multiple analysis methods per category (#279)

### DIFF
--- a/app/components/Entity/components/AnalysisMethod/analysisMethod.styles.ts
+++ b/app/components/Entity/components/AnalysisMethod/analysisMethod.styles.ts
@@ -1,77 +1,65 @@
-import { GridPaperSection } from "@databiosphere/findable-ui/lib/components/common/Section/section.styles";
 import {
   inkLight,
-  smokeDark,
-  smokeLightest,
+  white,
 } from "@databiosphere/findable-ui/lib/styles/common/mixins/colors";
-import {
-  textBody4002Lines,
-  textBody500,
-} from "@databiosphere/findable-ui/lib/styles/common/mixins/fonts";
-import { css } from "@emotion/react";
 import styled from "@emotion/styled";
+import { Accordion } from "@mui/material";
+import { smokeLightest } from "@databiosphere/findable-ui/lib/theme/common/palette";
+import { elevation01 } from "@databiosphere/findable-ui/lib/theme/common/shadows";
 
-interface Props {
-  isAvailable: boolean;
-}
+export const StyledAccordion = styled(Accordion)`
+  &.MuiAccordion-root {
+    background-color: ${white};
+    box-shadow: ${elevation01};
 
-export const StyledSection = styled(GridPaperSection, {
-  shouldForwardProp: (props) => props !== "isAvailable",
-})<Props>`
-  flex-direction: row;
-  gap: 16px;
+    .MuiAccordion-heading {
+      display: block;
+      padding: 20px;
 
-  .MuiChip-root,
-  .MuiSvgIcon-root {
-    align-self: center;
-  }
+      .MuiAccordionSummary-root {
+        flex-direction: row;
+        gap: 16px;
 
-  .MuiSvgIcon-root {
-    transform: rotate(180deg);
-    transition: transform 300ms;
-  }
+        .MuiAccordionSummary-content {
+          display: flex;
+          flex-direction: column;
+          gap: 4px;
+          margin: 0;
 
-  &:hover {
-    .MuiSvgIcon-root {
-      transform: rotate(180deg) translateX(-2px);
-    }
-  }
+          .MuiTypography-root {
+            margin: 0;
 
-  ${(props) =>
-    props.isAvailable &&
-    css`
-      cursor: pointer;
-    `}
+            &.MuiTypography-text-heading-small {
+              font-size: 16px;
+              letter-spacing: normal;
+              line-height: 24px;
+            }
+          }
+        }
 
-  ${(props) =>
-    !props.isAvailable &&
-    css`
-      background-color: ${smokeLightest(props)};
-      pointer-events: none;
+        .MuiAccordionSummary-expandIconWrapper {
+          .MuiSvgIcon-root {
+            transform: rotate(90deg);
+          }
 
-      .MuiChip-root {
-        .MuiChip-label {
-          color: ${inkLight(props)};
+          .MuiChip-root {
+            color: ${inkLight};
+          }
+        }
+
+        &.Mui-disabled {
+          opacity: 1;
         }
       }
+    }
 
-      .MuiSvgIcon-root {
-        color: ${smokeDark(props)};
-      }
-    `}
-`;
+    .MuiAccordionDetails-root {
+      margin: 0;
+      padding: 0;
+    }
 
-export const SectionContent = styled.div`
-  flex: 1;
-
-  h3 {
-    ${textBody500};
-    margin: 0 0 4px;
+    &.Mui-disabled {
+      background-color: ${smokeLightest};
+    }
   }
-
-  p {
-    ${textBody4002Lines};
-    color: ${inkLight};
-    margin: 0;
-  }
-`;
+` as typeof Accordion;

--- a/app/components/Entity/components/AnalysisMethod/analysisMethod.tsx
+++ b/app/components/Entity/components/AnalysisMethod/analysisMethod.tsx
@@ -8,7 +8,7 @@ import {
 import { StyledAccordion } from "./analysisMethod.styles";
 import { CHIP_PROPS, ICON_PROPS, TYPOGRAPHY_PROPS } from "./constants";
 import { Props } from "./types";
-import { RoundedPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/paper.styles";
+import { FluidPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/paper.styles";
 import { TEXT_HEADING_SMALL } from "@databiosphere/findable-ui/lib/theme/common/typography";
 import { Fragment } from "react";
 import { Workflow } from "./components/Workflow/workflow";
@@ -22,7 +22,7 @@ export const AnalysisMethod = ({
 }: Props): JSX.Element => {
   const isDisabled = workflows.length === 0;
   return (
-    <StyledAccordion component={RoundedPaper} disabled={isDisabled}>
+    <StyledAccordion component={FluidPaper} disabled={isDisabled}>
       <AccordionSummary
         expandIcon={
           isDisabled ? (

--- a/app/components/Entity/components/AnalysisMethod/analysisMethod.tsx
+++ b/app/components/Entity/components/AnalysisMethod/analysisMethod.tsx
@@ -1,60 +1,56 @@
-import { SouthIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/SouthIcon/southIcon";
-import { STATUS_BADGE_COLOR } from "@databiosphere/findable-ui/lib/components/common/StatusBadge/statusBadge";
 import {
-  ANCHOR_TARGET,
-  REL_ATTRIBUTE,
-} from "@databiosphere/findable-ui/lib/components/Links/common/entities";
-import {
-  Loading,
-  LOADING_PANEL_STYLE,
-} from "@databiosphere/findable-ui/lib/components/Loading/loading";
-import { useAsync } from "@databiosphere/findable-ui/lib/hooks/useAsync";
-import { Chip } from "@mui/material";
-import { getWorkflowLandingUrl } from "app/utils/galaxy-api";
-import { SectionContent, StyledSection } from "./analysisMethod.styles";
-import { CHIP_PROPS, ICON_PROPS } from "./constants";
+  AccordionDetails,
+  AccordionSummary,
+  Chip,
+  Divider,
+  Typography,
+} from "@mui/material";
+import { StyledAccordion } from "./analysisMethod.styles";
+import { CHIP_PROPS, ICON_PROPS, TYPOGRAPHY_PROPS } from "./constants";
 import { Props } from "./types";
+import { RoundedPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/paper.styles";
+import { TEXT_HEADING_SMALL } from "@databiosphere/findable-ui/lib/theme/common/typography";
+import { Fragment } from "react";
+import { Workflow } from "./components/Workflow/workflow";
+import { ChevronRightRounded } from "@mui/icons-material";
 
 export const AnalysisMethod = ({
-  content,
   geneModelUrl,
   genomeVersionAssemblyId,
-  workflowId,
+  workflowCategory,
+  workflows,
 }: Props): JSX.Element => {
-  const isAvailable = Boolean(workflowId);
-  const { data: landingUrl, isLoading, run } = useAsync<string>();
+  const isDisabled = workflows.length === 0;
   return (
-    <StyledSection
-      isAvailable={isAvailable}
-      onClick={async (): Promise<void> => {
-        if (!workflowId) return;
-        const url =
-          landingUrl ??
-          (await run(
-            getWorkflowLandingUrl(
-              workflowId,
-              genomeVersionAssemblyId,
-              geneModelUrl
-            )
-          ));
-        window.open(
-          url,
-          ANCHOR_TARGET.BLANK,
-          REL_ATTRIBUTE.NO_OPENER_NO_REFERRER
-        );
-      }}
-      role="button"
-    >
-      <Loading loading={isLoading} panelStyle={LOADING_PANEL_STYLE.INHERIT} />
-      <SectionContent>{content}</SectionContent>
-      {!isAvailable && (
-        <Chip
-          {...CHIP_PROPS}
-          color={STATUS_BADGE_COLOR.DEFAULT}
-          label="Coming Soon"
-        />
-      )}
-      <SouthIcon {...ICON_PROPS} />
-    </StyledSection>
+    <StyledAccordion component={RoundedPaper} disabled={isDisabled}>
+      <AccordionSummary
+        expandIcon={
+          isDisabled ? (
+            <Chip {...CHIP_PROPS} />
+          ) : (
+            <ChevronRightRounded {...ICON_PROPS} />
+          )
+        }
+      >
+        <Typography variant={TEXT_HEADING_SMALL}>
+          {workflowCategory.name}
+        </Typography>
+        <Typography {...TYPOGRAPHY_PROPS}>
+          {workflowCategory.description}
+        </Typography>
+      </AccordionSummary>
+      <AccordionDetails>
+        {workflows.map((workflow) => (
+          <Fragment key={workflow.workflowName}>
+            <Divider />
+            <Workflow
+              geneModelUrl={geneModelUrl}
+              genomeVersionAssemblyId={genomeVersionAssemblyId}
+              workflow={workflow}
+            />
+          </Fragment>
+        ))}
+      </AccordionDetails>
+    </StyledAccordion>
   );
 };

--- a/app/components/Entity/components/AnalysisMethod/components/Workflow/constants.ts
+++ b/app/components/Entity/components/AnalysisMethod/components/Workflow/constants.ts
@@ -1,0 +1,13 @@
+import { Grid2Props, SvgIconProps } from "@mui/material";
+
+export const GRID2_PROPS: Grid2Props = {
+  container: true,
+  role: "button",
+  spacing: 4,
+  wrap: "nowrap",
+};
+
+export const ICON_PROPS: Partial<SvgIconProps> = {
+  color: "inkLight",
+  fontSize: "small",
+};

--- a/app/components/Entity/components/AnalysisMethod/components/Workflow/types.ts
+++ b/app/components/Entity/components/AnalysisMethod/components/Workflow/types.ts
@@ -1,0 +1,6 @@
+import { Workflow } from "../../../../../../apis/catalog/brc-analytics-catalog/common/entities";
+import { Props as AnalysisMethodsProps } from "../../../AnalysisMethodsCatalog/types";
+
+export interface Props extends AnalysisMethodsProps {
+  workflow: Workflow;
+}

--- a/app/components/Entity/components/AnalysisMethod/components/Workflow/workflow.styles.ts
+++ b/app/components/Entity/components/AnalysisMethod/components/Workflow/workflow.styles.ts
@@ -1,0 +1,19 @@
+import styled from "@emotion/styled";
+import { Grid2 } from "@mui/material";
+
+export const StyledGrid2 = styled(Grid2)`
+  cursor: pointer;
+  padding: 20px;
+
+  .MuiSvgIcon-root {
+    align-self: center;
+    transform: rotate(180deg);
+    transition: transform 300ms;
+  }
+
+  &:hover {
+    .MuiSvgIcon-root {
+      transform: rotate(180deg) translateX(-2px);
+    }
+  }
+`;

--- a/app/components/Entity/components/AnalysisMethod/components/Workflow/workflow.tsx
+++ b/app/components/Entity/components/AnalysisMethod/components/Workflow/workflow.tsx
@@ -1,0 +1,51 @@
+import { SouthIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/SouthIcon/southIcon";
+import {
+  Loading,
+  LOADING_PANEL_STYLE,
+} from "@databiosphere/findable-ui/lib/components/Loading/loading";
+import { useAsync } from "@databiosphere/findable-ui/lib/hooks/useAsync";
+import { Grid2, Typography } from "@mui/material";
+import { Props } from "./types";
+import { TEXT_BODY_500 } from "@databiosphere/findable-ui/lib/theme/common/typography";
+import { getWorkflowLandingUrl } from "../../../../../../utils/galaxy-api";
+import {
+  ANCHOR_TARGET,
+  REL_ATTRIBUTE,
+} from "@databiosphere/findable-ui/lib/components/Links/common/entities";
+import { StyledGrid2 } from "./workflow.styles";
+import { TYPOGRAPHY_PROPS } from "../../constants";
+import { GRID2_PROPS, ICON_PROPS } from "./constants";
+
+export const Workflow = ({
+  geneModelUrl,
+  genomeVersionAssemblyId,
+  workflow,
+}: Props): JSX.Element => {
+  const { trsId, workflowDescription, workflowName } = workflow;
+  const { data: landingUrl, isLoading, run } = useAsync<string>();
+  return (
+    <StyledGrid2
+      {...GRID2_PROPS}
+      onClick={async (): Promise<void> => {
+        if (!trsId) return;
+        const url =
+          landingUrl ??
+          (await run(
+            getWorkflowLandingUrl(trsId, genomeVersionAssemblyId, geneModelUrl)
+          ));
+        window.open(
+          url,
+          ANCHOR_TARGET.BLANK,
+          REL_ATTRIBUTE.NO_OPENER_NO_REFERRER
+        );
+      }}
+    >
+      <Loading loading={isLoading} panelStyle={LOADING_PANEL_STYLE.INHERIT} />
+      <Grid2 container spacing={1}>
+        <Typography variant={TEXT_BODY_500}>{workflowName}</Typography>
+        <Typography {...TYPOGRAPHY_PROPS}>{workflowDescription}</Typography>
+      </Grid2>
+      <SouthIcon {...ICON_PROPS} />
+    </StyledGrid2>
+  );
+};

--- a/app/components/Entity/components/AnalysisMethod/constants.ts
+++ b/app/components/Entity/components/AnalysisMethod/constants.ts
@@ -1,10 +1,19 @@
 import { ChipProps, SvgIconProps } from "@mui/material";
+import { TEXT_BODY_400_2_LINES } from "@databiosphere/findable-ui/lib/theme/common/typography";
+import { STATUS_BADGE_COLOR } from "@databiosphere/findable-ui/lib/components/common/StatusBadge/statusBadge";
 
 export const CHIP_PROPS: Partial<ChipProps> = {
+  color: STATUS_BADGE_COLOR.DEFAULT,
+  label: "Coming Soon",
   variant: "status",
 };
 
 export const ICON_PROPS: Partial<SvgIconProps> = {
   color: "inkLight",
-  fontSize: "small",
+  fontSize: "medium",
+};
+
+export const TYPOGRAPHY_PROPS = {
+  color: "ink.light",
+  variant: TEXT_BODY_400_2_LINES,
 };

--- a/app/components/Entity/components/AnalysisMethod/types.ts
+++ b/app/components/Entity/components/AnalysisMethod/types.ts
@@ -1,8 +1,12 @@
-import { ReactNode } from "react";
+import {
+  Workflow,
+  WorkflowCategory,
+} from "../../../../apis/catalog/brc-analytics-catalog/common/entities";
+import { Props as AnalysisMethodsProps } from "../AnalysisMethodsCatalog/types";
 
-export interface Props {
-  content: ReactNode;
+export interface Props extends AnalysisMethodsProps {
   geneModelUrl: string | null;
   genomeVersionAssemblyId: string;
-  workflowId: string;
+  workflowCategory: WorkflowCategory;
+  workflows: Workflow[];
 }

--- a/app/components/Entity/components/AnalysisMethods/analysisMethods.styles.ts
+++ b/app/components/Entity/components/AnalysisMethods/analysisMethods.styles.ts
@@ -1,0 +1,15 @@
+import styled from "@emotion/styled";
+import { Typography } from "@mui/material";
+import { mediaTabletDown } from "@databiosphere/findable-ui/lib/styles/common/mixins/breakpoints";
+
+export const StyledTypography = styled(Typography)`
+  & {
+    font-size: 18px;
+    letter-spacing: normal;
+    line-height: 26px;
+
+    ${mediaTabletDown} {
+      margin: 0 16px;
+    }
+  }
+` as typeof Typography;

--- a/app/components/Entity/components/AnalysisMethods/analysisMethods.tsx
+++ b/app/components/Entity/components/AnalysisMethods/analysisMethods.tsx
@@ -2,16 +2,20 @@ import {
   FluidPaper,
   GridPaper,
 } from "@databiosphere/findable-ui/lib/components/common/Paper/paper.styles";
-import { GridPaperSection } from "@databiosphere/findable-ui/lib/components/common/Section/section.styles";
 import { Props } from "./types";
+import { Fragment } from "react";
+import { StyledTypography } from "./analysisMethods.styles";
+import { TYPOGRAPHY_PROPS } from "./constants";
 
 export const AnalysisMethods = ({ children }: Props): JSX.Element => {
   return (
-    <FluidPaper>
-      <GridPaper>
-        <GridPaperSection>Analyze in Galaxy</GridPaperSection>
-        {children}
-      </GridPaper>
-    </FluidPaper>
+    <Fragment>
+      <StyledTypography {...TYPOGRAPHY_PROPS}>
+        Select a Workflow
+      </StyledTypography>
+      <FluidPaper>
+        <GridPaper>{children}</GridPaper>
+      </FluidPaper>
+    </Fragment>
   );
 };

--- a/app/components/Entity/components/AnalysisMethods/analysisMethods.tsx
+++ b/app/components/Entity/components/AnalysisMethods/analysisMethods.tsx
@@ -1,7 +1,3 @@
-import {
-  FluidPaper,
-  GridPaper,
-} from "@databiosphere/findable-ui/lib/components/common/Paper/paper.styles";
 import { Props } from "./types";
 import { Fragment } from "react";
 import { StyledTypography } from "./analysisMethods.styles";
@@ -13,9 +9,7 @@ export const AnalysisMethods = ({ children }: Props): JSX.Element => {
       <StyledTypography {...TYPOGRAPHY_PROPS}>
         Select a Workflow
       </StyledTypography>
-      <FluidPaper>
-        <GridPaper>{children}</GridPaper>
-      </FluidPaper>
+      {children}
     </Fragment>
   );
 };

--- a/app/components/Entity/components/AnalysisMethods/constants.ts
+++ b/app/components/Entity/components/AnalysisMethods/constants.ts
@@ -1,0 +1,7 @@
+import { TEXT_HEADING } from "@databiosphere/findable-ui/lib/theme/common/typography";
+import { TypographyProps } from "@mui/material";
+
+export const TYPOGRAPHY_PROPS: TypographyProps = {
+  component: "h3",
+  variant: TEXT_HEADING,
+};

--- a/app/components/Entity/components/AnalysisMethodsCatalog/analysisMethodsCatalog.tsx
+++ b/app/components/Entity/components/AnalysisMethodsCatalog/analysisMethodsCatalog.tsx
@@ -24,15 +24,8 @@ export const AnalysisMethodsCatalog = ({
             key={workflowCategory.category}
             geneModelUrl={geneModelUrl}
             genomeVersionAssemblyId={genomeVersionAssemblyId}
-            content={
-              <>
-                <h3>{workflowCategory.name}</h3>
-                <p>{workflowCategory.description}</p>
-              </>
-            }
-            workflowId={
-              availableWorkflows.length === 0 ? "" : availableWorkflows[0].trsId
-            }
+            workflows={availableWorkflows}
+            workflowCategory={workflowCategory}
           />
         );
       })}

--- a/app/components/Home/components/Section/components/SectionHero/components/Hero/hero.tsx
+++ b/app/components/Home/components/Section/components/SectionHero/components/Hero/hero.tsx
@@ -3,10 +3,7 @@ import {
   FILL,
   GRID_SIZE,
 } from "../../../../../../../Layout/components/Hero/common/constants";
-import {
-  ELEMENT_ID,
-  Height,
-} from "../../../../../../../Layout/components/Hero/common/entities";
+import { ELEMENT_ID } from "../../../../../../../Layout/components/Hero/common/entities";
 import {
   getFillUrl,
   getViewBox,
@@ -21,7 +18,7 @@ import { SVG } from "./hero.styles";
 
 export interface HeroProps {
   gridSize?: number;
-  height?: Height;
+  height?: number;
 }
 
 export const Hero = ({

--- a/app/components/Layout/components/AppLayout/components/Section/components/SectionHero/components/Hero/hero.tsx
+++ b/app/components/Layout/components/AppLayout/components/Section/components/SectionHero/components/Hero/hero.tsx
@@ -1,6 +1,6 @@
 import { Fragment } from "react";
 import { FILL, GRID_SIZE } from "../../../../../../../Hero/common/constants";
-import { ELEMENT_ID, Height } from "../../../../../../../Hero/common/entities";
+import { ELEMENT_ID } from "../../../../../../../Hero/common/entities";
 import { getFillUrl, getViewBox } from "../../../../../../../Hero/common/utils";
 import { CoralPinkCircle } from "../../../../../../../Hero/components/Defs/CoralPinkCircle/coralPinkCircle";
 import { SmokeCircle } from "../../../../../../../Hero/components/Defs/SmokeCircle/smokeCircle";
@@ -10,7 +10,7 @@ import { SVG } from "./hero.styles";
 
 export interface HeroProps {
   gridSize?: number;
-  height?: Height;
+  height?: number;
 }
 
 export const Hero = ({

--- a/app/components/Layout/components/Hero/common/entities.ts
+++ b/app/components/Layout/components/Hero/common/entities.ts
@@ -11,8 +11,6 @@ export enum ELEMENT_ID {
   PATTERN_YELLOW_RECT = "patternYellowRect",
 }
 
-export type Height = number; // Should be a multiple of GRID_SIZE.
-
 export enum PATTERN_UNIT {
   USER_SPACE_ON_USE = "userSpaceOnUse",
 }

--- a/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
@@ -28,6 +28,7 @@ import {
 } from "../../../../apis/catalog/brc-analytics-catalog/common/utils";
 import { COLUMN_IDENTIFIER } from "@databiosphere/findable-ui/lib/components/Table/common/columnIdentifier";
 import { LABEL } from "@databiosphere/findable-ui/lib/apis/azul/common/entities";
+import { TEXT_BODY_SMALL_400 } from "@databiosphere/findable-ui/lib/theme/common/typography";
 
 /**
  * Build props for the accession cell.
@@ -371,10 +372,12 @@ export const buildGenomeChooseAnalysisMethodDetailViewHero = (
   return {
     breadcrumbs: getGenomeEntityChooseAnalysisMethodBreadcrumbs(genome),
     subTitle: C.Link({
-      label: C.SubTitle({ subTitle: genome.species }),
+      TypographyProps: { color: "ink.light", variant: TEXT_BODY_SMALL_400 },
+      label: `Species: ${genome.species}`,
+      underline: "hover",
       url: `${ROUTES.ORGANISMS}/${encodeURIComponent(getGenomeOrganismId(genome))}`,
     }),
-    title: genome.accession,
+    title: `Analyze in Galaxy - ${genome.accession}`,
   };
 };
 
@@ -575,6 +578,7 @@ function getGenomeEntityChooseAnalysisMethodBreadcrumbs(
   return [
     { path: ROUTES.GENOMES, text: "Assemblies" },
     { path: "", text: genome.accession },
+    { path: "", text: "Analyze" },
   ];
 }
 


### PR DESCRIPTION
Closes #279.

Analysis methods supports multiple workflows as per [mocks](https://www.figma.com/design/wxBBIrZcZb6IhYSg4d8B7J/BRC-Analytics-Homepage?node-id=1107-1109&m=dev).
Includes minor change to workflow hero (breadcrumbs and sub title).

<img width="1703" alt="image" src="https://github.com/user-attachments/assets/73bd7bf2-0fc9-4770-82f8-17f290fa0167" />

<img width="1702" alt="image" src="https://github.com/user-attachments/assets/65b83b31-84ef-4982-a80f-4571d12415f1" />
