### PR TITLE
style:  apply consistent python formatting, import sorting --  automate w/ ruff #393

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -17,7 +17,7 @@ npm run lint ||
 )
 
 # Format Python files
-echo '🐍 Formatting Python files with Black...'
+echo '🐍 Formatting Python files with Ruff...'
 npm run format:python
 
 # Check TypeScript

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -16,6 +16,10 @@ npm run lint ||
         false;
 )
 
+# Format Python files
+echo '🐍 Formatting Python files with Black...'
+npm run format:python
+
 # Check TypeScript
 npx tsc --noEmit ||
 (

--- a/catalog/build/py/build-files-from-ncbi.py
+++ b/catalog/build/py/build-files-from-ncbi.py
@@ -11,43 +11,43 @@ QC_REPORT_PATH = "catalog/output/qc-report.md"
 TREE_OUTPUT_PATH = "catalog/output/ncbi-taxa-tree.json"
 
 TAXONOMIC_GROUPS_BY_TAXONOMY_ID = {
-  2: "Bacteria",
-  10239: "Viruses",
-  5794: "Apicomplexa",
-  5653: "Kinetoplastea",
-  6029: "Microsporidia",
-  4762: "Oomycota",
-  7742: "Vertebrata",
-  554915: "Amoebozoa",
-  2611341: "Metamonada",
-  6656: "Arthropoda",
-  4890: "Ascomycota",
-  5204: "Basidiomycota",
-  4761: "Chytridiomycota",
-  1913637: "Mucoromycota"
+    2: "Bacteria",
+    10239: "Viruses",
+    5794: "Apicomplexa",
+    5653: "Kinetoplastea",
+    6029: "Microsporidia",
+    4762: "Oomycota",
+    7742: "Vertebrata",
+    554915: "Amoebozoa",
+    2611341: "Metamonada",
+    6656: "Arthropoda",
+    4890: "Ascomycota",
+    5204: "Basidiomycota",
+    4761: "Chytridiomycota",
+    1913637: "Mucoromycota",
 }
 
 TAXANOMIC_LEVELS_FOR_TREE = [
-  "domain",
-  "realm",
-  "kingdom",
-  "phylum",
-  "class",
-  "order",
-  "family",
-  "genus",
-  "species",
-  "strain"
+    "domain",
+    "realm",
+    "kingdom",
+    "phylum",
+    "class",
+    "order",
+    "family",
+    "genus",
+    "species",
+    "strain",
 ]
 
 if __name__ == "__main__":
-  build_files(
-    ASSEMBLIES_PATH,
-    GENOMES_OUTPUT_PATH,
-    UCSC_ASSEMBLIES_URL,
-    TREE_OUTPUT_PATH,
-    TAXANOMIC_LEVELS_FOR_TREE,
-    {"taxonomicGroup": TAXONOMIC_GROUPS_BY_TAXONOMY_ID},
-    qc_report_path=QC_REPORT_PATH,
-    organisms_path=ORGANISMS_PATH
-  )
+    build_files(
+        ASSEMBLIES_PATH,
+        GENOMES_OUTPUT_PATH,
+        UCSC_ASSEMBLIES_URL,
+        TREE_OUTPUT_PATH,
+        TAXANOMIC_LEVELS_FOR_TREE,
+        {"taxonomicGroup": TAXONOMIC_GROUPS_BY_TAXONOMY_ID},
+        qc_report_path=QC_REPORT_PATH,
+        organisms_path=ORGANISMS_PATH,
+    )

--- a/catalog/build/py/generated_schema/schema.py
+++ b/catalog/build/py/generated_schema/schema.py
@@ -1,32 +1,13 @@
-from __future__ import annotations 
+from __future__ import annotations
 
 import re
 import sys
-from datetime import (
-    date,
-    datetime,
-    time
-)
-from decimal import Decimal 
-from enum import Enum 
-from typing import (
-    Any,
-    ClassVar,
-    Dict,
-    List,
-    Literal,
-    Optional,
-    Union
-)
+from datetime import date, datetime, time
+from decimal import Decimal
+from enum import Enum
+from typing import Any, ClassVar, Dict, List, Literal, Optional, Union
 
-from pydantic import (
-    BaseModel,
-    ConfigDict,
-    Field,
-    RootModel,
-    field_validator
-)
-
+from pydantic import BaseModel, ConfigDict, Field, RootModel, field_validator
 
 metamodel_version = "None"
 version = "None"
@@ -34,52 +15,62 @@ version = "None"
 
 class ConfiguredBaseModel(BaseModel):
     model_config = ConfigDict(
-        validate_assignment = True,
-        validate_default = True,
-        extra = "forbid",
-        arbitrary_types_allowed = True,
-        use_enum_values = True,
-        strict = False,
+        validate_assignment=True,
+        validate_default=True,
+        extra="forbid",
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        strict=False,
     )
     pass
-
-
 
 
 class LinkMLMeta(RootModel):
     root: Dict[str, Any] = {}
     model_config = ConfigDict(frozen=True)
 
-    def __getattr__(self, key:str):
+    def __getattr__(self, key: str):
         return getattr(self.root, key)
 
-    def __getitem__(self, key:str):
+    def __getitem__(self, key: str):
         return self.root[key]
 
-    def __setitem__(self, key:str, value):
+    def __setitem__(self, key: str, value):
         self.root[key] = value
 
-    def __contains__(self, key:str) -> bool:
+    def __contains__(self, key: str) -> bool:
         return key in self.root
 
 
-linkml_meta = LinkMLMeta({'default_prefix': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/schema.yaml#',
-     'description': 'Combined source data schemas.',
-     'id': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/schema.yaml#',
-     'imports': ['./assemblies',
-                 './organisms',
-                 './outbreaks',
-                 './workflow_categories',
-                 './workflows'],
-     'name': 'schema',
-     'prefixes': {'linkml': {'prefix_prefix': 'linkml',
-                             'prefix_reference': 'https://w3id.org/linkml/'}},
-     'source_file': './catalog/schema/schema.yaml'} )
+linkml_meta = LinkMLMeta(
+    {
+        "default_prefix": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/schema.yaml#",
+        "description": "Combined source data schemas.",
+        "id": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/schema.yaml#",
+        "imports": [
+            "./assemblies",
+            "./organisms",
+            "./outbreaks",
+            "./workflow_categories",
+            "./workflows",
+        ],
+        "name": "schema",
+        "prefixes": {
+            "linkml": {
+                "prefix_prefix": "linkml",
+                "prefix_reference": "https://w3id.org/linkml/",
+            }
+        },
+        "source_file": "./catalog/schema/schema.yaml",
+    }
+)
+
 
 class OrganismPloidy(str, Enum):
     """
     Possible ploidies of an organism.
     """
+
     DIPLOID = "DIPLOID"
     HAPLOID = "HAPLOID"
     POLYPLOID = "POLYPLOID"
@@ -89,6 +80,7 @@ class OutbreakPriority(str, Enum):
     """
     Possible priorities of an outbreak.
     """
+
     HIGHEST = "HIGHEST"
     CRITICAL = "CRITICAL"
     HIGH = "HIGH"
@@ -100,6 +92,7 @@ class OutbreakResourceType(str, Enum):
     """
     Possible types of an outbreak resource.
     """
+
     PUBLICATION = "PUBLICATION"
     REFERENCE = "REFERENCE"
     NEWS = "NEWS"
@@ -112,6 +105,7 @@ class WorkflowCategoryId(str, Enum):
     """
     Set of IDs of workflow categories.
     """
+
     VARIANT_CALLING = "VARIANT_CALLING"
     TRANSCRIPTOMICS = "TRANSCRIPTOMICS"
     REGULATION = "REGULATION"
@@ -126,6 +120,7 @@ class WorkflowParameterVariable(str, Enum):
     """
     Possible variables that can be inserted into workflow parameters.
     """
+
     ASSEMBLY_ID = "ASSEMBLY_ID"
     ASSEMBLY_FASTA_URL = "ASSEMBLY_FASTA_URL"
     GENE_MODEL_URL = "GENE_MODEL_URL"
@@ -136,103 +131,254 @@ class WorkflowPloidy(str, Enum):
     """
     Possible ploidies supported by workflows.
     """
+
     ANY = "ANY"
     DIPLOID = "DIPLOID"
     HAPLOID = "HAPLOID"
     POLYPLOID = "POLYPLOID"
 
 
-
 class Assemblies(ConfiguredBaseModel):
     """
     Object containing list of assemblies.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/assemblies.yaml#',
-         'tree_root': True})
 
-    assemblies: List[Assembly] = Field(default=..., description="""List of assemblies.""", json_schema_extra = { "linkml_meta": {'alias': 'assemblies', 'domain_of': ['Assemblies']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/assemblies.yaml#",
+            "tree_root": True,
+        }
+    )
+
+    assemblies: List[Assembly] = Field(
+        default=...,
+        description="""List of assemblies.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "assemblies", "domain_of": ["Assemblies"]}
+        },
+    )
 
 
 class Assembly(ConfiguredBaseModel):
     """
     An assembly.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/assemblies.yaml#'})
 
-    accession: str = Field(default=..., description="""The assembly's accession.""", json_schema_extra = { "linkml_meta": {'alias': 'accession', 'domain_of': ['Assembly']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/assemblies.yaml#"
+        }
+    )
+
+    accession: str = Field(
+        default=...,
+        description="""The assembly's accession.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "accession", "domain_of": ["Assembly"]}
+        },
+    )
 
 
 class Organisms(ConfiguredBaseModel):
     """
     Object containing list of organisms.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/organisms.yaml#',
-         'tree_root': True})
 
