### PR TITLE
ci: add github action and workflow to check pr title for commit message format (#377)

### DIFF
--- a/.github/actions/check-input-commit-message/action.yml
+++ b/.github/actions/check-input-commit-message/action.yml
@@ -1,0 +1,9 @@
+name: Check input commit message
+description: Check an input string for Conventional Commits format and issue number
+inputs:
+  message:
+    description: String to check as a commit message
+    required: true
+runs:
+  using: "node20"
+  main: "index.js"

--- a/.github/actions/check-input-commit-message/index.js
+++ b/.github/actions/check-input-commit-message/index.js
@@ -1,0 +1,47 @@
+const core = require("@actions/core");
+
+async function runCommitlint(message) {
+  const { default: load } = await import("@commitlint/load");
+  const { default: lint } = await import("@commitlint/lint");
+  const { default: format } = await import("@commitlint/format");
+
+  console.log("Checking for Conventional Commits format");
+
+  const config = await load();
+  const report = await lint(message, config.rules, {
+    parserOpts: config.parserPreset?.parserOpts,
+  });
+  const reportMessage = format({ results: [report] }, { verbose: true });
+
+  if (report.valid) console.log(reportMessage + "\n");
+  else console.error(reportMessage + "\n");
+
+  return report.valid;
+}
+
+function checkIssueNumber(message) {
+  console.log(
+    "Checking for a '#xxx' reference to a corresponding GitHub issue"
+  );
+  if (/#[0-9]/.test(message)) {
+    console.log("Successfully found issue number\n");
+    return true;
+  } else {
+    console.error("Issue number missing\n");
+    return false;
+  }
+}
+
+async function checkMessage() {
+  const message = core.getInput("message");
+  const failedChecks = [];
+  if (!(await runCommitlint(message)))
+    failedChecks.push("Conventional Commits");
+  if (!checkIssueNumber(message)) failedChecks.push("issue number");
+  if (failedChecks.length > 0)
+    core.setFailed(
+      `Failed ${failedChecks.join(" and ")} check${failedChecks.length > 1 ? "s" : ""}`
+    );
+}
+
+checkMessage().catch((e) => core.setFailed(e.message));

--- a/.github/actions/check-input-commit-message/index.js
+++ b/.github/actions/check-input-commit-message/index.js
@@ -35,9 +35,9 @@ function checkIssueNumber(message) {
 async function checkMessage() {
   const message = core.getInput("message");
   const failedChecks = [];
+  if (!checkIssueNumber(message)) failedChecks.push("issue number");
   if (!(await runCommitlint(message)))
     failedChecks.push("Conventional Commits");
-  if (!checkIssueNumber(message)) failedChecks.push("issue number");
   if (failedChecks.length > 0)
     core.setFailed(
       `Failed ${failedChecks.join(" and ")} check${failedChecks.length > 1 ? "s" : ""}`

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -1,0 +1,22 @@
+name: Check pull request title
+on: [pull_request]
+
+jobs:
+  run-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20.10.0"
+      - name: Cache npm cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+      - name: Install dependencies
+        run: npm ci
+      - name: Check pull request title for commit message format
+        uses: ./.github/actions/check-input-commit-message
+        with:
+          message: ${{ github.event.pull_request.title }}

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -18,7 +18,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         run: npm ci
-      - name: Check pull request title for commit message format
+      - name: Check pull request title for Conventional Commits format and GitHub issue number
         uses: ./.github/actions/check-input-commit-message
         with:
           message: ${{ github.event.pull_request.title }}

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -1,5 +1,7 @@
 name: Check pull request title
-on: [pull_request]
+on:
+  pull_request:
+    types: [edited, opened, synchronize, reopened]
 
 jobs:
   run-checks:

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -4,7 +4,7 @@ on:
     types: [edited, opened, synchronize, reopened]
 
 jobs:
-  run-checks:
+  check-pr-title:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,9 +28,13 @@
         "validate.js": "^0.13.1"
       },
       "devDependencies": {
+        "@actions/core": "^1.11.1",
         "@babel/core": "^7.17.10",
         "@commitlint/cli": "^19.6.0",
         "@commitlint/config-conventional": "^19.6.0",
+        "@commitlint/format": "^19.8.0",
+        "@commitlint/lint": "^19.8.0",
+        "@commitlint/load": "^19.8.0",
         "@mui/types": "^7.2.18",
         "@next/eslint-plugin-next": "^15.0.4",
         "@playwright/test": "^1.49.1",
@@ -78,6 +82,41 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/@actions/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
+      "dev": true,
+      "dependencies": {
+        "@actions/exec": "^1.1.1",
+        "@actions/http-client": "^2.0.1"
+      }
+    },
+    "node_modules/@actions/exec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
+      "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
+      "dev": true,
+      "dependencies": {
+        "@actions/io": "^1.0.1"
+      }
+    },
+    "node_modules/@actions/http-client": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
+      "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
+      "dev": true,
+      "dependencies": {
+        "tunnel": "^0.0.6",
+        "undici": "^5.25.4"
+      }
+    },
+    "node_modules/@actions/io": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
+      "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==",
+      "dev": true
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.3.3",
@@ -1907,12 +1946,12 @@
       }
     },
     "node_modules/@commitlint/config-validator": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-19.5.0.tgz",
