### PR TITLE
feat: added additional workflows (#322)

### DIFF
--- a/catalog/output/workflows.json
+++ b/catalog/output/workflows.json
@@ -21,7 +21,13 @@
         "ploidy": "ANY",
         "trsId": "https://dockstore.org/api/ga4gh/trs/v2/tools/#workflow/github.com/iwc-workflows/rnaseq-pe/main/versions/v0.9",
         "workflowDescription": "This workflow takes as input a list of paired-end fastqs. Adapters and bad quality bases are removed with cutadapt. Reads are mapped with STAR with ENCODE parameters and genes are counted simultaneously as well as normalized coverage (per million mapped reads) on uniquely mapped reads. The counts are reprocessed to be similar to HTSeq-count output. FPKM are computed with cufflinks and/or with StringTie. The unstranded normalized coverage is computed with bedtools.",
-        "workflowName": "RNAseq_PE"
+        "workflowName": "RNA-seq for Paired-end fastqs"
+      },
+      {
+        "ploidy": "ANY",
+        "trsId": "https://dockstore.org/api/ga4gh/trs/v2/tools/#workflow/github.com/iwc-workflows/rnaseq-sr/main/versions/v0.9",
+        "workflowDescription": "This workflow takes as input a list of single-end fastqs. Adapters and bad quality bases are removed with fastp. Reads are mapped with STAR with ENCODE parameters and genes are counted simultaneously as well as normalized coverage (per million mapped reads) on uniquely mapped reads. The counts are reprocessed to be similar to HTSeq-count output. Alternatively, featureCounts can be used to count the reads/fragments per gene. FPKM are computed with cufflinks and/or with StringTie. The unstranded normalized coverage is computed with bedtools.",
+        "workflowName": "RNA-seq for Single-read fastqs"
       }
     ]
   },
@@ -34,7 +40,13 @@
         "ploidy": "ANY",
         "trsId": "https://dockstore.org/api/ga4gh/trs/v2/tools/#workflow/github.com/iwc-workflows/chipseq-pe/main/versions/v0.12",
         "workflowDescription": "This workflow takes as input a collection of paired fastqs. Remove adapters with cutadapt, map pairs with bowtie2. Keep MAPQ30 and concordant pairs. MACS2 for paired bam.",
-        "workflowName": "ChIPseq_PE"
+        "workflowName": "ChIPseq for Paired-end fastqs"
+      },
+      {
+        "ploidy": "ANY",
+        "trsId": "https://dockstore.org/api/ga4gh/trs/v2/tools/#workflow/github.com/iwc-workflows/chipseq-sr/main/versions/v0.12",
+        "workflowDescription": "This workflow takes as input a collection of fastqs (single reads). Remove adapters with cutadapt, map with bowtie2. Keep MAPQ30. MACS2 for bam with fixed extension or model.",
+        "workflowName": "ChIPseq for Single-read fastqs"
       }
     ]
   },