-    organisms: List[Organism] = Field(default=..., description="""List of organisms.""", json_schema_extra = { "linkml_meta": {'alias': 'organisms', 'domain_of': ['Organisms']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/organisms.yaml#",
+            "tree_root": True,
+        }
+    )
+
+    organisms: List[Organism] = Field(
+        default=...,
+        description="""List of organisms.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "organisms", "domain_of": ["Organisms"]}
+        },
+    )
 
 
 class Organism(ConfiguredBaseModel):
     """
     Info for an organism.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/organisms.yaml#'})
 
-    taxonomy_id: int = Field(default=..., description="""The organism's NCBI taxonomy ID.""", json_schema_extra = { "linkml_meta": {'alias': 'taxonomy_id', 'domain_of': ['Organism', 'Outbreak', 'Workflow']} })
-    ploidy: List[OrganismPloidy] = Field(default=..., description="""The ploidies that the organism may have.""", json_schema_extra = { "linkml_meta": {'alias': 'ploidy', 'domain_of': ['Organism', 'Workflow']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/organisms.yaml#"
+        }
+    )
+
+    taxonomy_id: int = Field(
+        default=...,
+        description="""The organism's NCBI taxonomy ID.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "taxonomy_id",
+                "domain_of": ["Organism", "Outbreak", "Workflow"],
+            }
+        },
+    )
+    ploidy: List[OrganismPloidy] = Field(
+        default=...,
+        description="""The ploidies that the organism may have.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "ploidy", "domain_of": ["Organism", "Workflow"]}
+        },
+    )
 
 
 class Outbreaks(ConfiguredBaseModel):
     """
     Object containing list of outbreaks.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/outbreaks.yaml#',
-         'tree_root': True})
 
-    outbreaks: List[Outbreak] = Field(default=..., description="""List of outbreaks.""", json_schema_extra = { "linkml_meta": {'alias': 'outbreaks', 'domain_of': ['Outbreaks']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/outbreaks.yaml#",
+            "tree_root": True,
+        }
+    )
+
+    outbreaks: List[Outbreak] = Field(
+        default=...,
+        description="""List of outbreaks.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "outbreaks", "domain_of": ["Outbreaks"]}
+        },
+    )
 
 
 class Outbreak(ConfiguredBaseModel):
     """
     Info for an outbreak.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/outbreaks.yaml#'})
 
-    taxonomy_id: int = Field(default=..., description="""The outbreak's NCBI taxonomy ID.""", json_schema_extra = { "linkml_meta": {'alias': 'taxonomy_id', 'domain_of': ['Organism', 'Outbreak', 'Workflow']} })
-    priority: OutbreakPriority = Field(default=..., description="""The priority of the outbreak.""", json_schema_extra = { "linkml_meta": {'alias': 'priority', 'domain_of': ['Outbreak']} })
-    resources: List[OutbreakResource] = Field(default=..., description="""The resources associated with the outbreak.""", json_schema_extra = { "linkml_meta": {'alias': 'resources', 'domain_of': ['Outbreak']} })
-    description: MarkdownFileReference = Field(default=..., description="""The description of the outbreak.""", json_schema_extra = { "linkml_meta": {'alias': 'description', 'domain_of': ['Outbreak', 'WorkflowCategory']} })
-    active: bool = Field(default=..., description="""Determines if outbreak should be included, as they presumably change over time.""", json_schema_extra = { "linkml_meta": {'alias': 'active', 'domain_of': ['Outbreak', 'Workflow']} })
-    highlight_descendant_taxonomy_ids: Optional[List[int]] = Field(default=None, description="""Taxonomy IDs of child taxa that should be highlighted.""", json_schema_extra = { "linkml_meta": {'alias': 'highlight_descendant_taxonomy_ids', 'domain_of': ['Outbreak']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/outbreaks.yaml#"
+        }
+    )
+
+    taxonomy_id: int = Field(
+        default=...,
+        description="""The outbreak's NCBI taxonomy ID.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "taxonomy_id",
+                "domain_of": ["Organism", "Outbreak", "Workflow"],
+            }
+        },
+    )
+    priority: OutbreakPriority = Field(
+        default=...,
+        description="""The priority of the outbreak.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "priority", "domain_of": ["Outbreak"]}
+        },
+    )
+    resources: List[OutbreakResource] = Field(
+        default=...,
+        description="""The resources associated with the outbreak.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "resources", "domain_of": ["Outbreak"]}
+        },
+    )
+    description: MarkdownFileReference = Field(
+        default=...,
+        description="""The description of the outbreak.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Outbreak", "WorkflowCategory"],
+            }
+        },
+    )
+    active: bool = Field(
+        default=...,
+        description="""Determines if outbreak should be included, as they presumably change over time.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "active", "domain_of": ["Outbreak", "Workflow"]}
+        },
+    )
+    highlight_descendant_taxonomy_ids: Optional[List[int]] = Field(
+        default=None,
+        description="""Taxonomy IDs of child taxa that should be highlighted.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "highlight_descendant_taxonomy_ids",
+                "domain_of": ["Outbreak"],
+            }
+        },
+    )
 
 
 class OutbreakResource(ConfiguredBaseModel):
     """
     A resource associated with an outbreak.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/outbreaks.yaml#'})
 
-    url: str = Field(default=..., description="""The URL of the resource.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['OutbreakResource', 'WorkflowUrlSpec']} })
-    title: str = Field(default=..., description="""The title of the resource.""", json_schema_extra = { "linkml_meta": {'alias': 'title', 'domain_of': ['OutbreakResource']} })
-    type: OutbreakResourceType = Field(default=..., description="""The type of the resource.""", json_schema_extra = { "linkml_meta": {'alias': 'type', 'domain_of': ['OutbreakResource']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/outbreaks.yaml#"
+        }
+    )
+
+    url: str = Field(
+        default=...,
+        description="""The URL of the resource.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["OutbreakResource", "WorkflowUrlSpec"],
+            }
+        },
+    )
+    title: str = Field(
+        default=...,
+        description="""The title of the resource.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "title", "domain_of": ["OutbreakResource"]}
+        },
+    )
+    type: OutbreakResourceType = Field(
+        default=...,
+        description="""The type of the resource.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "type", "domain_of": ["OutbreakResource"]}
+        },
+    )
 
 
 class MarkdownFileReference(ConfiguredBaseModel):
     """
     A reference to a markdown file
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/outbreaks.yaml#'})
 
-    path: str = Field(default=..., description="""Path to the markdown file""", json_schema_extra = { "linkml_meta": {'alias': 'path', 'domain_of': ['MarkdownFileReference']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/outbreaks.yaml#"
+        }
+    )
 
-    @field_validator('path')
+    path: str = Field(
+        default=...,
+        description="""Path to the markdown file""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "path", "domain_of": ["MarkdownFileReference"]}
+        },
+    )
+
+    @field_validator("path")
     def pattern_path(cls, v):
-        pattern=re.compile(r".*\.md$")
-        if isinstance(v,list):
+        pattern = re.compile(r".*\.md$")
+        if isinstance(v, list):
             for element in v:
                 if isinstance(v, str) and not pattern.match(element):
                     raise ValueError(f"Invalid path format: {element}")
-        elif isinstance(v,str):
+        elif isinstance(v, str):
             if not pattern.match(v):
                 raise ValueError(f"Invalid path format: {v}")
         return v
@@ -242,71 +388,242 @@ class WorkflowCategories(ConfiguredBaseModel):
     """
     Object containing list of workflow categories.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/workflow_categories.yaml#',
-         'tree_root': True})
 
-    workflow_categories: List[WorkflowCategory] = Field(default=..., description="""List of workflow categories.""", json_schema_extra = { "linkml_meta": {'alias': 'workflow_categories', 'domain_of': ['WorkflowCategories']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/workflow_categories.yaml#",
+            "tree_root": True,
+        }
+    )
+
+    workflow_categories: List[WorkflowCategory] = Field(
+        default=...,
+        description="""List of workflow categories.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "workflow_categories",
+                "domain_of": ["WorkflowCategories"],
+            }
+        },
+    )
 
 
 class WorkflowCategory(ConfiguredBaseModel):
     """
     Workflow category.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/workflow_categories.yaml#'})
 
-    category: WorkflowCategoryId = Field(default=..., description="""The ID of the workflow category.""", json_schema_extra = { "linkml_meta": {'alias': 'category', 'domain_of': ['WorkflowCategory']} })
-    name: str = Field(default=..., description="""The display name of the workflow category.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['WorkflowCategory']} })
-    description: str = Field(default=..., description="""The description of the workflow category.""", json_schema_extra = { "linkml_meta": {'alias': 'description', 'domain_of': ['Outbreak', 'WorkflowCategory']} })
-    show_coming_soon: bool = Field(default=..., description="""Whether to show 'Coming Soon' for the workflow category when it is not available.""", json_schema_extra = { "linkml_meta": {'alias': 'show_coming_soon', 'domain_of': ['WorkflowCategory']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/workflow_categories.yaml#"
+        }
+    )
+
+    category: WorkflowCategoryId = Field(
+        default=...,
+        description="""The ID of the workflow category.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "category", "domain_of": ["WorkflowCategory"]}
+        },
+    )
+    name: str = Field(
+        default=...,
+        description="""The display name of the workflow category.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "name", "domain_of": ["WorkflowCategory"]}
+        },
+    )
+    description: str = Field(
+        default=...,
+        description="""The description of the workflow category.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Outbreak", "WorkflowCategory"],
+            }
+        },
+    )
+    show_coming_soon: bool = Field(
+        default=...,
+        description="""Whether to show 'Coming Soon' for the workflow category when it is not available.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "show_coming_soon",
+                "domain_of": ["WorkflowCategory"],
+            }
+        },
+    )
 
 
 class Workflows(ConfiguredBaseModel):
     """
     Object containing list of workflows.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/workflows.yaml#',
-         'tree_root': True})
 
-    workflows: List[Workflow] = Field(default=..., description="""List of workflows.""", json_schema_extra = { "linkml_meta": {'alias': 'workflows', 'domain_of': ['Workflows']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/workflows.yaml#",
+            "tree_root": True,
+        }
+    )
+
+    workflows: List[Workflow] = Field(
+        default=...,
+        description="""List of workflows.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "workflows", "domain_of": ["Workflows"]}
+        },
+    )
 
 
 class Workflow(ConfiguredBaseModel):
     """
     A workflow.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/workflows.yaml#'})
 
-    trs_id: str = Field(default=..., description="""The workflow's TRS ID.""", json_schema_extra = { "linkml_meta": {'alias': 'trs_id', 'domain_of': ['Workflow']} })
-    categories: List[WorkflowCategoryId] = Field(default=..., description="""The IDs of the categories the workflow belongs to.""", json_schema_extra = { "linkml_meta": {'alias': 'categories', 'domain_of': ['Workflow']} })
-    workflow_name: str = Field(default=..., description="""The display name of the workflow.""", json_schema_extra = { "linkml_meta": {'alias': 'workflow_name', 'domain_of': ['Workflow']} })
-    workflow_description: str = Field(default=..., description="""The description of the workflow.""", json_schema_extra = { "linkml_meta": {'alias': 'workflow_description', 'domain_of': ['Workflow']} })
-    ploidy: WorkflowPloidy = Field(default=..., description="""The ploidy supported by the workflow.""", json_schema_extra = { "linkml_meta": {'alias': 'ploidy', 'domain_of': ['Organism', 'Workflow']} })
-    taxonomy_id: Optional[int] = Field(default=None, description="""The NCBI ID of the taxon supported by the workflow.""", json_schema_extra = { "linkml_meta": {'alias': 'taxonomy_id', 'domain_of': ['Organism', 'Outbreak', 'Workflow']} })
-    parameters: List[WorkflowParameter] = Field(default=..., description="""The parameters of the workflow.""", json_schema_extra = { "linkml_meta": {'alias': 'parameters', 'domain_of': ['Workflow']} })
-    active: bool = Field(default=..., description="""Determines if workflow should be included.""", json_schema_extra = { "linkml_meta": {'alias': 'active', 'domain_of': ['Outbreak', 'Workflow']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/workflows.yaml#"
+        }
+    )
+
+    trs_id: str = Field(
+        default=...,
+        description="""The workflow's TRS ID.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "trs_id", "domain_of": ["Workflow"]}
+        },
+    )
+    categories: List[WorkflowCategoryId] = Field(
+        default=...,
+        description="""The IDs of the categories the workflow belongs to.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "categories", "domain_of": ["Workflow"]}
+        },
+    )
+    workflow_name: str = Field(
+        default=...,
+        description="""The display name of the workflow.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "workflow_name", "domain_of": ["Workflow"]}
+        },
+    )
+    workflow_description: str = Field(
+        default=...,
+        description="""The description of the workflow.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "workflow_description", "domain_of": ["Workflow"]}
+        },
+    )
+    ploidy: WorkflowPloidy = Field(
+        default=...,
+        description="""The ploidy supported by the workflow.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "ploidy", "domain_of": ["Organism", "Workflow"]}
+        },
+    )
+    taxonomy_id: Optional[int] = Field(
+        default=None,
+        description="""The NCBI ID of the taxon supported by the workflow.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "taxonomy_id",
+                "domain_of": ["Organism", "Outbreak", "Workflow"],
+            }
+        },
+    )
+    parameters: List[WorkflowParameter] = Field(
+        default=...,
+        description="""The parameters of the workflow.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "parameters", "domain_of": ["Workflow"]}
+        },
+    )
+    active: bool = Field(
+        default=...,
+        description="""Determines if workflow should be included.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "active", "domain_of": ["Outbreak", "Workflow"]}
+        },
+    )
 
 
 class WorkflowParameter(ConfiguredBaseModel):
     """
     A parameter that is provided to a workflow; must include a source for the parameter's value in order to be provided.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/workflows.yaml#'})
 
-    key: str = Field(default=..., description="""The key in which the parameter will be set.""", json_schema_extra = { "linkml_meta": {'alias': 'key', 'domain_of': ['WorkflowParameter']} })
-    variable: Optional[WorkflowParameterVariable] = Field(default=None, description="""A variable to substitute in as the value of the parameter.""", json_schema_extra = { "linkml_meta": {'alias': 'variable', 'domain_of': ['WorkflowParameter']} })
-    url_spec: Optional[WorkflowUrlSpec] = Field(default=None, description="""A direct URL specification for the parameter.""", json_schema_extra = { "linkml_meta": {'alias': 'url_spec', 'domain_of': ['WorkflowParameter']} })
-    type_guide: Optional[Any] = Field(default=None, description="""Arbitrary data describing the type of the parameter, intended only as convenient reference for maintainers.""", json_schema_extra = { "linkml_meta": {'alias': 'type_guide', 'domain_of': ['WorkflowParameter']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/workflows.yaml#"
+        }
+    )
+
+    key: str = Field(
+        default=...,
+        description="""The key in which the parameter will be set.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "key", "domain_of": ["WorkflowParameter"]}
+        },
+    )
+    variable: Optional[WorkflowParameterVariable] = Field(
+        default=None,
+        description="""A variable to substitute in as the value of the parameter.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "variable", "domain_of": ["WorkflowParameter"]}
+        },
+    )
+    url_spec: Optional[WorkflowUrlSpec] = Field(
+        default=None,
+        description="""A direct URL specification for the parameter.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "url_spec", "domain_of": ["WorkflowParameter"]}
+        },
+    )
+    type_guide: Optional[Any] = Field(
+        default=None,
+        description="""Arbitrary data describing the type of the parameter, intended only as convenient reference for maintainers.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "type_guide", "domain_of": ["WorkflowParameter"]}
+        },
+    )
 
 
 class WorkflowUrlSpec(ConfiguredBaseModel):
     """
     A URL specification for a workflow parameter.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/workflows.yaml#'})
 
-    ext: str = Field(default=..., description="""The file extension of the URL.""", json_schema_extra = { "linkml_meta": {'alias': 'ext', 'domain_of': ['WorkflowUrlSpec']} })
-    src: str = Field(default=..., description="""The source type, typically 'url'.""", json_schema_extra = { "linkml_meta": {'alias': 'src', 'domain_of': ['WorkflowUrlSpec']} })
-    url: str = Field(default=..., description="""The URL to the resource.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['OutbreakResource', 'WorkflowUrlSpec']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/workflows.yaml#"
+        }
+    )
+
+    ext: str = Field(
+        default=...,
+        description="""The file extension of the URL.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "ext", "domain_of": ["WorkflowUrlSpec"]}
+        },
+    )
+    src: str = Field(
+        default=...,
+        description="""The source type, typically 'url'.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "src", "domain_of": ["WorkflowUrlSpec"]}
+        },
+    )
+    url: str = Field(
+        default=...,
+        description="""The URL to the resource.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["OutbreakResource", "WorkflowUrlSpec"],
+            }
+        },
+    )
 
 
 # Model rebuild
