### PR TITLE
feat: update workflow card for "Launch Galaxy" button (#300)

### DIFF
--- a/app/components/Entity/components/AnalysisMethod/analysisMethod.styles.ts
+++ b/app/components/Entity/components/AnalysisMethod/analysisMethod.styles.ts
@@ -6,6 +6,7 @@ import styled from "@emotion/styled";
 import { Accordion } from "@mui/material";
 import { smokeLightest } from "@databiosphere/findable-ui/lib/theme/common/palette";
 import { elevation01 } from "@databiosphere/findable-ui/lib/theme/common/shadows";
+import { mediaTabletDown } from "@databiosphere/findable-ui/lib/styles/common/mixins/breakpoints";
 
 export const StyledAccordion = styled(Accordion)`
   &.MuiAccordion-root {
@@ -54,8 +55,14 @@ export const StyledAccordion = styled(Accordion)`
     }
 
     .MuiAccordionDetails-root {
+      border-radius: 0 0 8px 8px; // bottom corners only
       margin: 0;
+      overflow: hidden; // simple way to manage workflow loading panel bleed
       padding: 0;
+
+      ${mediaTabletDown} {
+        border-radius: 0;
+      }
     }
 
     &.Mui-disabled {

--- a/app/components/Entity/components/AnalysisMethod/components/Workflow/constants.ts
+++ b/app/components/Entity/components/AnalysisMethod/components/Workflow/constants.ts
@@ -1,13 +1,17 @@
-import { Grid2Props, SvgIconProps } from "@mui/material";
+import { ButtonProps, Grid2Props } from "@mui/material";
+import {
+  COLOR,
+  VARIANT,
+} from "@databiosphere/findable-ui/lib/styles/common/mui/button";
 
 export const GRID2_PROPS: Grid2Props = {
   container: true,
-  role: "button",
+  direction: "column",
   spacing: 4,
   wrap: "nowrap",
 };
 
-export const ICON_PROPS: Partial<SvgIconProps> = {
-  color: "inkLight",
-  fontSize: "small",
+export const BUTTON_PROPS: Partial<ButtonProps> = {
+  color: COLOR.PRIMARY,
+  variant: VARIANT.CONTAINED,
 };

--- a/app/components/Entity/components/AnalysisMethod/components/Workflow/workflow.styles.ts
+++ b/app/components/Entity/components/AnalysisMethod/components/Workflow/workflow.styles.ts
@@ -2,18 +2,9 @@ import styled from "@emotion/styled";
 import { Grid2 } from "@mui/material";
 
 export const StyledGrid2 = styled(Grid2)`
-  cursor: pointer;
   padding: 20px;
 
-  .MuiSvgIcon-root {
-    align-self: center;
-    transform: rotate(180deg);
-    transition: transform 300ms;
-  }
-
-  &:hover {
-    .MuiSvgIcon-root {
-      transform: rotate(180deg) translateX(-2px);
-    }
+  .MuiButton-root {
+    align-self: flex-start;
   }
 `;

--- a/app/components/Entity/components/AnalysisMethod/components/Workflow/workflow.tsx
+++ b/app/components/Entity/components/AnalysisMethod/components/Workflow/workflow.tsx
@@ -1,20 +1,17 @@
-import { SouthIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/SouthIcon/southIcon";
-import {
-  Loading,
-  LOADING_PANEL_STYLE,
-} from "@databiosphere/findable-ui/lib/components/Loading/loading";
+import { Loading } from "@databiosphere/findable-ui/lib/components/Loading/loading";
 import { useAsync } from "@databiosphere/findable-ui/lib/hooks/useAsync";
-import { Grid2, Typography } from "@mui/material";
+import { Button, Grid2, Typography } from "@mui/material";
 import { Props } from "./types";
 import { TEXT_BODY_500 } from "@databiosphere/findable-ui/lib/theme/common/typography";
+import { StyledGrid2 } from "./workflow.styles";
+import { TYPOGRAPHY_PROPS } from "../../constants";
+import { BUTTON_PROPS, GRID2_PROPS } from "./constants";
 import { getWorkflowLandingUrl } from "../../../../../../utils/galaxy-api";
 import {
   ANCHOR_TARGET,
   REL_ATTRIBUTE,
 } from "@databiosphere/findable-ui/lib/components/Links/common/entities";
-import { StyledGrid2 } from "./workflow.styles";
-import { TYPOGRAPHY_PROPS } from "../../constants";
-import { GRID2_PROPS, ICON_PROPS } from "./constants";
+import { PAPER_PANEL_STYLE } from "@databiosphere/findable-ui/lib/components/common/Paper/paper";
 
 export const Workflow = ({
   geneModelUrl,
@@ -24,28 +21,34 @@ export const Workflow = ({
   const { trsId, workflowDescription, workflowName } = workflow;
   const { data: landingUrl, isLoading, run } = useAsync<string>();
   return (
-    <StyledGrid2
-      {...GRID2_PROPS}
-      onClick={async (): Promise<void> => {
-        if (!trsId) return;
-        const url =
-          landingUrl ??
-          (await run(
-            getWorkflowLandingUrl(trsId, genomeVersionAssemblyId, geneModelUrl)
-          ));
-        window.open(
-          url,
-          ANCHOR_TARGET.BLANK,
-          REL_ATTRIBUTE.NO_OPENER_NO_REFERRER
-        );
-      }}
-    >
-      <Loading loading={isLoading} panelStyle={LOADING_PANEL_STYLE.INHERIT} />
+    <StyledGrid2 {...GRID2_PROPS}>
+      <Loading loading={isLoading} panelStyle={PAPER_PANEL_STYLE.NONE} />
       <Grid2 container spacing={1}>
         <Typography variant={TEXT_BODY_500}>{workflowName}</Typography>
         <Typography {...TYPOGRAPHY_PROPS}>{workflowDescription}</Typography>
       </Grid2>
-      <SouthIcon {...ICON_PROPS} />
+      <Button
+        {...BUTTON_PROPS}
+        disabled={!trsId}
+        onClick={async (): Promise<void> => {
+          const url =
+            landingUrl ??
+            (await run(
+              getWorkflowLandingUrl(
+                trsId,
+                genomeVersionAssemblyId,
+                geneModelUrl
+              )
+            ));
+          window.open(
+            url,
+            ANCHOR_TARGET.BLANK,
+            REL_ATTRIBUTE.NO_OPENER_NO_REFERRER
+          );
+        }}
+      >
+        Launch Galaxy
+      </Button>
     </StyledGrid2>
   );
 };


### PR DESCRIPTION
Closes #300.

- Updates workflow card with "Launch Galaxy" button as per [mocks](https://www.figma.com/design/wxBBIrZcZb6IhYSg4d8B7J/BRC-Analytics-Homepage?node-id=1107-1109&m=dev).

<img width="1703" alt="image" src="https://github.com/user-attachments/assets/4ab40af1-8671-46d6-88a7-2777f10cdf5d" />