--- a/catalog/output/workflows.json
+++ b/catalog/output/workflows.json
@@ -19,6 +19,18 @@
     "workflows": [
       {
         "ploidy": "ANY",
+        "trsId": "https://dockstore.org/api/ga4gh/trs/v2/tools/#workflow/github.com/iwc-workflows/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex/main/versions/v0.5",
+        "workflowDescription": "This workflow processes the CMO fastqs with CITE-seq-Count and include the translation step required for cellPlex processing. In parallel it processes the Gene Expresion fastqs with STARsolo, filter cells with DropletUtils and reformat all outputs to be easily used by the function 'Read10X' from Seurat.",
+        "workflowName": "scRNA-seq preprocessing 10X cellPlex"
+      },
+      {
+        "ploidy": "ANY",
+        "trsId": "https://dockstore.org/api/ga4gh/trs/v2/tools/#workflow/github.com/iwc-workflows/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-v3/main/versions/v0.5",
+        "workflowDescription": "This workflow processes the Gene Expresion fastqs with STARsolo, filter cells with DropletUtils and reformat all outputs to be easily used by the function 'Read10X' from Seurat.",
+        "workflowName": "scRNA-seq preprocessing 10X Bundle"
+      },
+      {
+        "ploidy": "ANY",
         "trsId": "https://dockstore.org/api/ga4gh/trs/v2/tools/#workflow/github.com/iwc-workflows/rnaseq-pe/main/versions/v0.9",
         "workflowDescription": "This workflow takes as input a list of paired-end fastqs. Adapters and bad quality bases are removed with cutadapt. Reads are mapped with STAR with ENCODE parameters and genes are counted simultaneously as well as normalized coverage (per million mapped reads) on uniquely mapped reads. The counts are reprocessed to be similar to HTSeq-count output. FPKM are computed with cufflinks and/or with StringTie. The unstranded normalized coverage is computed with bedtools.",
         "workflowName": "RNA-seq for Paired-end fastqs"
@@ -36,6 +48,18 @@
     "description": "Workflows for the analysis of ChIP-seq, ATAC-Seq, and beyond.",
     "name": "Regulation",
     "workflows": [
+      {
+        "ploidy": "ANY",
+        "trsId": "https://dockstore.org/api/ga4gh/trs/v2/tools/#workflow/github.com/iwc-workflows/cutandrun/main/versions/v0.13",
+        "workflowDescription": "This workflow take as input a collection of paired fastq. Remove adapters with cutadapt, map pairs with bowtie2 allowing dovetail. Keep MAPQ30 and concordant pairs. BAM to BED. MACS2 with 'ATAC' parameters.",
+        "workflowName": "CUTandRUN"
+      },
+      {
+        "ploidy": "ANY",
+        "trsId": "https://dockstore.org/api/ga4gh/trs/v2/tools/#workflow/github.com/iwc-workflows/atacseq/main/versions/v1.0",
+        "workflowDescription": "This workflow takes as input a collection of paired fastq. It will remove bad quality and adapters with cutadapt. Map with Bowtie2 end-to-end. Will remove reads on MT and unconcordant pairs and pairs with mapping quality below 30 and PCR duplicates. Will compute the pile-up on 5'' +- 100bp. Will call peaks and count the number of reads falling in the 1kb region centered on the summit. Will compute 2 normalization for coverage: normalized by million reads and normalized by million reads in peaks. Will plot the number of reads for each fragment length.",
+        "workflowName": "ATACseq"
+      },
       {
         "ploidy": "ANY",
         "trsId": "https://dockstore.org/api/ga4gh/trs/v2/tools/#workflow/github.com/iwc-workflows/chipseq-pe/main/versions/v0.12",

--- a/catalog/source/workflows.yml
+++ b/catalog/source/workflows.yml
@@ -3,14 +3,14 @@ workflows:
     categories:
       - "REGULATION"
     ploidy: "ANY"
-    workflow_name: "ChIPseq_PE"
+    workflow_name: "ChIPseq for Paired-end fastqs"
     workflow_description: "This workflow takes as input a collection of paired fastqs. Remove adapters with cutadapt, map pairs with bowtie2. Keep MAPQ30 and concordant pairs. MACS2 for paired bam."
 
   - trs_id: "https://dockstore.org/api/ga4gh/trs/v2/tools/#workflow/github.com/iwc-workflows/rnaseq-pe/main/versions/v0.9"
     categories:
       - "TRANSCRIPTOMICS"
     ploidy: "ANY"
-    workflow_name: "RNAseq_PE"
+    workflow_name: "RNA-seq for Paired-end fastqs"
     workflow_description: "This workflow takes as input a list of paired-end fastqs. Adapters and bad quality bases are removed with cutadapt. Reads are mapped with STAR with ENCODE parameters and genes are counted simultaneously as well as normalized coverage (per million mapped reads) on uniquely mapped reads. The counts are reprocessed to be similar to HTSeq-count output. FPKM are computed with cufflinks and/or with StringTie. The unstranded normalized coverage is computed with bedtools."
 
   - trs_id: "https://dockstore.org/api/ga4gh/trs/v2/tools/#workflow/github.com/iwc-workflows/haploid-variant-calling-wgs-pe/main/versions/v0.1"
@@ -19,3 +19,17 @@ workflows:
     ploidy: "HAPLOID"
     workflow_name: "Paired end variant calling in haploid system"
     workflow_description: "Workflow for variant analysis against a reference genome in GenBank format"
+
+  - trs_id: "https://dockstore.org/api/ga4gh/trs/v2/tools/#workflow/github.com/iwc-workflows/chipseq-sr/main/versions/v0.12"
+    categories:
+      - "REGULATION"
+    ploidy: "ANY"
+    workflow_name: "ChIPseq for Single-read fastqs"
+    workflow_description: "This workflow takes as input a collection of fastqs (single reads). Remove adapters with cutadapt, map with bowtie2. Keep MAPQ30. MACS2 for bam with fixed extension or model."
+
+  - trs_id: "https://dockstore.org/api/ga4gh/trs/v2/tools/#workflow/github.com/iwc-workflows/rnaseq-sr/main/versions/v0.9"
+    categories:
+      - "TRANSCRIPTOMICS"
+    ploidy: "ANY"
+    workflow_name: "RNA-seq for Single-read fastqs"
+    workflow_description: "This workflow takes as input a list of single-end fastqs. Adapters and bad quality bases are removed with fastp. Reads are mapped with STAR with ENCODE parameters and genes are counted simultaneously as well as normalized coverage (per million mapped reads) on uniquely mapped reads. The counts are reprocessed to be similar to HTSeq-count output. Alternatively, featureCounts can be used to count the reads/fragments per gene. FPKM are computed with cufflinks and/or with StringTie. The unstranded normalized coverage is computed with bedtools."

--- a/catalog/source/workflows.yml
+++ b/catalog/source/workflows.yml
@@ -1,4 +1,32 @@
 workflows:
+  - trs_id: "https://dockstore.org/api/ga4gh/trs/v2/tools/#workflow/github.com/iwc-workflows/cutandrun/main/versions/v0.13"
+    categories:
+      - "REGULATION"
+    workflow_name: "CUTandRUN"
+    workflow_description: "This workflow take as input a collection of paired fastq. Remove adapters with cutadapt, map pairs with bowtie2 allowing dovetail. Keep MAPQ30 and concordant pairs. BAM to BED. MACS2 with 'ATAC' parameters."
+    ploidy: "ANY"
+
+  - trs_id: "https://dockstore.org/api/ga4gh/trs/v2/tools/#workflow/github.com/iwc-workflows/atacseq/main/versions/v1.0"
+    categories:
+      - "REGULATION"
+    workflow_name: "ATACseq"
+    workflow_description: "This workflow takes as input a collection of paired fastq. It will remove bad quality and adapters with cutadapt. Map with Bowtie2 end-to-end. Will remove reads on MT and unconcordant pairs and pairs with mapping quality below 30 and PCR duplicates. Will compute the pile-up on 5'' +- 100bp. Will call peaks and count the number of reads falling in the 1kb region centered on the summit. Will compute 2 normalization for coverage: normalized by million reads and normalized by million reads in peaks. Will plot the number of reads for each fragment length."
+    ploidy: "ANY"
+
+  - trs_id: "https://dockstore.org/api/ga4gh/trs/v2/tools/#workflow/github.com/iwc-workflows/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex/main/versions/v0.5"
+    categories:
+      - "TRANSCRIPTOMICS"
+    workflow_name: "scRNA-seq preprocessing 10X cellPlex"
+    workflow_description: "This workflow processes the CMO fastqs with CITE-seq-Count and include the translation step required for cellPlex processing. In parallel it processes the Gene Expresion fastqs with STARsolo, filter cells with DropletUtils and reformat all outputs to be easily used by the function 'Read10X' from Seurat."
+    ploidy: "ANY"
+
+  - trs_id: "https://dockstore.org/api/ga4gh/trs/v2/tools/#workflow/github.com/iwc-workflows/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-v3/main/versions/v0.5"
+    categories:
+      - "TRANSCRIPTOMICS"
+    workflow_name: "scRNA-seq preprocessing 10X Bundle"
+    workflow_description: "This workflow processes the Gene Expresion fastqs with STARsolo, filter cells with DropletUtils and reformat all outputs to be easily used by the function 'Read10X' from Seurat."
+    ploidy: "ANY"
+
   - trs_id: "https://dockstore.org/api/ga4gh/trs/v2/tools/#workflow/github.com/iwc-workflows/chipseq-pe/main/versions/v0.12"
     categories:
       - "REGULATION"


### PR DESCRIPTION
changed strategy a bit to try to go around the issue where some workflows may need support for additional pre-populated parameters, but still get some fun things on the site quickly.

this should get single read options for rnaseq and chipseq, add cutandrun, atacseq and some scrnaseq stuff.

also improved display names of some things. perhaps we want to improve those in iwc in future, and if so, probably an issue or two need filed somewhere for that?

feedback welcome