-      "integrity": "sha512-CHtj92H5rdhKt17RmgALhfQt95VayrUo2tSqY9g2w+laAXyk7K/Ef6uPm9tn5qSIwSmrLjKaXK9eiNuxmQrDBw==",
+      "version": "19.8.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-19.8.0.tgz",
+      "integrity": "sha512-+r5ZvD/0hQC3w5VOHJhGcCooiAVdynFlCe2d6I9dU+PvXdV3O+fU4vipVg+6hyLbQUuCH82mz3HnT/cBQTYYuA==",
       "dev": true,
       "dependencies": {
-        "@commitlint/types": "^19.5.0",
+        "@commitlint/types": "^19.8.0",
         "ajv": "^8.11.0"
       },
       "engines": {
@@ -1920,12 +1959,12 @@
       }
     },
     "node_modules/@commitlint/ensure": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-19.5.0.tgz",
-      "integrity": "sha512-Kv0pYZeMrdg48bHFEU5KKcccRfKmISSm9MvgIgkpI6m+ohFTB55qZlBW6eYqh/XDfRuIO0x4zSmvBjmOwWTwkg==",
+      "version": "19.8.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-19.8.0.tgz",
+      "integrity": "sha512-kNiNU4/bhEQ/wutI1tp1pVW1mQ0QbAjfPRo5v8SaxoVV+ARhkB8Wjg3BSseNYECPzWWfg/WDqQGIfV1RaBFQZg==",
       "dev": true,
       "dependencies": {
-        "@commitlint/types": "^19.5.0",
+        "@commitlint/types": "^19.8.0",
         "lodash.camelcase": "^4.3.0",
         "lodash.kebabcase": "^4.1.1",
         "lodash.snakecase": "^4.1.1",
@@ -1937,21 +1976,21 @@
       }
     },
     "node_modules/@commitlint/execute-rule": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-19.5.0.tgz",
-      "integrity": "sha512-aqyGgytXhl2ejlk+/rfgtwpPexYyri4t8/n4ku6rRJoRhGZpLFMqrZ+YaubeGysCP6oz4mMA34YSTaSOKEeNrg==",
+      "version": "19.8.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-19.8.0.tgz",
+      "integrity": "sha512-fuLeI+EZ9x2v/+TXKAjplBJWI9CNrHnyi5nvUQGQt4WRkww/d95oVRsc9ajpt4xFrFmqMZkd/xBQHZDvALIY7A==",
       "dev": true,
       "engines": {
         "node": ">=v18"
       }
     },
     "node_modules/@commitlint/format": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-19.5.0.tgz",
