### PR TITLE
chore: Remove issue number check from husky (#363)

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -2,16 +2,6 @@
 
 echo "Checking commit message"
 
-# Check for issue number
-
-commit_regex='#[0-9]'
-error_msg="Aborting commit. Your commit message is missing a '#xxx' reference to a corresponding GitHub issue. Add '--no-verify' to your git commit command if you wish to skip this check."
-
-if ! grep -iqE "$commit_regex" "$1"; then
-    echo "$error_msg" >&2
-    exit 1
-fi
-
 # Check for Conventional Commits format
 
 npx commitlint --config ./commitlint.config.js --edit $1


### PR DESCRIPTION
This closes #363.  It drops the issue number check, but leaves the commitlint validation.  If we want to follow up with a github workflow enforcing that PRs reference an issue, that's fine.

Also adds .venv to prettierignore.