@@ -325,4 +642,3 @@ Workflows.model_rebuild()
 Workflow.model_rebuild()
 WorkflowParameter.model_rebuild()
 WorkflowUrlSpec.model_rebuild()
-

--- a/catalog/build/py/iwc_manifest_to_workflows_yaml.py
+++ b/catalog/build/py/iwc_manifest_to_workflows_yaml.py
@@ -6,8 +6,13 @@ from typing import Dict
 
 import requests
 import yaml
-
-from generated_schema.schema import Workflows, Workflow, WorkflowParameter, WorkflowCategoryId, WorkflowPloidy
+from generated_schema.schema import (
+    Workflow,
+    WorkflowCategoryId,
+    WorkflowParameter,
+    WorkflowPloidy,
+    Workflows,
+)
 
 URL = "https://iwc.galaxyproject.org/workflow_manifest.json"
 WORKFLOWS_PATH = "catalog/source/workflows.yml"
@@ -16,9 +21,14 @@ DOCKSTORE_COLLECTION_TO_CATEGORY = {
     "Transcriptomics": WorkflowCategoryId.TRANSCRIPTOMICS,
     "Epigenetics": WorkflowCategoryId.REGULATION,
     "Genome assembly": WorkflowCategoryId.ASSEMBLY,
-    "Virology": WorkflowCategoryId.CONSENSUS_SEQUENCES
+    "Virology": WorkflowCategoryId.CONSENSUS_SEQUENCES,
 }
-MANIFEST_SOURCE_OF_TRUTH = ("trs_id", "workflow_name", "categories", "workflow_description")
+MANIFEST_SOURCE_OF_TRUTH = (
+    "trs_id",
+    "workflow_name",
+    "categories",
+    "workflow_description",
+)
 
 
 def read_existing_yaml():
@@ -36,7 +46,10 @@ def get_workflow_categories_from_collections(collections):
     return sorted(
         list(
             set(
-                [DOCKSTORE_COLLECTION_TO_CATEGORY.get(c, WorkflowCategoryId.OTHER) for c in collections]
+                [
+                    DOCKSTORE_COLLECTION_TO_CATEGORY.get(c, WorkflowCategoryId.OTHER)
+                    for c in collections
+                ]
             )
         )
     )
@@ -64,9 +77,16 @@ def get_input_types(workflow_definition):
                     step_input_guide["ext"] = input_formats[0]
                 else:
                     step_input_guide["ext"] = input_formats
-            inputs.append(WorkflowParameter(key=step_label, type_guide=step_input_guide))
+            inputs.append(
+                WorkflowParameter(key=step_label, type_guide=step_input_guide)
+            )
         if step_type == "parameter_input":
-            inputs.append(WorkflowParameter(key=step_label, type_guide={"class": tool_state.get("parameter_type")}))
+            inputs.append(
+                WorkflowParameter(
+                    key=step_label,
+                    type_guide={"class": tool_state.get("parameter_type")},
+                )
+            )
     return inputs
 
 