-      "integrity": "sha512-yNy088miE52stCI3dhG/vvxFo9e4jFkU1Mj3xECfzp/bIS/JUay4491huAlVcffOoMK1cd296q0W92NlER6r3A==",
+      "version": "19.8.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-19.8.0.tgz",
+      "integrity": "sha512-EOpA8IERpQstxwp/WGnDArA7S+wlZDeTeKi98WMOvaDLKbjptuHWdOYYr790iO7kTCif/z971PKPI2PkWMfOxg==",
       "dev": true,
       "dependencies": {
-        "@commitlint/types": "^19.5.0",
+        "@commitlint/types": "^19.8.0",
         "chalk": "^5.3.0"
       },
       "engines": {
@@ -1959,12 +1998,12 @@
       }
     },
     "node_modules/@commitlint/is-ignored": {
-      "version": "19.6.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-19.6.0.tgz",
-      "integrity": "sha512-Ov6iBgxJQFR9koOupDPHvcHU9keFupDgtB3lObdEZDroiG4jj1rzky60fbQozFKVYRTUdrBGICHG0YVmRuAJmw==",
+      "version": "19.8.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-19.8.0.tgz",
+      "integrity": "sha512-L2Jv9yUg/I+jF3zikOV0rdiHUul9X3a/oU5HIXhAJLE2+TXTnEBfqYP9G5yMw/Yb40SnR764g4fyDK6WR2xtpw==",
       "dev": true,
       "dependencies": {
-        "@commitlint/types": "^19.5.0",
+        "@commitlint/types": "^19.8.0",
         "semver": "^7.6.0"
       },
       "engines": {
@@ -1972,9 +2011,9 @@
       }
     },
     "node_modules/@commitlint/is-ignored/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -1984,33 +2023,33 @@
       }
     },
     "node_modules/@commitlint/lint": {
-      "version": "19.6.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-19.6.0.tgz",
-      "integrity": "sha512-LRo7zDkXtcIrpco9RnfhOKeg8PAnE3oDDoalnrVU/EVaKHYBWYL1DlRR7+3AWn0JiBqD8yKOfetVxJGdEtZ0tg==",
+      "version": "19.8.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-19.8.0.tgz",
+      "integrity": "sha512-+/NZKyWKSf39FeNpqhfMebmaLa1P90i1Nrb1SrA7oSU5GNN/lksA4z6+ZTnsft01YfhRZSYMbgGsARXvkr/VLQ==",
       "dev": true,
       "dependencies": {
-        "@commitlint/is-ignored": "^19.6.0",
-        "@commitlint/parse": "^19.5.0",
-        "@commitlint/rules": "^19.6.0",
-        "@commitlint/types": "^19.5.0"
+        "@commitlint/is-ignored": "^19.8.0",
+        "@commitlint/parse": "^19.8.0",
+        "@commitlint/rules": "^19.8.0",
+        "@commitlint/types": "^19.8.0"
       },
       "engines": {
         "node": ">=v18"
       }
     },
     "node_modules/@commitlint/load": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-19.5.0.tgz",
-      "integrity": "sha512-INOUhkL/qaKqwcTUvCE8iIUf5XHsEPCLY9looJ/ipzi7jtGhgmtH7OOFiNvwYgH7mA8osUWOUDV8t4E2HAi4xA==",
+      "version": "19.8.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-19.8.0.tgz",
+      "integrity": "sha512-4rvmm3ff81Sfb+mcWT5WKlyOa+Hd33WSbirTVUer0wjS1Hv/Hzr07Uv1ULIV9DkimZKNyOwXn593c+h8lsDQPQ==",
       "dev": true,
       "dependencies": {
-        "@commitlint/config-validator": "^19.5.0",
-        "@commitlint/execute-rule": "^19.5.0",
-        "@commitlint/resolve-extends": "^19.5.0",
-        "@commitlint/types": "^19.5.0",
+        "@commitlint/config-validator": "^19.8.0",
+        "@commitlint/execute-rule": "^19.8.0",
+        "@commitlint/resolve-extends": "^19.8.0",
+        "@commitlint/types": "^19.8.0",
         "chalk": "^5.3.0",
         "cosmiconfig": "^9.0.0",
-        "cosmiconfig-typescript-loader": "^5.0.0",
+        "cosmiconfig-typescript-loader": "^6.1.0",
         "lodash.isplainobject": "^4.0.6",
         "lodash.merge": "^4.6.2",
         "lodash.uniq": "^4.5.0"
@@ -2020,21 +2059,21 @@
       }
     },
     "node_modules/@commitlint/message": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-19.5.0.tgz",
