### PR TITLE
chore: add .venv to prettier ignore list (#373)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -12,6 +12,7 @@ coverage
 
 # python
 venv
+.venv
 
 # releases
 /CHANGELOG.md


### PR DESCRIPTION
Pulled off of #372 to have unrelated commits not grouped (when squashed).

Closes https://github.com/galaxyproject/brc-analytics/issues/373