@@ -81,9 +101,11 @@ def generate_current_workflows():
                 continue
             workflow_input = Workflow(
                 active=False,
-                trs_id=f'{workflow["trsID"]}/versions/v{workflow["definition"]["release"]}',
+                trs_id=f"{workflow['trsID']}/versions/v{workflow['definition']['release']}",
                 workflow_name=workflow["definition"]["name"],
-                categories=get_workflow_categories_from_collections(workflow["collections"]),
+                categories=get_workflow_categories_from_collections(
+                    workflow["collections"]
+                ),
                 workflow_description=workflow["definition"]["annotation"],
                 ploidy=WorkflowPloidy.ANY,
                 # readme=workflow["readme"],
@@ -108,7 +130,9 @@ def merge_into_existing():
             for key in MANIFEST_SOURCE_OF_TRUTH:
                 exisiting_dict[key] = new_dict[key]
             # check that specified parameters still exist
-            current_workflow_parameter_keys = {param.key for param in current_workflow_input.parameters}
+            current_workflow_parameter_keys = {
+                param.key for param in current_workflow_input.parameters
+            }
             for param in existing_workflow_input.parameters:
                 if param.key not in current_workflow_parameter_keys:
                     # Should be rare, but can happen.
@@ -131,7 +155,7 @@ def to_workflows_yaml(exclude_other: bool):
             if WorkflowCategoryId.OTHER in workflow.categories:
                 workflow.categories.remove(WorkflowCategoryId.OTHER)
                 if not workflow.categories:
-                    print(f'Excluding workflow {workflow.trs_id}, category unknown')
+                    print(f"Excluding workflow {workflow.trs_id}, category unknown")
                     continue
             final_workflows.append(workflow)
         sorted_workflows = final_workflows

--- a/catalog/build/py/package/catalog_build/build.py
+++ b/catalog/build/py/package/catalog_build/build.py
@@ -437,7 +437,8 @@ def report_inconsistent_taxonomy_ids(df):
   inconsistent_ids_series = df.groupby(["species", "strain"]).filter(lambda g: g["taxonomyId"].nunique() > 1).groupby(["species", "strain"])["taxonomyId"].apply(set)
   inconsistent_ids_strings = [(f"{species} strain {strain}" if strain else species, ", ".join([str(id) for id in ids])) for (species, strain), ids in inconsistent_ids_series.items()]
   if len(inconsistent_ids_strings) > 0:
-    print(f"Taxa with inconsistent taxonomy IDs: {", ".join([f"{taxon} ({ids})" for taxon, ids in inconsistent_ids_strings])}")
+    inconsistent_taxonmy_ids_combined = ", ".join([f"{taxon} ({ids})" for taxon, ids in inconsistent_ids_strings])
+    print(f"Taxa with inconsistent taxonomy IDs: {inconsistent_taxonmy_ids_combined}")
   return inconsistent_ids_strings
 
 

--- a/catalog/build/py/package/catalog_build/build.py
+++ b/catalog/build/py/package/catalog_build/build.py
@@ -1,324 +1,372 @@
-import pandas as pd
-import yaml
-import requests
-import urllib
-import re
 import json
-import time
-from functools import partial
-from bs4 import BeautifulSoup
 import logging
+import re
+import time
+import urllib
+from functools import partial
 
-MAX_NCBI_URL_LENGTH = 2000 # The actual limit seems to be a bit over 4000
+import pandas as pd
+import requests
+import yaml
+from bs4 import BeautifulSoup
+
+MAX_NCBI_URL_LENGTH = 2000  # The actual limit seems to be a bit over 4000
 
 log = logging.getLogger(__name__)
 
 
 def rate_limit_handler(request_call):
-  try:
-    response = request_call()
-    response.raise_for_status()
-    return response
-  except requests.HTTPError:
-    if response.status_code == 429:
-      retry_after = int(response.headers.get("Retry-After"))
-      print(f"Rate limited, waiting {retry_after} seconds")
-      time.sleep(retry_after)
-      response = request_call()
-      response.raise_for_status()
-      return response
-    raise
+    try:
+        response = request_call()
+        response.raise_for_status()
+        return response
+    except requests.HTTPError:
+        if response.status_code == 429:
+            retry_after = int(response.headers.get("Retry-After"))
+            print(f"Rate limited, waiting {retry_after} seconds")
+            time.sleep(retry_after)
+            response = request_call()
+            response.raise_for_status()
+            return response
+        raise
 
 
 def post_ncbi_request(url, json_data):
-  """
-  Makes a POST request to the NCBI API with error handling and rate limiting.
-  Handles pagination if the response contains next_page_token.
-  
-  Args:
-    url: The API endpoint URL
-    json_data: The data to send in the request body
-    
-  Returns:
-    List of all reports from paginated responses
-    
-  Raises:
-    Exception: If the request fails or contains errors
-  """
-  all_reports = []
-  page = 1
-  
-  while True:
-    print(f"Requesting page {page} of {url}")
-    
-    # Add page token to request if it exists
-    if "next_page_token" in json_data:
-      json_data["page_token"] = json_data.pop("next_page_token")
-    
-    response = requests.post(url, json=json_data)
-    response = rate_limit_handler(lambda: response)
-    
-    if response.status_code != 200:
-      raise Exception(f"Failed to fetch data: {response.status_code} {response.text}")
-    
-    data = response.json()
-    
-    if len(data["reports"][0].get("errors", [])) > 0:
-      raise Exception(data["reports"][0])
-    
-    all_reports.extend(data["reports"])
-    
-    next_page_token = data.get("next_page_token")
-    if not next_page_token:
-      break
-    
-    json_data["next_page_token"] = next_page_token
-    page += 1
-    
-  return all_reports
+    """
+    Makes a POST request to the NCBI API with error handling and rate limiting.
+    Handles pagination if the response contains next_page_token.
+
+    Args:
+      url: The API endpoint URL
+      json_data: The data to send in the request body
+
+    Returns:
+      List of all reports from paginated responses
+
+    Raises:
+      Exception: If the request fails or contains errors
+    """
+    all_reports = []
+    page = 1
+
+    while True:
+        print(f"Requesting page {page} of {url}")
+
+        # Add page token to request if it exists
+        if "next_page_token" in json_data:
+            json_data["page_token"] = json_data.pop("next_page_token")
+
+        response = requests.post(url, json=json_data)
+        response = rate_limit_handler(lambda: response)
+
+        if response.status_code != 200:
+            raise Exception(
+                f"Failed to fetch data: {response.status_code} {response.text}"
+            )
+
+        data = response.json()
+
+        if len(data["reports"][0].get("errors", [])) > 0:
+            raise Exception(data["reports"][0])
+
+        all_reports.extend(data["reports"])
+
+        next_page_token = data.get("next_page_token")
+        if not next_page_token:
+            break
+
+        json_data["next_page_token"] = next_page_token
+        page += 1
+
+    return all_reports
 
 
 def read_assemblies(assemblies_path):
-  with open(assemblies_path) as stream:
-    return pd.DataFrame(yaml.safe_load(stream)["assemblies"])
+    with open(assemblies_path) as stream:
+        return pd.DataFrame(yaml.safe_load(stream)["assemblies"])
 
 
 def read_organisms(organisms_path):
-  with open(organisms_path) as stream:
-    return pd.DataFrame(yaml.safe_load(stream)["organisms"])
+    with open(organisms_path) as stream:
+        return pd.DataFrame(yaml.safe_load(stream)["organisms"])
 
 
 def match_taxonomic_group(tax_id, lineage, taxonomic_groups):
-  if tax_id not in taxonomic_groups:
+    if tax_id not in taxonomic_groups:
+        return None
+    taxon_info = taxonomic_groups[tax_id]
+    name, exclude = (
+        (taxon_info["value"], taxon_info.get("exclude"))
+        if isinstance(taxon_info, dict)
+        else (taxon_info, None)
+    )
+    if exclude is None:
+        return name
+    if isinstance(exclude, int):
+        exclude = [exclude]
+    if all(tid not in lineage for tid in exclude):
+        return name
     return None
-  taxon_info = taxonomic_groups[tax_id]
-  name, exclude = (taxon_info["value"], taxon_info.get("exclude")) if isinstance(taxon_info, dict) else (taxon_info, None)
-  if exclude is None:
-    return name
-  if isinstance(exclude, int):
-    exclude = [exclude]
-  if all(tid not in lineage for tid in exclude):
-    return name
-  return None
 
 
 def get_taxonomic_groups(lineage, taxonomic_groups):
-  return [group for group in (match_taxonomic_group(tax_id, lineage, taxonomic_groups) for tax_id in lineage) if group is not None]
+    return [
+        group
+        for group in (
+            match_taxonomic_group(tax_id, lineage, taxonomic_groups)
+            for tax_id in lineage
+        )
+        if group is not None
+    ]
 
 
 def get_taxonomic_group_sets(lineage, taxonomic_group_sets):
-  return {field: ",".join(get_taxonomic_groups(lineage, taxonomic_groups)) for field, taxonomic_groups in taxonomic_group_sets.items()}
+    return {
+        field: ",".join(get_taxonomic_groups(lineage, taxonomic_groups))
+        for field, taxonomic_groups in taxonomic_group_sets.items()
+    }
 
 
 def get_taxonomic_level_key(level):
-  return f"taxonomicLevel{level[0].upper()}{level[1:]}"
+    return f"taxonomicLevel{level[0].upper()}{level[1:]}"
 
 
 def get_species_row(taxon_info, taxonomic_group_sets, taxonomic_levels, name_info=None):
-  classification = taxon_info["taxonomy"]["classification"]
-  species_info = classification["species"]
-  taxonomy_id = taxon_info["taxonomy"]["tax_id"]
-  ancestor_taxonomy_ids = taxon_info["taxonomy"]["parents"]
+    classification = taxon_info["taxonomy"]["classification"]
+    species_info = classification["species"]
+    taxonomy_id = taxon_info["taxonomy"]["tax_id"]
+    ancestor_taxonomy_ids = taxon_info["taxonomy"]["parents"]
 
-  taxonomic_level_fields = {get_taxonomic_level_key(level): classification.get(level, {}).get("name") for level in taxonomic_levels}
-  own_level = taxon_info["taxonomy"]["rank"].lower() if "rank" in taxon_info["taxonomy"] else None
-  if own_level in taxonomic_levels and own_level not in classification:
-    taxonomic_level_fields[get_taxonomic_level_key(own_level)] = taxon_info["taxonomy"]["current_scientific_name"]["name"]
-  
-  if name_info:
-    common_names = name_info["taxonomy"].get("other_common_names")
-    if common_names:
-      taxonomic_level_fields["commonName"] = common_names[0]
+    taxonomic_level_fields = {
+        get_taxonomic_level_key(level): classification.get(level, {}).get("name")
+        for level in taxonomic_levels
+    }
+    own_level = (
+        taxon_info["taxonomy"]["rank"].lower()
+        if "rank" in taxon_info["taxonomy"]
+        else None
+    )
+    if own_level in taxonomic_levels and own_level not in classification:
+        taxonomic_level_fields[get_taxonomic_level_key(own_level)] = taxon_info[
+            "taxonomy"
+        ]["current_scientific_name"]["name"]
 
-  return {
-    "taxonomyId": taxonomy_id,
-    "species": species_info["name"],
-    "speciesTaxonomyId": species_info["id"],
-    "lineageTaxonomyIds": ",".join([str(id) for id in ancestor_taxonomy_ids + [taxonomy_id]]),
-    **get_taxonomic_group_sets(ancestor_taxonomy_ids, taxonomic_group_sets),
-    **taxonomic_level_fields
-  }
+    if name_info:
+        common_names = name_info["taxonomy"].get("other_common_names")
+        if common_names:
+            taxonomic_level_fields["commonName"] = common_names[0]
+
+    return {
+        "taxonomyId": taxonomy_id,
+        "species": species_info["name"],
+        "speciesTaxonomyId": species_info["id"],
+        "lineageTaxonomyIds": ",".join(
+            [str(id) for id in ancestor_taxonomy_ids + [taxonomy_id]]
+        ),
+        **get_taxonomic_group_sets(ancestor_taxonomy_ids, taxonomic_group_sets),
+        **taxonomic_level_fields,
+    }
 
 
 def get_species_info(taxonomy_ids):
-  """
-  Fetches species information from NCBI API for the given taxonomy IDs.
-  
-  Args:
-    taxonomy_ids: List of taxonomy IDs to fetch information for
-    
-  Returns:
-    List of species information dictionaries from NCBI
-  """
-  url = "https://api.ncbi.nlm.nih.gov/datasets/v2/taxonomy/dataset_report"
-  taxon_ids = list(set(str(id) for id in taxonomy_ids))
-  return post_ncbi_request(url, {"taxons": taxon_ids})
+    """
+    Fetches species information from NCBI API for the given taxonomy IDs.
+
+    Args:
+      taxonomy_ids: List of taxonomy IDs to fetch information for
+
+    Returns:
+      List of species information dictionaries from NCBI
+    """
+    url = "https://api.ncbi.nlm.nih.gov/datasets/v2/taxonomy/dataset_report"
+    taxon_ids = list(set(str(id) for id in taxonomy_ids))
+    return post_ncbi_request(url, {"taxons": taxon_ids})
 
 
 def get_species_name_info(taxonomy_ids):
-  """
-  Fetches species name information from NCBI API for the given taxonomy IDs.
-  
-  Args:
-    taxonomy_ids: List of taxonomy IDs to fetch information for
-    
-  Returns:
-    List of species name information dictionaries from NCBI
-  """
-  url = "https://api.ncbi.nlm.nih.gov/datasets/v2/taxonomy/name_report"
-  taxon_ids = list(set(str(id) for id in taxonomy_ids))
-  return post_ncbi_request(url, {"taxons": taxon_ids})
+    """
+    Fetches species name information from NCBI API for the given taxonomy IDs.
+
+    Args:
+      taxonomy_ids: List of taxonomy IDs to fetch information for
+
+    Returns:
+      List of species name information dictionaries from NCBI
+    """
+    url = "https://api.ncbi.nlm.nih.gov/datasets/v2/taxonomy/name_report"
+    taxon_ids = list(set(str(id) for id in taxonomy_ids))
+    return post_ncbi_request(url, {"taxons": taxon_ids})
 
 
-def get_species_df(species_info, species_name_info, taxonomic_group_sets, taxonomic_levels):
-  """
-  Converts species information into a DataFrame.
-  
-  Args:
-    species_info: List of species information dictionaries from NCBI
-    species_name_info: List of species name information dictionaries from NCBI
-    taxonomic_group_sets: Dictionary of taxonomic group sets
-    taxonomic_levels: List of taxonomic levels to include
-    
-  Returns:
-    DataFrame containing species information
-  """
-  # Create a dictionary mapping tax_id to name_info for easy lookup
-  name_info_dict = {
-      str(info["taxonomy"]["tax_id"]): info
-      for info in species_name_info
-  }
-  
-  # Create rows with both species_info and corresponding name_info
-  rows = []
-  for info in species_info:
-    tax_id = str(info["taxonomy"]["tax_id"])
-    name_info = name_info_dict.get(tax_id)
-    rows.append(get_species_row(info, taxonomic_group_sets, taxonomic_levels, name_info))
-  
-  return pd.DataFrame(rows)
+def get_species_df(
+    species_info, species_name_info, taxonomic_group_sets, taxonomic_levels
+):
+    """
+    Converts species information into a DataFrame.
+
+    Args:
+      species_info: List of species information dictionaries from NCBI
+      species_name_info: List of species name information dictionaries from NCBI
+      taxonomic_group_sets: Dictionary of taxonomic group sets
+      taxonomic_levels: List of taxonomic levels to include
+
+    Returns:
+      DataFrame containing species information
+    """
+    # Create a dictionary mapping tax_id to name_info for easy lookup
+    name_info_dict = {
+        str(info["taxonomy"]["tax_id"]): info for info in species_name_info
+    }
+
+    # Create rows with both species_info and corresponding name_info
+    rows = []
+    for info in species_info:
+        tax_id = str(info["taxonomy"]["tax_id"])
+        name_info = name_info_dict.get(tax_id)
+        rows.append(
+            get_species_row(info, taxonomic_group_sets, taxonomic_levels, name_info)
+        )
+
+    return pd.DataFrame(rows)
 
 
 def get_species_tree(taxonomy_ids, taxonomic_levels, species_info=None):
-  """
-  Builds a species tree from taxonomy IDs and taxonomic levels.
-  
-  Args:
-    taxonomy_ids: List of taxonomy IDs to include in the tree
-    taxonomic_levels: List of taxonomic levels to include in the tree
-    species_info: Optional pre-fetched species information to avoid additional API calls
-    
-  Returns:
-    A nested tree structure of species
-  """
-  species_tree_response = requests.post(
-    "https://api.ncbi.nlm.nih.gov/datasets/v2/taxonomy/filtered_subtree",
-    json={"taxons": [str(int(t)) for t in taxonomy_ids], "rank_limits": [t.upper() for t in taxonomic_levels]},
-  ).json()
+    """
+    Builds a species tree from taxonomy IDs and taxonomic levels.
 
-  # Build a tree from the response
-  edges = species_tree_response.get("edges", {})
-  all_children = {child for edge in edges.values() for child in edge.get("visible_children", [])}
-  all_children = [str(num) for num in all_children]
-  root_ids = [node_id for node_id in edges if node_id not in all_children]
-  root_ids = [str(num) for num in root_ids]
+    Args:
+      taxonomy_ids: List of taxonomy IDs to include in the tree
+      taxonomic_levels: List of taxonomic levels to include in the tree
+      species_info: Optional pre-fetched species information to avoid additional API calls
 
-  if not root_ids:
-      return {}
-  
-  # this bc the ncbi result is odd, multi-root
-  root_id = "1"
-  for root_id_candidate in root_ids:
-      if root_id_candidate != root_id:
-          edges[root_id]["visible_children"].append(root_id_candidate)
+    Returns:
+      A nested tree structure of species
+    """
+    species_tree_response = requests.post(
+        "https://api.ncbi.nlm.nih.gov/datasets/v2/taxonomy/filtered_subtree",
+        json={
+            "taxons": [str(int(t)) for t in taxonomy_ids],
+            "rank_limits": [t.upper() for t in taxonomic_levels],
+        },
+    ).json()
 
-  species_tree = ncbi_tree_to_nested_tree(root_id, edges, taxonomy_ids)
+    # Build a tree from the response
+    edges = species_tree_response.get("edges", {})
+    all_children = {
+        child for edge in edges.values() for child in edge.get("visible_children", [])
+    }
+    all_children = [str(num) for num in all_children]
+    root_ids = [node_id for node_id in edges if node_id not in all_children]
+    root_ids = [str(num) for num in root_ids]
 
-  # Find the set of all unique tax_ids and their display names
-  tax_ids = all_children + root_ids
-  tax_ids = set(tax_ids)
-  
-  # Initialize maps with root node
-  taxon_name_map = {"1": "root"}
-  taxon_rank_map = {"1": "NA"}
-  
-  # If we have pre-fetched species_info, use it to populate the name and rank maps
-  if species_info:
-    # Extract taxon names and ranks from species_info
-    for info in species_info:
-      tax_id = str(info["taxonomy"]["tax_id"])
-      if tax_id in tax_ids:
-        taxon_name_map[tax_id] = info["taxonomy"]["current_scientific_name"]["name"]
-        if "rank" in info["taxonomy"]:
-          taxon_rank_map[tax_id] = info["taxonomy"]["rank"]
-        else:
-          print(f"rank not found for tax_id: {tax_id}")
-      
-      # Also extract parent taxa information if available
-      if "classification" in info["taxonomy"]:
-        for rank_level, rank_info in info["taxonomy"]["classification"].items():
-          if isinstance(rank_info, dict) and "id" in rank_info and "name" in rank_info:
-            parent_name = rank_info["name"]
-            parent_id = rank_info["id"]
-            parent_id_str = str(parent_id)
-            if parent_id_str in tax_ids and parent_id_str not in taxon_name_map:
-              taxon_name_map[parent_id_str] = parent_name
-              taxon_rank_map[parent_id_str] = rank_level
-    
-  # Fetch any missing taxa information
-  fetch_taxa_info(tax_ids, taxon_name_map, taxon_rank_map, "missing parent taxa")
+    if not root_ids:
+        return {}
 
-  named_species_tree = update_species_tree_names(species_tree, taxon_name_map, taxon_rank_map)
+    # this bc the ncbi result is odd, multi-root
+    root_id = "1"
+    for root_id_candidate in root_ids:
+        if root_id_candidate != root_id:
+            edges[root_id]["visible_children"].append(root_id_candidate)
 
-  return named_species_tree
+    species_tree = ncbi_tree_to_nested_tree(root_id, edges, taxonomy_ids)
+
+    # Find the set of all unique tax_ids and their display names
+    tax_ids = all_children + root_ids
+    tax_ids = set(tax_ids)
+
+    # Initialize maps with root node
+    taxon_name_map = {"1": "root"}
+    taxon_rank_map = {"1": "NA"}
+
+    # If we have pre-fetched species_info, use it to populate the name and rank maps
+    if species_info:
+        # Extract taxon names and ranks from species_info
+        for info in species_info:
+            tax_id = str(info["taxonomy"]["tax_id"])
+            if tax_id in tax_ids:
+                taxon_name_map[tax_id] = info["taxonomy"]["current_scientific_name"][
+                    "name"
+                ]
+                if "rank" in info["taxonomy"]:
+                    taxon_rank_map[tax_id] = info["taxonomy"]["rank"]
+                else:
+                    print(f"rank not found for tax_id: {tax_id}")
+
+            # Also extract parent taxa information if available
+            if "classification" in info["taxonomy"]:
+                for rank_level, rank_info in info["taxonomy"]["classification"].items():
+                    if (
+                        isinstance(rank_info, dict)
+                        and "id" in rank_info
+                        and "name" in rank_info
+                    ):
+                        parent_name = rank_info["name"]
+                        parent_id = rank_info["id"]
+                        parent_id_str = str(parent_id)
+                        if (
+                            parent_id_str in tax_ids
+                            and parent_id_str not in taxon_name_map
+                        ):
+                            taxon_name_map[parent_id_str] = parent_name
+                            taxon_rank_map[parent_id_str] = rank_level
+
+    # Fetch any missing taxa information
+    fetch_taxa_info(tax_ids, taxon_name_map, taxon_rank_map, "missing parent taxa")
+
+    named_species_tree = update_species_tree_names(
+        species_tree, taxon_name_map, taxon_rank_map
+    )
+
+    return named_species_tree
 
 
 def fetch_taxa_info(tax_ids, taxon_name_map, taxon_rank_map, description="taxa"):
-  """
-  Fetches taxonomic information and updates the provided name and rank maps.
-  
-  Args:
-    tax_ids: List or set of taxonomy IDs to fetch
-    taxon_name_map: Dictionary to update with taxon ID to name mappings
-    taxon_rank_map: Dictionary to update with taxon ID to rank mappings
-    description: Description of the taxa being fetched for logging
-    
-  Returns:
-    None (updates the provided maps in-place)
-  """
-  # Filter out tax_ids that are already in the map
-  missing_tax_ids = [tid for tid in tax_ids if tid not in taxon_name_map and tid != "1"]
-  
-  if not missing_tax_ids:
-    return
-    
-  print(f"Fetching information for {len(missing_tax_ids)} {description}")
-  
-  url = "https://api.ncbi.nlm.nih.gov/datasets/v2/taxonomy/dataset_report"
-  reports = post_ncbi_request(url, {"taxons": missing_tax_ids})
-  
-  for report in reports:
-    tax_id = str(report["taxonomy"]["tax_id"])
-    taxon_name_map[tax_id] = report["taxonomy"]["current_scientific_name"]["name"]
-    if "rank" in report["taxonomy"]:
-      taxon_rank_map[tax_id] = report["taxonomy"]["rank"]
-    else:
-      print(f"rank not found for tax_id: {tax_id}")
+    """
+    Fetches taxonomic information and updates the provided name and rank maps.
+
+    Args:
+      tax_ids: List or set of taxonomy IDs to fetch
+      taxon_name_map: Dictionary to update with taxon ID to name mappings
+      taxon_rank_map: Dictionary to update with taxon ID to rank mappings
+      description: Description of the taxa being fetched for logging
+
+    Returns:
+      None (updates the provided maps in-place)
+    """
+    # Filter out tax_ids that are already in the map
+    missing_tax_ids = [
+        tid for tid in tax_ids if tid not in taxon_name_map and tid != "1"
+    ]
+
+    if not missing_tax_ids:
+        return
+
+    print(f"Fetching information for {len(missing_tax_ids)} {description}")
+
+    url = "https://api.ncbi.nlm.nih.gov/datasets/v2/taxonomy/dataset_report"
+    reports = post_ncbi_request(url, {"taxons": missing_tax_ids})
+
+    for report in reports:
+        tax_id = str(report["taxonomy"]["tax_id"])
+        taxon_name_map[tax_id] = report["taxonomy"]["current_scientific_name"]["name"]
+        if "rank" in report["taxonomy"]:
+            taxon_rank_map[tax_id] = report["taxonomy"]["rank"]
+        else:
+            print(f"rank not found for tax_id: {tax_id}")
 
 
 def ncbi_tree_to_nested_tree(node_id, edges, taxonomy_ids):
-  children = edges.get(str(node_id), {}).get("visible_children", [])
-  children = [str(num) for num in children]
-  # ncbi results odd again, dup children
-  children = set(children)
-  if (len(children) > 0 or int(node_id) in taxonomy_ids):
-    child_trees = [ncbi_tree_to_nested_tree(child, edges, taxonomy_ids) for child in children]
-    child_trees = [item for item in child_trees if item is not None]
-    return {
-      "name": node_id,
-      "ncbi_tax_id": node_id,
-      "children": child_trees
-    }
+    children = edges.get(str(node_id), {}).get("visible_children", [])
+    children = [str(num) for num in children]
+    # ncbi results odd again, dup children
+    children = set(children)
+    if len(children) > 0 or int(node_id) in taxonomy_ids:
+        child_trees = [
+            ncbi_tree_to_nested_tree(child, edges, taxonomy_ids) for child in children
+        ]
+        child_trees = [item for item in child_trees if item is not None]
+        return {"name": node_id, "ncbi_tax_id": node_id, "children": child_trees}
+
 
 def update_species_tree_names(tree, taxon_name_map, taxon_rank_map):
     tree["rank"] = taxon_rank_map.get(tree["name"], "Unknown")
@@ -328,297 +376,415 @@ def update_species_tree_names(tree, taxon_name_map, taxon_rank_map):
         update_species_tree_names(child, taxon_name_map, taxon_rank_map)
     return tree
 
+
 def get_genome_row(genome_info):
-  refseq_category = genome_info["assembly_info"].get("refseq_category")
-  return {
-    "strain": genome_info["organism"].get("infraspecific_names", {}).get("strain", ""),
-    "taxonomyId": genome_info["organism"]["tax_id"],
-    "accession": genome_info["accession"],
-    "isRef": refseq_category == "reference genome",
-    "level": genome_info["assembly_info"]["assembly_level"],
-    "chromosomeCount": genome_info["assembly_stats"].get("total_number_of_chromosomes"),
-    "length": genome_info["assembly_stats"]["total_sequence_length"],
-    "scaffoldCount": genome_info["assembly_stats"].get("number_of_scaffolds"),
-    "scaffoldN50": genome_info["assembly_stats"].get("scaffold_n50"),
-    "scaffoldL50": genome_info["assembly_stats"].get("scaffold_l50"),
-    "coverage": genome_info["assembly_stats"].get("genome_coverage"),
-    "gcPercent": genome_info["assembly_stats"].get("gc_percent"),
-    "annotationStatus": genome_info.get("annotation_info", {}).get("status"),
-    "pairedAccession": genome_info.get("paired_accession"),
-  }
+    refseq_category = genome_info["assembly_info"].get("refseq_category")
+    return {
+        "strain": genome_info["organism"]
+        .get("infraspecific_names", {})
+        .get("strain", ""),
+        "taxonomyId": genome_info["organism"]["tax_id"],
+        "accession": genome_info["accession"],
+        "isRef": refseq_category == "reference genome",
+        "level": genome_info["assembly_info"]["assembly_level"],
+        "chromosomeCount": genome_info["assembly_stats"].get(
+            "total_number_of_chromosomes"
+        ),
+        "length": genome_info["assembly_stats"]["total_sequence_length"],
+        "scaffoldCount": genome_info["assembly_stats"].get("number_of_scaffolds"),
+        "scaffoldN50": genome_info["assembly_stats"].get("scaffold_n50"),
+        "scaffoldL50": genome_info["assembly_stats"].get("scaffold_l50"),
+        "coverage": genome_info["assembly_stats"].get("genome_coverage"),
+        "gcPercent": genome_info["assembly_stats"].get("gc_percent"),
+        "annotationStatus": genome_info.get("annotation_info", {}).get("status"),
+        "pairedAccession": genome_info.get("paired_accession"),
+    }
 
 
 def get_biosample_data(genome_info):
-  return {
-    "accession": genome_info["accession"],
-    "biosample": genome_info["assembly_info"]["biosample"]["accession"],
-    'sample_ids': ",".join([f"{sample['db']}:{sample['value']}" for sample in genome_info["assembly_info"]["biosample"].get('sample_ids', '') if 'db' in sample]),
-  }
+    return {
+        "accession": genome_info["accession"],
+        "biosample": genome_info["assembly_info"]["biosample"]["accession"],
+        "sample_ids": ",".join(
+            [
+                f"{sample['db']}:{sample['value']}"
+                for sample in genome_info["assembly_info"]["biosample"].get(
+                    "sample_ids", ""
+                )
+                if "db" in sample
+            ]
+        ),
+    }
 
 
 def get_genomes_and_primarydata_df(accessions):
-  """
-  Fetches genome information and creates DataFrames for genomes and biosample data.
-  
-  Args:
-    accessions: List of genome accessions to fetch information for
-    
-  Returns:
-    Tuple of (genomes_df, biosample_df)
-  """
-  # Convert pandas Series to list if necessary
-  if isinstance(accessions, pd.Series):
-    accessions = accessions.tolist()
-  
-  url = "https://api.ncbi.nlm.nih.gov/datasets/v2/genome/dataset_report"
-  reports = post_ncbi_request(url, {"accessions": accessions})
-  
-  return (
-    pd.DataFrame(data=[get_genome_row(info) for info in reports]),
-    pd.DataFrame(data=[get_biosample_data(info) for info in reports if 'biosample' in info['assembly_info']])
-  )
+    """
+    Fetches genome information and creates DataFrames for genomes and biosample data.
+
+    Args:
+      accessions: List of genome accessions to fetch information for
+
+    Returns:
+      Tuple of (genomes_df, biosample_df)
+    """
+    # Convert pandas Series to list if necessary
+    if isinstance(accessions, pd.Series):
+        accessions = accessions.tolist()
+
+    url = "https://api.ncbi.nlm.nih.gov/datasets/v2/genome/dataset_report"
+    reports = post_ncbi_request(url, {"accessions": accessions})
+
+    return (
+        pd.DataFrame(data=[get_genome_row(info) for info in reports]),
+        pd.DataFrame(
+            data=[
+                get_biosample_data(info)
+                for info in reports
+                if "biosample" in info["assembly_info"]
+            ]
+        ),
+    )
 
 
 def _id_to_gene_model_url(asm_id: str, session: requests.Session):
-  print(f"finding gene model url for: {asm_id}")
-  ucsc_files_endpoint = "https://genome.ucsc.edu/list/files"
-  download_base_url = "https://hgdownload.soe.ucsc.edu"
-  #wait 1s because of rate limiting
-  time.sleep(1)
-  response = session.get(ucsc_files_endpoint, params={"genome": asm_id})
-  try:
-    response.raise_for_status()
-  except Exception:
-    # FIXME?: Some accessions don't have a gene folder
+    print(f"finding gene model url for: {asm_id}")
+    ucsc_files_endpoint = "https://genome.ucsc.edu/list/files"
+    download_base_url = "https://hgdownload.soe.ucsc.edu"
+    # wait 1s because of rate limiting
+    time.sleep(1)
+    response = session.get(ucsc_files_endpoint, params={"genome": asm_id})
+    try:
+        response.raise_for_status()
+    except Exception:
+        # FIXME?: Some accessions don't have a gene folder
+        return None
+    # find link to gtf, should ideally be ncbiRefSeq, but augustus will do
+    files = response.json()
+    gtf_urls = [
+        entry["url"] for entry in files["urlList"] if entry["url"].endswith(".gtf.gz")
+    ]
+    augustus_url = None
+    for url in gtf_urls:
+        if "ncbiRefSeq" in url:
+            return urllib.parse.urljoin(f"{download_base_url}/", url)
+        elif "ncbiGene" in url:
+            return urllib.parse.urljoin(f"{download_base_url}/", url)
+        elif "augustus" in url:
+            augustus_url = url
+    if augustus_url:
+        return urllib.parse.urljoin(f"{download_base_url}/", augustus_url)
+    # No match, I guess that's OK ?
     return None
-  # find link to gtf, should ideally be ncbiRefSeq, but augustus will do
-  files = response.json()
-  gtf_urls = [entry["url"] for entry in files["urlList"] if entry["url"].endswith(".gtf.gz")]
-  augustus_url = None
-  for url in gtf_urls:
-    if "ncbiRefSeq" in url:
-      return urllib.parse.urljoin(f"{download_base_url}/", url)
-    elif "ncbiGene" in url:
-      return urllib.parse.urljoin(f"{download_base_url}/", url)
-    elif "augustus" in url:
-      augustus_url = url
-  if augustus_url:
-    return urllib.parse.urljoin(f"{download_base_url}/", augustus_url)
-  # No match, I guess that's OK ?
-  return None
 
 
 def add_gene_model_url(genomes_df: pd.DataFrame):
-  print("Fetching gene model URLs")
-  session = requests.Session()
-  return pd.concat([genomes_df, genomes_df["accession"].apply(partial(_id_to_gene_model_url, session=session)).rename("geneModelUrl")], axis="columns")
+    print("Fetching gene model URLs")
+    session = requests.Session()
+    return pd.concat(
+        [
+            genomes_df,
+            genomes_df["accession"]
+            .apply(partial(_id_to_gene_model_url, session=session))
+            .rename("geneModelUrl"),
+        ],
+        axis="columns",
+    )
 
 
-def report_missing_values_from(values_name, message_predicate, all_values_series, *partial_values_series):
-  present_values_mask = all_values_series.astype(bool)
-  present_values_mask[:] = False
-  for series in partial_values_series:
-    present_values_mask |= all_values_series.isin(series)
-  return report_missing_values(values_name, message_predicate, all_values_series, present_values_mask)
+def report_missing_values_from(
+    values_name, message_predicate, all_values_series, *partial_values_series
+):
+    present_values_mask = all_values_series.astype(bool)
+    present_values_mask[:] = False
+    for series in partial_values_series:
+        present_values_mask |= all_values_series.isin(series)
+    return report_missing_values(
+        values_name, message_predicate, all_values_series, present_values_mask
+    )
 
 
-def report_missing_values(values_name, message_predicate, values_series, present_values_mask):
-  missing_values = values_series[~present_values_mask]
-  if len(missing_values) > 0:
-    if len(missing_values) > len(values_series)/2:
-      present_values = values_series[present_values_mask]
-      print(f"Only {len(present_values)} of {len(values_series)} {values_name} {message_predicate}: {", ".join(present_values)}")
-    else:
-      print(f"{len(missing_values)} {values_name} not {message_predicate}: {", ".join(missing_values)}")
-  return missing_values
+def report_missing_values(
+    values_name, message_predicate, values_series, present_values_mask
+):
+    missing_values = values_series[~present_values_mask]
+    if len(missing_values) > 0:
+        if len(missing_values) > len(values_series) / 2:
+            present_values = values_series[present_values_mask]
+            print(
+                f"Only {len(present_values)} of {len(values_series)} {values_name} {message_predicate}: {', '.join(present_values)}"
+            )
+        else:
+            print(
+                f"{len(missing_values)} {values_name} not {message_predicate}: {', '.join(missing_values)}"
+            )
+    return missing_values
 
 
 def report_inconsistent_taxonomy_ids(df):
-  inconsistent_ids_series = df.groupby(["species", "strain"]).filter(lambda g: g["taxonomyId"].nunique() > 1).groupby(["species", "strain"])["taxonomyId"].apply(set)
-  inconsistent_ids_strings = [(f"{species} strain {strain}" if strain else species, ", ".join([str(id) for id in ids])) for (species, strain), ids in inconsistent_ids_series.items()]
-  if len(inconsistent_ids_strings) > 0:
-    inconsistent_taxonmy_ids_combined = ", ".join([f"{taxon} ({ids})" for taxon, ids in inconsistent_ids_strings])
-    print(f"Taxa with inconsistent taxonomy IDs: {inconsistent_taxonmy_ids_combined}")
-  return inconsistent_ids_strings
+    inconsistent_ids_series = (
+        df.groupby(["species", "strain"])
+        .filter(lambda g: g["taxonomyId"].nunique() > 1)
+        .groupby(["species", "strain"])["taxonomyId"]
+        .apply(set)
+    )
+    inconsistent_ids_strings = [
+        (
+            f"{species} strain {strain}" if strain else species,
+            ", ".join([str(id) for id in ids]),
+        )
+        for (species, strain), ids in inconsistent_ids_series.items()
+    ]
+    if len(inconsistent_ids_strings) > 0:
+        inconsistent_taxonmy_ids_combined = ", ".join(
+            [f"{taxon} ({ids})" for taxon, ids in inconsistent_ids_strings]
+        )
+        print(
+            f"Taxa with inconsistent taxonomy IDs: {inconsistent_taxonmy_ids_combined}"
+        )
+    return inconsistent_ids_strings
 
 
 def fetch_sra_metadata(srs_ids, batch_size=20):
-  """
-  Fetches metadata for a list of SRS IDs from the SRA database.
-
-  This function retrieves metadata for a given list of SRS (SRA Sample) IDs by querying the NCBI and EBI databases.
-  It fetches the metadata in batches and handles retries and waiting mechanisms for failed requests. The metadata includes
-  information about the experiment, platform, instrument, library, and associated files.
-
-  Args:
-    srs_ids (list): A list of SRS IDs to fetch metadata for.
-    batch_size (int, optional): The number of SRS IDs to process in each batch. Defaults to 20.
-
-  Returns:
-    dict: A dictionary containing the fetched metadata, organized by sample accession and run accession.
-
-  Raises:
-    Exception: If the data could not be fetched after the specified number of retries or if duplicate entries are found.
-  """
-  def fetch_url_data(url, counter=0, counter_limit=2, wait_time=2, num_retry=3):
     """
-    Fetches data from a given URL with retry and wait mechanisms.
+    Fetches metadata for a list of SRS IDs from the SRA database.
+
+    This function retrieves metadata for a given list of SRS (SRA Sample) IDs by querying the NCBI and EBI databases.
+    It fetches the metadata in batches and handles retries and waiting mechanisms for failed requests. The metadata includes
+    information about the experiment, platform, instrument, library, and associated files.
+
     Args:
-      url (str): The URL to fetch data from.
-      counter (int, optional): The current retry counter. Defaults to 0.
-      counter_limit (int, optional): The maximum number of retries before waiting. Defaults to 3.
-      wait_time (int, optional): The time to wait before retrying in seconds. Defaults to 5.
-      num_retry (int, optional): The number of retry attempts. Defaults to 3.
+      srs_ids (list): A list of SRS IDs to fetch metadata for.
+      batch_size (int, optional): The number of SRS IDs to process in each batch. Defaults to 20.
+
     Returns:
-      tuple: A tuple containing the JSON response and the updated counter.
+      dict: A dictionary containing the fetched metadata, organized by sample accession and run accession.
+
     Raises:
-      Exception: If the data could not be fetched after the specified number of retries.
+      Exception: If the data could not be fetched after the specified number of retries or if duplicate entries are found.
     """
-    if counter > counter_limit:
-      time.sleep(wait_time)
-      counter = 0
 
-    response = requests.get(url)
-    while num_retry > 0 and response.status_code != 200:
-      time.sleep(wait_time)
-      log.debug(f"Failed to fetch, status: {response.status_code}, url: {url}. Retrying...")
-      response = requests.get(url)
-      num_retry -= 1
+    def fetch_url_data(url, counter=0, counter_limit=2, wait_time=2, num_retry=3):
+        """
+        Fetches data from a given URL with retry and wait mechanisms.
+        Args:
+          url (str): The URL to fetch data from.
+          counter (int, optional): The current retry counter. Defaults to 0.
+          counter_limit (int, optional): The maximum number of retries before waiting. Defaults to 3.
+          wait_time (int, optional): The time to wait before retrying in seconds. Defaults to 5.
+          num_retry (int, optional): The number of retry attempts. Defaults to 3.
+        Returns:
+          tuple: A tuple containing the JSON response and the updated counter.
+        Raises:
+          Exception: If the data could not be fetched after the specified number of retries.
+        """
+        if counter > counter_limit:
+            time.sleep(wait_time)
+            counter = 0
 
-    if num_retry <= 0:
-      raise Exception(f"Failed to fetch, status: {response.status_code}, url: {url} ")
-    log.debug(f"Fetching data from {url}")
-    return response, counter + 1
+        response = requests.get(url)
+        while num_retry > 0 and response.status_code != 200:
+            time.sleep(wait_time)
+            log.debug(
+                f"Failed to fetch, status: {response.status_code}, url: {url}. Retrying..."
+            )
+            response = requests.get(url)
+            num_retry -= 1
 
-  if srs_ids is None:
-    return None
+        if num_retry <= 0:
+            raise Exception(
+                f"Failed to fetch, status: {response.status_code}, url: {url} "
+            )
+        log.debug(f"Fetching data from {url}")
+        return response, counter + 1
 
-  data = {}
-  counter = 0
-  samples_processed = 0
-  for i in range(0, len(srs_ids), batch_size):
-    print(f"Processing metadata for samples: {samples_processed} of {len(srs_ids)}", end='\r')
-    batch_srs_id = srs_ids[i:i + batch_size]
-    samples_processed += len(batch_srs_id)
-    search_data, counter = fetch_url_data(f"https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=sra&term={"+OR+".join(batch_srs_id)}&retmode=json&retmax=1000", counter)
-    search_data = search_data.json()
+    if srs_ids is None:
+        return None
 
-    if int(search_data.get("esearchresult", {}).get("count", 0)) == 0:
-      log.debug(f"No SRR IDs found for SRS {batch_srs_id}")
-      return None
+    data = {}
+    counter = 0
+    samples_processed = 0
+    for i in range(0, len(srs_ids), batch_size):
+        print(
+            f"Processing metadata for samples: {samples_processed} of {len(srs_ids)}",
+            end="\r",
+        )
+        batch_srs_id = srs_ids[i : i + batch_size]
+        samples_processed += len(batch_srs_id)
+        search_data, counter = fetch_url_data(
+            f"https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=sra&term={'+OR+'.join(batch_srs_id)}&retmode=json&retmax=1000",
+            counter,
+        )
+        search_data = search_data.json()
 
-    # Extract SRR IDs
-    srr_ids = search_data.get("esearchresult", {}).get("idlist", [])
-    if srr_ids:
-      for i in range(0, len(srr_ids), batch_size):
-        batch_srr_id = srr_ids[i:i + batch_size]
-        summary_data, counter = fetch_url_data(f"https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=sra&id={','.join(batch_srr_id)}&retmode=json&retmax=1000", counter)
-        summary_data = summary_data.json()
-        if 'result' in summary_data:
-          for result in summary_data['result']['uids']:
-              exp_soup = BeautifulSoup(f"<Root>{summary_data['result'][result]['expxml']}</Root>", 'xml')
-              run_soup = BeautifulSoup(f"<Root>{summary_data['result'][result]['runs']}</Root>", 'xml')
+        if int(search_data.get("esearchresult", {}).get("count", 0)) == 0:
+            log.debug(f"No SRR IDs found for SRS {batch_srs_id}")
+            return None
 
-              library_layout = exp_soup.find("LIBRARY_LAYOUT").find().name
-              title = exp_soup.find("Title").text
-              platform = exp_soup.find("Platform").text
-              instrument = exp_soup.find("Platform")["instrument_model"]
-              organism_name = exp_soup.find("Organism").get("ScientificName", "")
-              total_spots = exp_soup.find("Statistics")["total_spots"]
-              total_bases = exp_soup.find("Statistics")["total_bases"]
+        # Extract SRR IDs
+        srr_ids = search_data.get("esearchresult", {}).get("idlist", [])
+        if srr_ids:
+            for i in range(0, len(srr_ids), batch_size):
+                batch_srr_id = srr_ids[i : i + batch_size]
+                summary_data, counter = fetch_url_data(
+                    f"https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=sra&id={','.join(batch_srr_id)}&retmode=json&retmax=1000",
+                    counter,
+                )
+                summary_data = summary_data.json()
+                if "result" in summary_data:
+                    for result in summary_data["result"]["uids"]:
+                        exp_soup = BeautifulSoup(
+                            f"<Root>{summary_data['result'][result]['expxml']}</Root>",
+                            "xml",
+                        )
+                        run_soup = BeautifulSoup(
+                            f"<Root>{summary_data['result'][result]['runs']}</Root>",
+                            "xml",
+                        )
 
-              sra_experiment_acc = exp_soup.find("Experiment")["acc"]
-              sra_sample_acc = exp_soup.find("Sample")["acc"]
-              sra_study_acc = exp_soup.find("Study")["acc"]
-              sra_submitter_acc = exp_soup.find("Submitter")["acc"]
+                        library_layout = exp_soup.find("LIBRARY_LAYOUT").find().name
+                        title = exp_soup.find("Title").text
+                        platform = exp_soup.find("Platform").text
+                        instrument = exp_soup.find("Platform")["instrument_model"]
+                        organism_name = exp_soup.find("Organism").get(
+                            "ScientificName", ""
+                        )
+                        total_spots = exp_soup.find("Statistics")["total_spots"]
+                        total_bases = exp_soup.find("Statistics")["total_bases"]
 
-              library_name = exp_soup.find("LIBRARY_NAME").text if exp_soup.find("LIBRARY_NAME") else ""
-              library_strategy = exp_soup.find("LIBRARY_STRATEGY").text if exp_soup.find("LIBRARY_STRATEGY") else ""
-              library_source = exp_soup.find("LIBRARY_SOURCE").text if exp_soup.find("LIBRARY_SOURCE") else ""
-              library_selection = exp_soup.find("LIBRARY_SELECTION").text if exp_soup.find("LIBRARY_SELECTION") else ""
-              bioproject_elem = exp_soup.find("Bioproject")
-              bioproject = bioproject_elem.text if bioproject_elem else ""
-              
-              for run in run_soup.find_all("Run"):
-                sra_run_acc = run["acc"]
-                run_total_bases = run["total_bases"]
-                run_total_spots = run["total_spots"]
+                        sra_experiment_acc = exp_soup.find("Experiment")["acc"]
+                        sra_sample_acc = exp_soup.find("Sample")["acc"]
+                        sra_study_acc = exp_soup.find("Study")["acc"]
+                        sra_submitter_acc = exp_soup.find("Submitter")["acc"]
 
-                d = {
-                  "title": title,
-                  "platform": platform,
-                  "instrument": instrument,
-                  "total_spots": total_spots,
-                  "total_bases": total_bases,
-                  "bioproject": bioproject,
-                  "organism_name": organism_name,
-                  "library_name": library_name,
-                  'library_layout': library_layout,
-                  "library_strategy": library_strategy,
-                  "library_source": library_source,
-                  "library_selection": library_selection,
-                  "sra_experiment_acc": sra_experiment_acc,
-                  "sra_run_acc": sra_run_acc,
-                  'sra_sample_acc': sra_sample_acc,
-                  "sra_study_acc": sra_study_acc,
-                  "sra_submitter_acc": sra_submitter_acc,
-                  "run_total_bases": run_total_bases,
-                  "run_total_spots": run_total_spots,
-                }
+                        library_name = (
+                            exp_soup.find("LIBRARY_NAME").text
+                            if exp_soup.find("LIBRARY_NAME")
+                            else ""
+                        )
+                        library_strategy = (
+                            exp_soup.find("LIBRARY_STRATEGY").text
+                            if exp_soup.find("LIBRARY_STRATEGY")
+                            else ""
+                        )
+                        library_source = (
+                            exp_soup.find("LIBRARY_SOURCE").text
+                            if exp_soup.find("LIBRARY_SOURCE")
+                            else ""
+                        )
+                        library_selection = (
+                            exp_soup.find("LIBRARY_SELECTION").text
+                            if exp_soup.find("LIBRARY_SELECTION")
+                            else ""
+                        )
+                        bioproject_elem = exp_soup.find("Bioproject")
+                        bioproject = bioproject_elem.text if bioproject_elem else ""
 
-                if sra_sample_acc in data:
-                    if sra_run_acc in data[sra_sample_acc]:
-                        raise Exception(f"Duplicate biosample run_acc {sra_run_acc} found {sra_sample_acc}")
-                    else:
-                        data[sra_sample_acc][sra_run_acc] = d
-                else:
-                    data[sra_sample_acc] = {sra_run_acc: d}
-  print(f"Processing metadata for samples: {samples_processed} of {len(srs_ids)}", end='\n')
-  samples_processed = 0
-  for sample_acc in data:
-    print(f"Adding file urls to : {samples_processed} of {len(data)}", end='\r')
-    samples_processed += 1
-    # Fetch url, file size and md5 for raw/primary data files
-    file_list_data, counter = fetch_url_data(f"https://www.ebi.ac.uk/ena/portal/api/filereport?accession={sample_acc}&result=read_run&format=json&retmax=1000", counter)
-    file_list_data = file_list_data.json()
-    for result in file_list_data:
-      if result['run_accession'] not in data[sample_acc]:
-        raise Exception(f"Not metadata found for {result['run_accession']} {sample_acc}")
-      if 'fastq_ftp' in data[sample_acc][result['run_accession']]:
-        raise Exception(f"Duplicate file list entry for {result['run_accession']}  {sample_acc}")
+                        for run in run_soup.find_all("Run"):
+                            sra_run_acc = run["acc"]
+                            run_total_bases = run["total_bases"]
+                            run_total_spots = run["total_spots"]
 
-      data[sample_acc][result['run_accession']]['file_urls'] = result['fastq_ftp']
-      data[sample_acc][result['run_accession']]['file_size'] = result['fastq_bytes']
-      data[sample_acc][result['run_accession']]['file_md5'] = result['fastq_md5']
+                            d = {
+                                "title": title,
+                                "platform": platform,
+                                "instrument": instrument,
+                                "total_spots": total_spots,
+                                "total_bases": total_bases,
+                                "bioproject": bioproject,
+                                "organism_name": organism_name,
+                                "library_name": library_name,
+                                "library_layout": library_layout,
+                                "library_strategy": library_strategy,
+                                "library_source": library_source,
+                                "library_selection": library_selection,
+                                "sra_experiment_acc": sra_experiment_acc,
+                                "sra_run_acc": sra_run_acc,
+                                "sra_sample_acc": sra_sample_acc,
+                                "sra_study_acc": sra_study_acc,
+                                "sra_submitter_acc": sra_submitter_acc,
+                                "run_total_bases": run_total_bases,
+                                "run_total_spots": run_total_spots,
+                            }
 
-      data[sample_acc][result['run_accession']]['file_urls'] = result['fastq_ftp']
-      data[sample_acc][result['run_accession']]['file_size'] = result['fastq_bytes']
-      data[sample_acc][result['run_accession']]['file_md5'] = result['fastq_md5']
+                            if sra_sample_acc in data:
+                                if sra_run_acc in data[sra_sample_acc]:
+                                    raise Exception(
+                                        f"Duplicate biosample run_acc {sra_run_acc} found {sra_sample_acc}"
+                                    )
+                                else:
+                                    data[sra_sample_acc][sra_run_acc] = d
+                            else:
+                                data[sra_sample_acc] = {sra_run_acc: d}
+    print(
+        f"Processing metadata for samples: {samples_processed} of {len(srs_ids)}",
+        end="\n",
+    )
+    samples_processed = 0
+    for sample_acc in data:
+        print(f"Adding file urls to : {samples_processed} of {len(data)}", end="\r")
+        samples_processed += 1
+        # Fetch url, file size and md5 for raw/primary data files
+        file_list_data, counter = fetch_url_data(
+            f"https://www.ebi.ac.uk/ena/portal/api/filereport?accession={sample_acc}&result=read_run&format=json&retmax=1000",
+            counter,
+        )
+        file_list_data = file_list_data.json()
+        for result in file_list_data:
+            if result["run_accession"] not in data[sample_acc]:
+                raise Exception(
+                    f"Not metadata found for {result['run_accession']} {sample_acc}"
+                )
+            if "fastq_ftp" in data[sample_acc][result["run_accession"]]:
+                raise Exception(
+                    f"Duplicate file list entry for {result['run_accession']}  {sample_acc}"
+                )
 
-      if not len(data[sample_acc][result['run_accession']]['file_urls']):
-        # Some raw or primary data has been uploaded but not properly processed by SRA.
-        # These files will lack https/ftp URLs and statistics, looks like these are
-        # BAM files that are labeled as FASTQ.
-        # For these, we can retrieve S3 links instead.
-        file_list_data, counter = fetch_url_data(f"https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=sra&id=SRR25741043&retmode=xml", counter)
-        srafile_soup = BeautifulSoup(file_list_data.text, 'xml')
-        for file in srafile_soup.findAll("SRAFile"):
-          if file['supertype'] == "Original":
-            alternatives = file.find('Alternatives')
-            data[sample_acc][result['run_accession']]['file_urls'] = alternatives['url']
-            data[sample_acc][result['run_accession']]['file_size'] = file['size']
-            data[sample_acc][result['run_accession']]['file_md5'] = file['md5']
-  print(f"Adding file urls to : {samples_processed} of {len(data)}", end='\n')
-  return data
+            data[sample_acc][result["run_accession"]]["file_urls"] = result["fastq_ftp"]
+            data[sample_acc][result["run_accession"]]["file_size"] = result[
+                "fastq_bytes"
+            ]
+            data[sample_acc][result["run_accession"]]["file_md5"] = result["fastq_md5"]
+
+            data[sample_acc][result["run_accession"]]["file_urls"] = result["fastq_ftp"]
+            data[sample_acc][result["run_accession"]]["file_size"] = result[
+                "fastq_bytes"
+            ]
+            data[sample_acc][result["run_accession"]]["file_md5"] = result["fastq_md5"]
+
+            if not len(data[sample_acc][result["run_accession"]]["file_urls"]):
+                # Some raw or primary data has been uploaded but not properly processed by SRA.
+                # These files will lack https/ftp URLs and statistics, looks like these are
+                # BAM files that are labeled as FASTQ.
+                # For these, we can retrieve S3 links instead.
+                file_list_data, counter = fetch_url_data(
+                    f"https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=sra&id=SRR25741043&retmode=xml",
+                    counter,
+                )
+                srafile_soup = BeautifulSoup(file_list_data.text, "xml")
+                for file in srafile_soup.findAll("SRAFile"):
+                    if file["supertype"] == "Original":
+                        alternatives = file.find("Alternatives")
+                        data[sample_acc][result["run_accession"]]["file_urls"] = (
+                            alternatives["url"]
+                        )
+                        data[sample_acc][result["run_accession"]]["file_size"] = file[
+                            "size"
+                        ]
+                        data[sample_acc][result["run_accession"]]["file_md5"] = file[
+                            "md5"
+                        ]
+    print(f"Adding file urls to : {samples_processed} of {len(data)}", end="\n")
+    return data
+
 
 def report_missing_ploidy_info(genomes_df, organisms_df):
     """
     Reports assemblies that are missing ploidy information.
-    
+
     Args:
         genomes_df: DataFrame containing genome information
         organisms_df: DataFrame containing organism information, including ploidy information
-        
+
     Returns:
         A list of tuples containing (accession, speciesTaxonomyId) for assemblies without ploidy information
     """
@@ -629,7 +795,9 @@ def report_missing_ploidy_info(genomes_df, organisms_df):
     check_df = genomes_df[["accession", "speciesTaxonomyId", "species"]].copy()
 
     # Check which species tax IDs we have ploidy information for
-    check_df["has_ploidy"] = check_df["speciesTaxonomyId"].apply(lambda tax_id: tax_id in ploidy_map)
+    check_df["has_ploidy"] = check_df["speciesTaxonomyId"].apply(
+        lambda tax_id: tax_id in ploidy_map
+    )
 
     # Find assemblies where we have no ploidy information
     missing_ploidy = check_df[~check_df["has_ploidy"]]
@@ -641,101 +809,193 @@ def report_missing_ploidy_info(genomes_df, organisms_df):
         for _, row in missing_ploidy.iterrows():
             print(f"  {row['accession']}: {row['speciesTaxonomyId']}")
 
-    return list(zip(missing_ploidy['accession'], missing_ploidy['speciesTaxonomyId']))
+    return list(zip(missing_ploidy["accession"], missing_ploidy["speciesTaxonomyId"]))
 
 
-def make_qc_report(missing_ncbi_assemblies, inconsistent_taxonomy_ids, missing_ucsc_assemblies, missing_gene_model_urls=None, missing_ploidy_assemblies=None):
-    ncbi_assemblies_text = "None" if len(missing_ncbi_assemblies) == 0 else "\n".join([f"- {accession}" for accession in missing_ncbi_assemblies])
-    ucsc_assemblies_text = "None" if len(missing_ucsc_assemblies) == 0 else "\n".join([f"- {accession}" for accession in missing_ucsc_assemblies])
-    gene_model_urls_text = "N/A" if missing_gene_model_urls is None else "None" if len(missing_gene_model_urls) == 0 else "\n".join([f"- {accession}" for accession in missing_gene_model_urls])
-    taxonomy_ids_text = "None" if len(inconsistent_taxonomy_ids) == 0 else "\n".join([f"- {taxon}: {ids}" for taxon, ids in inconsistent_taxonomy_ids])
-    ploidy_assemblies_text = "None" if missing_ploidy_assemblies is None else "None" if len(missing_ploidy_assemblies) == 0 else "\n".join([f"- {accession} (speciesTaxonomyId: {tax_id})" for accession, tax_id in missing_ploidy_assemblies])
+def make_qc_report(
+    missing_ncbi_assemblies,
+    inconsistent_taxonomy_ids,
+    missing_ucsc_assemblies,
+    missing_gene_model_urls=None,
+    missing_ploidy_assemblies=None,
+):
+    ncbi_assemblies_text = (
+        "None"
+        if len(missing_ncbi_assemblies) == 0
+        else "\n".join([f"- {accession}" for accession in missing_ncbi_assemblies])
+    )
+    ucsc_assemblies_text = (
+        "None"
+        if len(missing_ucsc_assemblies) == 0
+        else "\n".join([f"- {accession}" for accession in missing_ucsc_assemblies])
+    )
+    gene_model_urls_text = (
+        "N/A"
+        if missing_gene_model_urls is None
+        else "None"
+        if len(missing_gene_model_urls) == 0
+        else "\n".join([f"- {accession}" for accession in missing_gene_model_urls])
+    )
+    taxonomy_ids_text = (
+        "None"
+        if len(inconsistent_taxonomy_ids) == 0
+        else "\n".join(
+            [f"- {taxon}: {ids}" for taxon, ids in inconsistent_taxonomy_ids]
+        )
+    )
+    ploidy_assemblies_text = (
+        "None"
+        if missing_ploidy_assemblies is None
+        else "None"
+        if len(missing_ploidy_assemblies) == 0
+        else "\n".join(
+            [
+                f"- {accession} (speciesTaxonomyId: {tax_id})"
+                for accession, tax_id in missing_ploidy_assemblies
+            ]
+        )
+    )
     return f"# Catalog QC report\n\n## Assemblies not found on NCBI\n\n{ncbi_assemblies_text}\n\n## Assemblies not found in UCSC list\n\n{ucsc_assemblies_text}\n\n## Assemblies with gene model URLs not found\n\n{gene_model_urls_text}\n\n## Species and strain combinations with multiple taxonomy IDs\n\n{taxonomy_ids_text}\n\n## Assemblies without ploidy information\n\n{ploidy_assemblies_text}"
 
 
 def build_files(
-  assemblies_path,
-  genomes_output_path,
-  ucsc_assemblies_url,
-  tree_output_path,
-  taxonomic_levels_for_tree, 
-  taxonomic_group_sets={},
-  do_gene_model_urls=True,
-  extract_primary_data=False,
-  primary_output_path=None,
-  qc_report_path=None,
-  organisms_path=None
+    assemblies_path,
+    genomes_output_path,
+    ucsc_assemblies_url,
+    tree_output_path,
+    taxonomic_levels_for_tree,
+    taxonomic_group_sets={},
+    do_gene_model_urls=True,
+    extract_primary_data=False,
+    primary_output_path=None,
+    qc_report_path=None,
+    organisms_path=None,
 ):
-  print("Building files")
+    print("Building files")
 
-  qc_report_params = {}
+    qc_report_params = {}
 
-  source_list_df = read_assemblies(assemblies_path)
+    source_list_df = read_assemblies(assemblies_path)
 
-  base_genomes_df, primarydata_df = get_genomes_and_primarydata_df(source_list_df["accession"])
+    base_genomes_df, primarydata_df = get_genomes_and_primarydata_df(
+        source_list_df["accession"]
+    )
 
-  primarydata_df['sra_sample_acc'] = primarydata_df["sample_ids"].str.split(",")
-  primarydata_df = primarydata_df.explode("sra_sample_acc")
-  primarydata_df = primarydata_df[~primarydata_df["sra_sample_acc"].isnull() & primarydata_df["sra_sample_acc"].str.startswith('SRA')]
-  primarydata_df["sra_sample_acc"] = primarydata_df["sra_sample_acc"].str.replace("SRA:", "")
-  if extract_primary_data:
-    sra_ids_list = primarydata_df["sra_sample_acc"].dropna().unique().tolist()
-    sra_metadata = fetch_sra_metadata(sra_ids_list)
-    sra_metadata_df = pd.DataFrame([sra_metadata[sra][srr] for sra in sra_metadata for srr in sra_metadata[sra]])
-    primarydata_df = primarydata_df.merge(sra_metadata_df, how="left", left_on="sra_sample_acc", right_on="sra_sample_acc")
-  
-  qc_report_params["missing_ncbi_assemblies"] = report_missing_values_from("accessions", "found on NCBI", source_list_df["accession"], base_genomes_df["accession"])
+    primarydata_df["sra_sample_acc"] = primarydata_df["sample_ids"].str.split(",")
+    primarydata_df = primarydata_df.explode("sra_sample_acc")
+    primarydata_df = primarydata_df[
+        ~primarydata_df["sra_sample_acc"].isnull()
+        & primarydata_df["sra_sample_acc"].str.startswith("SRA")
+    ]
+    primarydata_df["sra_sample_acc"] = primarydata_df["sra_sample_acc"].str.replace(
+        "SRA:", ""
+    )
+    if extract_primary_data:
+        sra_ids_list = primarydata_df["sra_sample_acc"].dropna().unique().tolist()
+        sra_metadata = fetch_sra_metadata(sra_ids_list)
+        sra_metadata_df = pd.DataFrame(
+            [
+                sra_metadata[sra][srr]
+                for sra in sra_metadata
+                for srr in sra_metadata[sra]
+            ]
+        )
+        primarydata_df = primarydata_df.merge(
+            sra_metadata_df,
+            how="left",
+            left_on="sra_sample_acc",
+            right_on="sra_sample_acc",
+        )
 
-  # Fetch species information once to be used by both species_df and species_tree
-  species_info = get_species_info(base_genomes_df["taxonomyId"])
-  species_name_info = get_species_name_info(base_genomes_df["taxonomyId"])
-  
-  # Create species DataFrame using the fetched species_info
-  species_df = get_species_df(species_info, species_name_info, taxonomic_group_sets, taxonomic_levels_for_tree)
+    qc_report_params["missing_ncbi_assemblies"] = report_missing_values_from(
+        "accessions",
+        "found on NCBI",
+        source_list_df["accession"],
+        base_genomes_df["accession"],
+    )
 
-  report_missing_values_from("species", "found on NCBI", base_genomes_df["taxonomyId"], species_df["taxonomyId"])
+    # Fetch species information once to be used by both species_df and species_tree
+    species_info = get_species_info(base_genomes_df["taxonomyId"])
+    species_name_info = get_species_name_info(base_genomes_df["taxonomyId"])
 
-  genomes_with_species_df = base_genomes_df.merge(species_df, how="left", on="taxonomyId")
+    # Create species DataFrame using the fetched species_info
+    species_df = get_species_df(
+        species_info, species_name_info, taxonomic_group_sets, taxonomic_levels_for_tree
+    )
 
-  qc_report_params["inconsistent_taxonomy_ids"] = report_inconsistent_taxonomy_ids(genomes_with_species_df)
+    report_missing_values_from(
+        "species",
+        "found on NCBI",
+        base_genomes_df["taxonomyId"],
+        species_df["taxonomyId"],
+    )
 
-  assemblies_df = pd.DataFrame(requests.get(ucsc_assemblies_url).json()["data"])[["ucscBrowser", "genBank", "refSeq"]]
+    genomes_with_species_df = base_genomes_df.merge(
+        species_df, how="left", on="taxonomyId"
+    )
 
-  gen_bank_merge_df = genomes_with_species_df.merge(assemblies_df, how="left", left_on="accession", right_on="genBank")
-  ref_seq_merge_df = genomes_with_species_df.merge(assemblies_df, how="left", left_on="accession", right_on="refSeq")
+    qc_report_params["inconsistent_taxonomy_ids"] = report_inconsistent_taxonomy_ids(
+        genomes_with_species_df
+    )
 
-  qc_report_params["missing_ucsc_assemblies"] = report_missing_values_from("accessions", "matched in assembly list", genomes_with_species_df["accession"], assemblies_df["genBank"], assemblies_df["refSeq"])
+    assemblies_df = pd.DataFrame(requests.get(ucsc_assemblies_url).json()["data"])[
+        ["ucscBrowser", "genBank", "refSeq"]
+    ]
 
-  genomes_df = gen_bank_merge_df.combine_first(ref_seq_merge_df)
+    gen_bank_merge_df = genomes_with_species_df.merge(
+        assemblies_df, how="left", left_on="accession", right_on="genBank"
+    )
+    ref_seq_merge_df = genomes_with_species_df.merge(
+        assemblies_df, how="left", left_on="accession", right_on="refSeq"
+    )
 
-  if do_gene_model_urls:
-    genomes_df = add_gene_model_url(genomes_df)
-    qc_report_params["missing_gene_model_urls"] = report_missing_values("accessions", "matched with gene model URLs", genomes_df["accession"], genomes_df["geneModelUrl"].astype(bool))
-  else:
-    genomes_df["geneModelUrl"] = ""
+    qc_report_params["missing_ucsc_assemblies"] = report_missing_values_from(
+        "accessions",
+        "matched in assembly list",
+        genomes_with_species_df["accession"],
+        assemblies_df["genBank"],
+        assemblies_df["refSeq"],
+    )
 
-  genomes_df.to_csv(genomes_output_path, index=False, sep="\t")
+    genomes_df = gen_bank_merge_df.combine_first(ref_seq_merge_df)
 
-  print(f"Wrote to {genomes_output_path}")
+    if do_gene_model_urls:
+        genomes_df = add_gene_model_url(genomes_df)
+        qc_report_params["missing_gene_model_urls"] = report_missing_values(
+            "accessions",
+            "matched with gene model URLs",
+            genomes_df["accession"],
+            genomes_df["geneModelUrl"].astype(bool),
+        )
+    else:
+        genomes_df["geneModelUrl"] = ""
 
-  if extract_primary_data:
-    primarydata_df.to_csv(primary_output_path, index=False, sep="\t")
-    print(f"Wrote to {primary_output_path}")
-  
-  if len(taxonomic_levels_for_tree) > 0:
-    # Use the taxonomy IDs from the genomes_df to build the species tree
-    # Pass the previously fetched species_info to avoid another API call
-    species_tree = get_species_tree(list(genomes_df["taxonomyId"]), taxonomic_levels_for_tree, species_info)
-    with open(tree_output_path, 'w') as outfile:
-      json.dump(species_tree, outfile, indent=4)
-    print(f"Wrote to {tree_output_path}")
+    genomes_df.to_csv(genomes_output_path, index=False, sep="\t")
 
-  if organisms_path is not None:
-    organisms_df = read_organisms(organisms_path)
-    qc_report_params["missing_ploidy_assemblies"] = report_missing_ploidy_info(genomes_df, organisms_df)
-    print(f"Checked ploidy for {len(genomes_df)} assemblies")
+    print(f"Wrote to {genomes_output_path}")
 
-  if qc_report_path is not None:
-    qc_report_text = make_qc_report(**qc_report_params)
-    with open(qc_report_path, "w") as file:
-      file.write(qc_report_text)
+    if extract_primary_data:
+        primarydata_df.to_csv(primary_output_path, index=False, sep="\t")
+        print(f"Wrote to {primary_output_path}")
+
+    if len(taxonomic_levels_for_tree) > 0:
+        # Use the taxonomy IDs from the genomes_df to build the species tree
+        # Pass the previously fetched species_info to avoid another API call
+        species_tree = get_species_tree(
+            list(genomes_df["taxonomyId"]), taxonomic_levels_for_tree, species_info
+        )
+        with open(tree_output_path, "w") as outfile:
+            json.dump(species_tree, outfile, indent=4)
+        print(f"Wrote to {tree_output_path}")
+
+    if organisms_path is not None:
+        organisms_df = read_organisms(organisms_path)
+        qc_report_params["missing_ploidy_assemblies"] = report_missing_ploidy_info(
+            genomes_df, organisms_df
+        )
+        print(f"Checked ploidy for {len(genomes_df)} assemblies")
+
+    if qc_report_path is not None:
+        qc_report_text = make_qc_report(**qc_report_params)
+        with open(qc_report_path, "w") as file:
+            file.write(qc_report_text)

--- a/catalog/build/py/package/setup.py
+++ b/catalog/build/py/package/setup.py
@@ -1,8 +1,8 @@
 from setuptools import setup
 
 setup(
-  name="catalog_build",
-  version="2.2.0",
-  packages=["catalog_build"],
-  install_requires=["pandas", "requests", "PyYAML", "BeautifulSoup4", "lxml"],
+    name="catalog_build",
+    version="2.2.0",
+    packages=["catalog_build"],
+    install_requires=["pandas", "requests", "PyYAML", "BeautifulSoup4", "lxml"],
 )

--- a/catalog/build/py/requirements.txt
+++ b/catalog/build/py/requirements.txt
@@ -77,3 +77,4 @@ urllib3==2.2.2
 watchdog==6.0.0
 webcolors==24.11.1
 wrapt==1.17.2
+ruff==0.11.0

--- a/catalog/schema/scripts/gen-typescript.py
+++ b/catalog/schema/scripts/gen-typescript.py
@@ -1,4 +1,5 @@
 import sys
+
 from linkml.generators.typescriptgen import TypescriptGenerator
 
 # The source for the base TypeScript generator can be found at https://github.com/linkml/linkml/blob/main/linkml/generators/typescriptgen.py
@@ -6,18 +7,21 @@ from linkml.generators.typescriptgen import TypescriptGenerator
 """
 LinkML TypeScript generator extended to handle enums and optional fields more correctly.
 """
+
+
 class TypescriptGeneratorFixed(TypescriptGenerator):
-  def range(self, slot):
-    range = slot.range
-    all_enums = self.schemaview.all_enums()
-    if range in all_enums:
-      name = self.generate_enums({range: all_enums[range]})[range]["name"]
-      if slot.multivalued:
-        base_result = f"{name}[]"
-      else:
-        base_result = name
-    else:
-      base_result = super().range(slot)
-    return base_result if slot.required else f"{base_result} | null"
+    def range(self, slot):
+        range = slot.range
+        all_enums = self.schemaview.all_enums()
+        if range in all_enums:
+            name = self.generate_enums({range: all_enums[range]})[range]["name"]
+            if slot.multivalued:
+                base_result = f"{name}[]"
+            else:
+                base_result = name
+        else:
+            base_result = super().range(slot)
+        return base_result if slot.required else f"{base_result} | null"
+
 
 print(TypescriptGeneratorFixed(sys.argv[1]).serialize())

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "next lint --dir .",
     "check-format": "prettier --check .",
     "format": "prettier --write . --cache",
+    "format:python": "./scripts/format-python.sh",
     "prepare": "husky",
     "test": "jest --runInBand",
     "build-brc-db": "esrun catalog/build/ts/build-catalog.ts",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,22 +1,16 @@
-[tool.black]
+[tool.ruff]
+target-version = "py38"
 line-length = 88
-target-version = ['py38']
-include = '\.pyi?$'
-exclude = '''
-/(
-    \.eggs
-  | \.git
-  | \.hg
-  | \.mypy_cache
-  | \.tox
-  | \.venv
-  | venv
-  | _build
-  | buck-out
-  | dist
-)/
-'''
+indent-width = 4
 
-[tool.isort]
-profile = "black"
-line_length = 88
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"
+
+[tool.ruff.lint]
+select = ["E", "F", "I"]
+ignore = []
+fixable = ["ALL"]
+unfixable = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ skip-magic-trailing-comma = false
 line-ending = "auto"
 
 [tool.ruff.lint]
-select = ["E", "F", "I"]
+select = ["E", "F", "I", "B"]
 ignore = []
 fixable = ["ALL"]
 unfixable = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[tool.black]
+line-length = 88
+target-version = ['py38']
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.eggs
+  | \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | venv
+  | _build
+  | buck-out
+  | dist
+)/
+'''
+
+[tool.isort]
+profile = "black"
+line_length = 88

--- a/scripts/format-python.sh
+++ b/scripts/format-python.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 
-# Format Python files using Black
-echo "Formatting Python files with Black..."
-black catalog/
+# Format Python files using Ruff (Rust-based formatter)
+echo "Formatting Python files with Ruff..."
+ruff format catalog/
 
-# Exit with Black's status code
+# Sort imports with Ruff
+echo "Sorting imports with Ruff..."
+ruff check --select I --fix catalog/
+
+# Exit with Ruff's status code
 exit $?

--- a/scripts/format-python.sh
+++ b/scripts/format-python.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Format Python files using Black
+echo "Formatting Python files with Black..."
+black catalog/
+
+# Exit with Black's status code
+exit $?


### PR DESCRIPTION
Just like we use prettier for js, this applies `ruff` for python.  We use black-style formatting, and sort imports a-la isort.

Closes #393.


Also, please leave this in draft until the data portion of the genome-viz stuff (#290) is merged to avoid extra conflict resolution work.  I'll reapply black here once that's in.