-      "integrity": "sha512-R7AM4YnbxN1Joj1tMfCyBryOC5aNJBdxadTZkuqtWi3Xj0kMdutq16XQwuoGbIzL2Pk62TALV1fZDCv36+JhTQ==",
+      "version": "19.8.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-19.8.0.tgz",
+      "integrity": "sha512-qs/5Vi9bYjf+ZV40bvdCyBn5DvbuelhR6qewLE8Bh476F7KnNyLfdM/ETJ4cp96WgeeHo6tesA2TMXS0sh5X4A==",
       "dev": true,
       "engines": {
         "node": ">=v18"
       }
     },
     "node_modules/@commitlint/parse": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-19.5.0.tgz",
-      "integrity": "sha512-cZ/IxfAlfWYhAQV0TwcbdR1Oc0/r0Ik1GEessDJ3Lbuma/MRO8FRQX76eurcXtmhJC//rj52ZSZuXUg0oIX0Fw==",
+      "version": "19.8.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-19.8.0.tgz",
+      "integrity": "sha512-YNIKAc4EXvNeAvyeEnzgvm1VyAe0/b3Wax7pjJSwXuhqIQ1/t2hD3OYRXb6D5/GffIvaX82RbjD+nWtMZCLL7Q==",
       "dev": true,
       "dependencies": {
-        "@commitlint/types": "^19.5.0",
+        "@commitlint/types": "^19.8.0",
         "conventional-changelog-angular": "^7.0.0",
         "conventional-commits-parser": "^5.0.0"
       },
@@ -2059,13 +2098,13 @@
       }
     },
     "node_modules/@commitlint/resolve-extends": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-19.5.0.tgz",
-      "integrity": "sha512-CU/GscZhCUsJwcKTJS9Ndh3AKGZTNFIOoQB2n8CmFnizE0VnEuJoum+COW+C1lNABEeqk6ssfc1Kkalm4bDklA==",
+      "version": "19.8.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-19.8.0.tgz",
+      "integrity": "sha512-CLanRQwuG2LPfFVvrkTrBR/L/DMy3+ETsgBqW1OvRxmzp/bbVJW0Xw23LnnExgYcsaFtos967lul1CsbsnJlzQ==",
       "dev": true,
       "dependencies": {
-        "@commitlint/config-validator": "^19.5.0",
-        "@commitlint/types": "^19.5.0",
+        "@commitlint/config-validator": "^19.8.0",
+        "@commitlint/types": "^19.8.0",
         "global-directory": "^4.0.1",
         "import-meta-resolve": "^4.0.0",
         "lodash.mergewith": "^4.6.2",
@@ -2076,24 +2115,24 @@
       }
     },
     "node_modules/@commitlint/rules": {
-      "version": "19.6.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-19.6.0.tgz",
-      "integrity": "sha512-1f2reW7lbrI0X0ozZMesS/WZxgPa4/wi56vFuJENBmed6mWq5KsheN/nxqnl/C23ioxpPO/PL6tXpiiFy5Bhjw==",
+      "version": "19.8.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-19.8.0.tgz",
+      "integrity": "sha512-IZ5IE90h6DSWNuNK/cwjABLAKdy8tP8OgGVGbXe1noBEX5hSsu00uRlLu6JuruiXjWJz2dZc+YSw3H0UZyl/mA==",
       "dev": true,
       "dependencies": {
-        "@commitlint/ensure": "^19.5.0",
-        "@commitlint/message": "^19.5.0",
-        "@commitlint/to-lines": "^19.5.0",
-        "@commitlint/types": "^19.5.0"
+        "@commitlint/ensure": "^19.8.0",
+        "@commitlint/message": "^19.8.0",
+        "@commitlint/to-lines": "^19.8.0",
+        "@commitlint/types": "^19.8.0"
       },
       "engines": {
         "node": ">=v18"
       }
     },
     "node_modules/@commitlint/to-lines": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-19.5.0.tgz",
-      "integrity": "sha512-R772oj3NHPkodOSRZ9bBVNq224DOxQtNef5Pl8l2M8ZnkkzQfeSTr4uxawV2Sd3ui05dUVzvLNnzenDBO1KBeQ==",
+      "version": "19.8.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-19.8.0.tgz",
+      "integrity": "sha512-3CKLUw41Cur8VMjh16y8LcsOaKbmQjAKCWlXx6B0vOUREplp6em9uIVhI8Cv934qiwkbi2+uv+mVZPnXJi1o9A==",
       "dev": true,
       "engines": {
         "node": ">=v18"
@@ -2195,9 +2234,9 @@
       }
     },
     "node_modules/@commitlint/types": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-19.5.0.tgz",
-      "integrity": "sha512-DSHae2obMSMkAtTBSOulg5X7/z+rGLxcXQIkg3OmWvY6wifojge5uVMydfhUvs7yQj+V7jNmRZ2Xzl8GJyqRgg==",
+      "version": "19.8.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-19.8.0.tgz",
+      "integrity": "sha512-LRjP623jPyf3Poyfb0ohMj8I3ORyBDOwXAgxxVPbSD0unJuW2mJWeiRfaQinjtccMqC5Wy1HOMfa4btKjbNxbg==",
       "dev": true,
       "dependencies": {
         "@types/conventional-commits-parser": "^5.0.0",
@@ -2893,6 +2932,15 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -6989,20 +7037,20 @@
       }
     },
     "node_modules/cosmiconfig-typescript-loader": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-5.1.0.tgz",
-      "integrity": "sha512-7PtBB+6FdsOvZyJtlF3hEPpACq7RQX6BVGsgC7/lfVXnKMvNCu/XY3ykreqG5w/rBNdu2z8LCIKoF3kpHHdHlA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-6.1.0.tgz",
+      "integrity": "sha512-tJ1w35ZRUiM5FeTzT7DtYWAFFv37ZLqSRkGi2oeCK1gPhvaWjkAtfXvLmvE1pRfxxp9aQo6ba/Pvg1dKj05D4g==",
       "dev": true,
       "dependencies": {
-        "jiti": "^1.21.6"
+        "jiti": "^2.4.1"
       },
       "engines": {
-        "node": ">=v16"
+        "node": ">=v18"
       },
       "peerDependencies": {
         "@types/node": "*",
-        "cosmiconfig": ">=8.2",
-        "typescript": ">=4"
+        "cosmiconfig": ">=9",
+        "typescript": ">=5"
       }
     },
     "node_modules/cosmiconfig/node_modules/argparse": {
@@ -12047,12 +12095,12 @@
       }
     },
     "node_modules/jiti": {
-      "version": "1.21.6",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.6.tgz",
-      "integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
+      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
       "dev": true,
       "bin": {
-        "jiti": "bin/jiti.js"
+        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/jose": {
@@ -16935,6 +16983,15 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
     },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -17055,6 +17112,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.28.5",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.5.tgz",
+      "integrity": "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==",
+      "dev": true,
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -40,9 +40,13 @@
     "validate.js": "^0.13.1"
   },
   "devDependencies": {
+    "@actions/core": "^1.11.1",
     "@babel/core": "^7.17.10",
     "@commitlint/cli": "^19.6.0",
     "@commitlint/config-conventional": "^19.6.0",
+    "@commitlint/format": "^19.8.0",
+    "@commitlint/lint": "^19.8.0",
+    "@commitlint/load": "^19.8.0",
     "@mui/types": "^7.2.18",
     "@next/eslint-plugin-next": "^15.0.4",
     "@playwright/test": "^1.49.1",


### PR DESCRIPTION
Closes #377

[GitHub's documentation](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#good-practices-for-mitigating-script-injection-attacks) recommends using a JavaScript action over using scripts in a YAML workflow when working with things like a PR title, so I've created a custom action to do the checks

See examples of [failing issue number](https://github.com/galaxyproject/brc-analytics/actions/runs/13807201667/job/38620406711#step:6:12), [failing Conventional Commits](https://github.com/galaxyproject/brc-analytics/actions/runs/13807395845/job/38620984585#step:6:16), and [failing both](https://github.com/galaxyproject/brc-analytics/actions/runs/13807174049/job/38620322910#step:6:16) (note: these were before the updates to the job and step names)