### PR TITLE
feat: querybuilder component that can be used to create valid query strings for the ena api #310

### DIFF
--- a/app/apis/catalog/brc-analytics-catalog/common/entities.ts
+++ b/app/apis/catalog/brc-analytics-catalog/common/entities.ts
@@ -69,6 +69,12 @@ export interface EntitiesResponsePagination {
   total: number;
 }
 
+export interface RunReadsFields {
+  description: string;
+  name: string;
+  type: string;
+}
+
 export interface WorkflowCategory {
   category: string;
   description: string;

--- a/app/components/Entity/components/QueryBuilder/queryBuilder.style.ts
+++ b/app/components/Entity/components/QueryBuilder/queryBuilder.style.ts
@@ -1,0 +1,18 @@
+import { GridPaperSection } from "@databiosphere/findable-ui/lib/components/common/Section/section.styles";
+
+import styled from "@emotion/styled";
+
+export const StyledSection = styled(GridPaperSection)`
+  flex-direction: column;
+`;
+
+export const QueryInputContent = styled.input`
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  box-sizing: border-box;
+  color: #637381;
+  margin: 10px 0;
+  padding: 10px;
+  width: 100%;
+`;

--- a/app/components/Entity/components/QueryBuilder/queryBuilder.tsx
+++ b/app/components/Entity/components/QueryBuilder/queryBuilder.tsx
@@ -1,0 +1,536 @@
+"use client"; // Ensure client-side rendering
+
+import React, { useEffect, useState } from "react";
+import { Alert, Box, Chip, Stack } from "@mui/material";
+
+import {
+  FluidPaper,
+  GridPaper,
+} from "@databiosphere/findable-ui/lib/components/common/Paper/paper.styles";
+
+import {
+  addAdditionPartToUIQuery,
+  combineExpressionParts,
+  formatExpression,
+  countParenthesis,
+  splitOnFirstEqualSign,
+  splitUnqouatedSpace,
+  validateExpression,
+} from "./utils";
+
+import runReadFields from "../../../../../catalog/output/runReadFields.json";
+
+import AddCircleOutlineIcon from "@mui/icons-material/AddCircleOutline";
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  MenuItem,
+  Select,
+  TextField,
+} from "@mui/material";
+import { QueryInputContent, StyledSection } from "./queryBuilder.style";
+
+interface QueryBuilderProps {
+  initialQuery: string;
+  onQueryChange?: (query: string) => void;
+}
+
+/**
+ * Renders a dialog component that allows the user to select a field type, which can be a logical operator,
+ * a grouper, or a field value. For field values, the user will also be able to set a corresponding value.
+ *
+ * @param field - The currently selected field type.
+ * @param modalOpen - A boolean indicating whether the dialog is open.
+ * @param handleClose - A callback function to handle closing the dialog.
+ * @param handleSave - A callback function to handle saving the selected field and value.
+ * @param setField - A function to update the selected field type.
+ * @param setValue - A function to update the value associated with the selected field.
+ * @param value - The current value associated with the selected field.
+ * @returns A JSX.Element representing the dialog component.
+ */
+function renderFieldDialog(
+  field: string,
+  modalOpen: boolean,
+  handleClose: () => void,
+  handleSave: () => void,
+  setField: (field: string) => void,
+  setValue: (vaule: string) => void,
+  value: string
+): JSX.Element {
+  return (
+    <Dialog open={modalOpen} onClose={handleClose}>
+      <DialogTitle>Edit Item</DialogTitle>
+      <DialogContent>
+        <Select
+          fullWidth
+          value={field}
+          onChange={(e) => setField(e.target.value as string)}
+          label="Field"
+        >
+          {runReadFields.map((field, index) => (
+            <MenuItem key={index} value={field.name}>
+              {field.name}
+            </MenuItem>
+          ))}
+        </Select>
+      </DialogContent>
+      <DialogContent hidden={["AND", "OR", "(", ")", ""].includes(field)}>
+        <TextField
+          autoFocus
+          fullWidth
+          margin="dense"
+          label="Item Value"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose} color="secondary">
+          Cancel
+        </Button>
+        <Button onClick={handleSave} color="primary">
+          Save
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+/**
+ * Renders a query part as a JSX element based on the provided parameters. The item will be a list of strings and will have length 1 or 2. The two options are:
+ * - Length 1: Represents logical operators and grouping 'AND, OR, ), (' or '--ADD--', which is used for rendering the option of adding new elements.
+ * - Length 2: Represents a field and value pair.
+ *
+ * @param {string[]} item - An array representing the query part. The first element determines the field type of the query part (e.g., "tax_id", "(", ")", or other labels).
+ * @param {number} index - The index of the query part in the list.
+ * @param {number} openParenthesis - The count of open parentheses in the query.
+ * @param {number} closeParenthesis - The count of close parentheses in the query.
+ * @param {(index: number, field: string, value: string) => void} handleClick - Callback function triggered when the query part is clicked. Receives the index, field, and value as arguments.
+ * @param {(index: number) => void} handleDelete - Callback function triggered when the query part is deleted. Receives the index as an argument.
+ * @returns {JSX.Element} A JSX element representing the query part, styled and configured based on its type and context.
+ */
+function renderQueryPart(
+  item: string[],
+  index: number,
+  openParenthesis: number,
+  closeParenthesis: number,
+  handleClick: (index: number, field: string, value: string) => void,
+  handleDelete: (index: number) => void
+): JSX.Element {
+  let label: string = item[0];
+  const variant: string = "outlined";
+  let color: string = "primary";
+
+  if (item[0] == "--ADD--") {
+    return (
+      <AddCircleOutlineIcon
+        key={index}
+        onClick={() => handleClick(index, "", "")}
+        sx={{ cursor: "pointer", fontSize: "0.5rem", position: "relative" }}
+      />
+    );
+  } else if (
+    (item[0] === "(" && openParenthesis > closeParenthesis) ||
+    (item[0] === ")" && openParenthesis < closeParenthesis)
+  ) {
+    return (
+      <Chip
+        key={index}
+        label={label}
+        color={color as "default" | "success"}
+        variant={variant as "outlined" | "filled"}
+        deleteIcon={
+          <span
+            style={{
+              color: "black",
+              fontSize: "0.5rem",
+              fontWeight: "bold",
+              lineHeight: "1",
+            }}
+          >
+            ×
+          </span>
+        }
+        sx={{
+          "& .MuiChip-deleteIcon": {
+            marginRight: "-4px",
+            marginTop: "-16px",
+          },
+          "@keyframes blinking": {
+            "0%": { backgroundColor: "red" },
+            "100%": { backgroundColor: "red" },
+            "50%": { backgroundColor: "transparent" },
+          },
+          animation: "blinking 1s infinite",
+        }}
+        onClick={() => handleClick(index, item[0], item[1])}
+        onDelete={() => handleDelete(index)}
+      />
+    );
+  } else {
+    if (label !== "AND" && label !== "OR") {
+      if (item[0] !== "(" && item[0] !== ")") {
+        label = `${item[0]} : ${item[1]} `;
+      }
+    } else {
+      color = "success";
+    }
+  }
+
+  return (
+    <Chip
+      key={index}
+      label={label}
+      color={color as "default" | "success"}
+      variant={variant as "outlined" | "filled"}
+      onDelete={() => handleDelete(index)}
+      onClick={() => handleClick(index, item[0], item[1])}
+      deleteIcon={
+        <span
+          style={{
+            color: "red",
+            fontSize: "0.5rem",
+            fontWeight: "bold",
+            lineHeight: "1",
+          }}
+        >
+          ×
+        </span>
+      }
+      sx={{
+        "& .MuiChip-deleteIcon": {
+          marginRight: "5px",
+          marginTop: "-8px",
+        },
+      }}
+    />
+  );
+}
+
+/**
+ * Renders a query string input field for entering filter criteria.
+ *
+ * @param filterString - The current filter string value to display in the input field.
+ * @param validateQueryExpressionAndUpdateFilterString - A callback function that validates the query expression
+ * and updates the filter string. It takes the input expression as a parameter and returns a boolean indicating
+ * whether the validation was successful.
+ * @returns A JSX element representing the query string input field.
+ */
+function renderQueryStringInput(
+  filterString: string,
+  validateQueryExpressionAndUpdateFilterString: (expression: string) => boolean
+): JSX.Element {
+  return (
+    <QueryInputContent
+      type="text"
+      placeholder="Enter filter criteria"
+      value={filterString}
+      onChange={(e) =>
+        validateQueryExpressionAndUpdateFilterString(
+          formatExpression(e.target.value)
+        )
+      }
+    />
+  );
+}
+
+/**
+ * Renders a query builder component that allows users to construct and modify a filter string
+ * using a visual interface. The component supports nested expressions, parentheses, and logical operators.
+ *
+ * @param filterString - The initial filter string to be parsed and displayed in the query builder.
+ * @param validateQueryExpressionAndUpdateFilterString - A callback function that validates the query expression
+ * and updates the filter string. It should return `true` if the expression is valid, otherwise `false`.
+ *
+ * @returns A JSX element representing the query builder interface.
+ *
+ * ## State Variables:
+ * - `field`: Represents the current selected field or logical operator being edited.
+ * - `index`: Tracks the index of the currently selected query part.
+ * - `modalOpen`: Controls the visibility of the modal dialog for editing query parts.
+ * - `value`: Stores the value of the currently selected query part.
+ * - `clientRendered`: Ensures the component is only rendered on the client side.
+ *
+ * ## Functions:
+ * - `handleClose`: Resets the modal state and clears the selected query part.
+ * - `handleDelete`: Removes a query part at the specified index and updates the filter string.
+ * - `handleOpen`: Opens the modal dialog for editing a query part, initializing its state.
+ * - `handleSave`: Saves the changes made to a query part and updates the filter string.
+ * - `renderElements`: Recursively renders query parts, handling nested parentheses and groups.
+ *
+ * ## Rendering:
+ * - The query builder is displayed as a stack of query parts, with support for nested groups.
+ * - A modal dialog is used for editing individual query parts.
+ *
+ * ## Dependencies:
+ * - `splitUnqouatedSpace`: Splits the filter string into parts based on unquoted spaces.
+ * - `splitOnFirstEqualSign`: Splits a query part into a field and value based on the first `=` sign.
+ * - `addAdditionPartToUIQuery`: Adds additional UI-specific parts to the query.
+ * - `combineExpressionParts`: Combines query parts back into a filter string.
+ * - `countParenthesis`: Counts the number of open and close parentheses in the filter string.
+ * - `renderQueryPart`: Renders an individual query part as a JSX element.
+ * - `renderFieldDialog`: Renders the modal dialog for editing query parts.
+ */
+function RenderQueryBuilder(
+  filterString: string,
+  validateQueryExpressionAndUpdateFilterString: (expression: string) => boolean
+): JSX.Element {
+  const [field, setField] = useState("");
+  const [index, setIndex] = useState(-1);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [value, setValue] = useState("");
+
+  const filterStringParts = addAdditionPartToUIQuery(
+    splitUnqouatedSpace(filterString).map((item) => splitOnFirstEqualSign(item))
+  );
+
+  const handleClose = (): void => {
+    setModalOpen(false);
+    setIndex(-1);
+    setField("");
+    setValue("");
+  };
+
+  const handleDelete = (index: number): void => {
+    const newTokenParts = [...filterStringParts];
+    newTokenParts.splice(index, 1);
+    validateQueryExpressionAndUpdateFilterString(
+      combineExpressionParts(
+        newTokenParts.filter((item) => item[0] !== "--ADD--")
+      )
+    );
+  };
+
+  const handleOpen = (index: number, field: string, value: string): void => {
+    setModalOpen(true);
+    setField(field === "" ? "AND" : field);
+    setIndex(index);
+    setValue(value);
+  };
+
+  const handleSave = (): void => {
+    filterStringParts[index][0] = field;
+    if (!["(", ")", "AND", "OR"].includes(field)) {
+      filterStringParts[index][1] = value;
+    } else {
+      filterStringParts[index].splice(1, 1);
+    }
+    validateQueryExpressionAndUpdateFilterString(
+      combineExpressionParts(
+        filterStringParts.filter((item: string[]) => item[0] !== "--ADD--")
+      )
+    );
+
+    handleClose();
+  };
+
+  const [openParenthesis, closeParenthesis] = countParenthesis(filterString);
+
+  function renderElements(
+    parts: string[][],
+    startIndex: number
+  ): [JSX.Element[], number] {
+    const elements: JSX.Element[] = [];
+    let index: number = startIndex;
+
+    while (index < parts.length) {
+      if (parts[index][0] === "(") {
+        const [nestedElements, endIndex] = renderElements(parts, index + 1);
+        elements.push(
+          <Box
+            sx={{
+              alignItems: "center",
+              border: "1px solid #ccc",
+              borderRadius: 2,
+              display: "flex",
+              flexWrap: "wrap",
+              gap: 1,
+              padding: 1,
+            }}
+          >
+            {renderQueryPart(
+              parts[index],
+              index,
+              openParenthesis,
+              closeParenthesis,
+              handleOpen,
+              handleDelete
+            )}
+            {nestedElements}
+          </Box>
+        );
+        index = endIndex; // Skip to the end of the group
+      } else if (parts[index][0] === ")") {
+        elements.push(
+          renderQueryPart(
+            parts[index],
+            index,
+            openParenthesis,
+            closeParenthesis,
+            handleOpen,
+            handleDelete
+          )
+        );
+        return [elements, index]; // End of the current group
+      } else {
+        elements.push(
+          renderQueryPart(
+            parts[index],
+            index,
+            openParenthesis,
+            closeParenthesis,
+            handleOpen,
+            handleDelete
+          )
+        );
+      }
+      index++;
+    }
+    return [elements, index];
+  }
+
+  const [clientRendered, setClientRendered] = useState(false);
+
+  useEffect(() => {
+    setClientRendered(true);
+  }, []);
+
+  return (
+    <>
+      {clientRendered && (
+        <Stack
+          direction="row"
+          spacing={1}
+          sx={{
+            alignItems: "center",
+            flexWrap: "wrap",
+            rowGap: 2,
+          }}
+        >
+          {renderElements(filterStringParts, 0)[0]}
+        </Stack>
+      )}
+      {renderFieldDialog(
+        field,
+        modalOpen,
+        handleClose,
+        handleSave,
+        setField,
+        setValue,
+        value
+      )}
+    </>
+  );
+}
+
+/**
+ * QueryBuilder component allows users to construct and validate query expressions
+ * using either a UI-based editor, a text-based editor, or a combination of both.
+ *
+ * @param {QueryBuilderProps} props - The properties for the QueryBuilder component.
+ * @param {string} props.initialQuery - The initial query expression to populate the builder, ex 'tax_id=5134'.
+ * @param {(expression: string) => void} props.onQueryChange - Callback function triggered when the query changes providing a valied filterstring.
+ *
+ * @returns {JSX.Element} The rendered QueryBuilder component.
+ *
+ * @remarks
+ * - The component maintains internal state for the query string (`filterString`), syntax errors (`searchSyntaxError`),
+ *   and the currently selected editor mode (`editorToShow`).
+ * - The `validateQueryExpressionAndUpdateFilterString` function validates the query expression and updates the state.
+ * - Users can toggle between different editor modes (UI, Text, or both) using a dropdown menu.
+ * - Syntax errors, if any, are displayed as a list of alerts.
+ *
+ * @example
+ * ```tsx
+ * <QueryBuilder
+ *   initialQuery="tax_id=5134 AND library_strategy=PAIRED"
+ *   onQueryChange={(query) => console.log("Updated query:", query)}
+ * />
+ * ```
+ */
+export const QueryBuilder = ({
+  initialQuery,
+  onQueryChange,
+}: QueryBuilderProps): JSX.Element => {
+  const [filterString, setFilterString] = useState<string>(
+    initialQuery ? formatExpression(initialQuery) : ""
+  );
+  const [searchSyntaxError, setSearchSyntaxError] = useState<string[]>([]);
+  const [editorToShow, setEditorToShow] = useState<string>("UI");
+
+  const validateQueryExpressionAndUpdateFilterString = (
+    expression: string
+  ): boolean => {
+    const expressionValidated = validateExpression(expression);
+    const valid = expressionValidated.length === 0;
+    if (!valid) {
+      setSearchSyntaxError(expressionValidated);
+    } else {
+      setSearchSyntaxError([]);
+    }
+    setFilterString(expression);
+    if (valid && onQueryChange) {
+      onQueryChange(expression);
+    }
+    return valid;
+  };
+
+  return (
+    <FluidPaper>
+      <GridPaper>
+        <StyledSection>
+          <p
+            style={{
+              fontSize: "0.8rem",
+              fontWeight: "bold",
+            }}
+          >
+            Query builder:
+            <select
+              style={{
+                backgroundColor: "white",
+                border: "none",
+                borderRadius: "0",
+                boxShadow: "none",
+                float: "right",
+                textAlign: "right",
+              }}
+              onChange={(e) => setEditorToShow(e.target.value)}
+              value={editorToShow}
+            >
+              <option value="UI">UI</option>
+              <option value="TEXT">Text</option>
+              <option value="UI/TEXT">UI/Text</option>
+            </select>
+          </p>
+          <div hidden={editorToShow !== "TEXT" && editorToShow !== "UI/TEXT"}>
+            {renderQueryStringInput(
+              filterString,
+              validateQueryExpressionAndUpdateFilterString
+            )}
+          </div>
+          <div hidden={editorToShow !== "UI" && editorToShow !== "UI/TEXT"}>
+            {RenderQueryBuilder(
+              filterString,
+              validateQueryExpressionAndUpdateFilterString
+            )}
+          </div>
+          {searchSyntaxError.length > 0 && (
+            <div>
+              <Stack sx={{ width: "100%" }} spacing={2}>
+                {searchSyntaxError.map((error, index) => (
+                  <Alert severity="error" key={index}>
+                    {error}
+                  </Alert>
+                ))}
+              </Stack>
+            </div>
+          )}
+        </StyledSection>
+      </GridPaper>
+    </FluidPaper>
+  );
+};

--- a/app/components/Entity/components/QueryBuilder/utils.tsx
+++ b/app/components/Entity/components/QueryBuilder/utils.tsx
@@ -1,0 +1,206 @@
+/**
+ * Combines parts of an expression into a single string.
+ *
+ * This function takes an array of string arrays, where each inner array represents
+ * a part of an expression. It joins the elements of each inner array with an "=" sign,
+ * then joins all the parts with a space, and finally replaces any multiple spaces with a single space.
+ *
+ * @param parts - An array of string arrays representing parts of an expression.
+ * @returns The combined expression as a single string.
+ */
+export function combineExpressionParts(parts: string[][]): string {
+  return parts
+    .map((part: string[]) => part.join("="))
+    .join(" ")
+    .replace(/\s+/g, " ");
+}
+
+export function formatExpression(expression: string): string {
+  // Make sure that any form of ' And ' and ' Or ' will be convert to
+  // ' AND ' and ' OR ' respectively
+  // Also remove whitespace adjecent to = sign
+  return expression
+    .replace(/\s[Aa][Nn][Dd]\s/g, " AND ")
+    .replace(/\s[Oo][Rr]\s/g, " OR ")
+    .replace(/\b\s*=\s*\b/g, "=");
+}
+
+/**
+ * Formats a large number into a more readable string with appropriate suffixes.
+ *
+ * - Numbers greater than or equal to 1 billion are formatted with a 'G' suffix.
+ * - Numbers greater than or equal to 1 million are formatted with an 'M' suffix.
+ * - Numbers greater than or equal to 1 thousand are formatted with a 'K' suffix.
+ * - Numbers less than 1 thousand are returned as-is.
+ *
+ * @param value - The number to format.
+ * @returns The formatted number as a string with the appropriate suffix.
+ */
+export function formatLargeNumber(value: number): string {
+  if (value >= 1e9) return `${(value / 1e9).toFixed(1)}G`;
+  if (value >= 1e6) return `${(value / 1e6).toFixed(1)}M`;
+  if (value >= 1e3) return `${(value / 1e3).toFixed(1)}K`;
+  return value.toString();
+}
+
+/**
+ * Splits a given string by spaces, parentheses, and quotes, while preserving quoted substrings.
+ *
+ * This function takes a string and splits it into an array of substrings based on spaces,
+ * parentheses, and quotes. Quoted substrings (either single or double quotes) are preserved
+ * as single elements in the resulting array.
+ *
+ * @param s - The input string to be split.
+ * @returns An array of substrings, with quoted substrings preserved.
+ *
+ * @example
+ * ```typescript
+ * validateExpression('(tax_id=7165 AND library_layout=SINGLE) OR (scientific_name="Taeniopygia guttata" AND instrument_platform=ILLUMINA) OR accession=GCA_023851605.1')
+ * // returns ["(", "tax_id=7165", "AND", "library_layout=SINGLE", ")", "OR", "(", 'scientific_name="Taeniopygia guttata"', "AND", "instrument_platform=ILLUMINA", ")", "OR", "accession=GCA_023851605.1"]
+ * ```
+ */
+export function splitUnqouatedSpace(s: string): string[] {
+  if (/\s|\(|\)/.test(s)) {
+    let part;
+    let qouteChar = "";
+    const parts = s.split(/(\(|\)|\s+)/).filter((part) => part.trim() !== "");
+    const combinedParts = [];
+    while ((part = parts.shift()) !== undefined) {
+      const firstQuoteIndex = part.search(/['"]/);
+      if (firstQuoteIndex === -1) {
+        // No quotes in the part
+        combinedParts.push(part);
+      } else {
+        // Quotes in the part, lets find the closing quote
+        qouteChar = part[firstQuoteIndex];
+        while (!part.endsWith(qouteChar) && parts.length > 0) {
+          part += ` ${parts.shift()}`;
+        }
+        combinedParts.push(part);
+      }
+    }
+    if (part) {
+      combinedParts.push(part);
+    }
+    return combinedParts;
+  }
+  return [s];
+}
+
+/**
+ * Validates an expression to ensure it follows the expected format.
+ *
+ * This function checks for balanced parentheses, valid conditions, and proper use of logical operators.
+ * It returns an array of error messages if any issues are found in the expression.
+ *
+ * @param expression - The expression to validate.
+ * @returns An array of error messages, or an empty array if the expression is valid.
+ *
+ * @example
+ * ```typescript
+ * validateExpression('(tax_id=7165 AND library_layout=SINGLE) OR (scientific_name="Taeniopygia guttata" AND instrument_platform=ILLUMINA) OR accession=GCA_023851605.1')
+ * // returns []
+ * ```
+ */
+export function validateExpression(expression: string): string[] {
+  const expression_bullder = /(\(|\)|\bAND\b|\bOR\b)/;
+
+  const proceessParts = (parts: string[]): string[] => {
+    // Regular expressions for validation
+    // Ensure that non-operator parts follow the pattern:
+    // <lowercase character, underscore> = <any character, any number, underscore, dash, and dots>
+    const conditionPattern = /^\s*([a-z_]+)\s*!?=\s*([A-Za-z0-9._-]+)\s*$/;
+    // <lowercase character, underscore> = <wrapped with quotations characters, any character, any number, underscore, dash, dots, and space>
+    const conditionPatternWithSpace =
+      /^\s*([a-z_]+)\s*!?=\s*(["'][A-Za-z0-9._ -]+["'])\s*$/;
+    // Logical operators, which need to be in uppercase and have adjacent spaces
+    const operatorPattern = /^\s*(AND|OR)\s*$/;
+    let prevWasCondition = false;
+    const expression_status = [];
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i];
+      if (conditionPattern.test(part) || conditionPatternWithSpace.test(part)) {
+        if (prevWasCondition) {
+          expression_status.push(`Error: Missing operator before '${part}'.`);
+        }
+        prevWasCondition = true;
+      } else if (operatorPattern.test(part)) {
+        if (!prevWasCondition) {
+          expression_status.push(
+            `Error: Operator '${part}' must be between conditions.`
+          );
+        }
+        prevWasCondition = false;
+      } else {
+        expression_status.push(`Error: Invalid expression '${part}'.`);
+      }
+    }
+
+    if (!prevWasCondition) {
+      expression_status.push(
+        "Error: Expression must end with a valid condition."
+      );
+    }
+
+    return expression_status;
+  };
+
+  const expression_status = [];
+  if (expression !== "") {
+    // Check for parentheses without content
+    const emptyParentheses = /\(\s*\)/;
+
+    // Check for unbalanced parentheses
+    const [openParenthesis, closeParenthesis] = countParenthesis(expression);
+    if (openParenthesis !== closeParenthesis) {
+      const error =
+        openParenthesis < closeParenthesis
+          ? "There are more opening parentheses than closing ones!"
+          : "There are more closing parentheses than opening ones!";
+      expression_status.push(
+        `Error: Unbalanced parentheses: ${error} ${openParenthesis} ( and ${closeParenthesis} ).`
+      );
+    }
+
+    if (emptyParentheses.test(expression)) {
+      expression_status.push("Error: Parentheses without content.");
+    }
+
+    // Process parts of the expression
+    const parts = proceessParts(
+      expression
+        .replace(/[()]/g, "")
+        .split(expression_bullder)
+        .map((t) => t.trim())
+        .filter((t) => t.length > 0)
+    );
+    expression_status.push(...parts);
+  }
+
+  return expression_status;
+}
+
+export function countParenthesis(expression: string): number[] {
+  return [
+    expression.match(/(\()/g)?.length || 0,
+    expression.match(/(\))/g)?.length || 0,
+  ];
+}
+
+export function splitOnFirstEqualSign(s: string): string[] {
+  const index = s.indexOf("=");
+  return index !== -1 ? [s.slice(0, index), s.slice(index + 1)] : [s];
+}
+
+export function addAdditionPartToUIQuery(
+  filterStringParts: string[][]
+): string[][] {
+  if (filterStringParts.length === 1 && filterStringParts[0][0].length === 0) {
+    return [["--ADD--"]];
+  } else {
+    return [
+      ["--ADD--"],
+      ...filterStringParts.flatMap((item) => [item, ["--ADD--"]]),
+    ];
+  }
+}

--- a/app/components/index.ts
+++ b/app/components/index.ts
@@ -36,3 +36,4 @@ export { AnalysisPortals } from "./Entity/components/AnalysisPortals/analysisPor
 export { GridPaperSection } from "./Layout/components/Detail/components/Section/section.styles";
 export { Branding } from "./Layout/components/Footer/components/Branding/branding";
 export { AnalyzeGenome } from "./Table/components/TableCell/components/AnalyzeGenome/analyzeGenome";
+export { QueryBuilder } from "./Entity/components/QueryBuilder/queryBuilder";

--- a/catalog/output/runReadFields.json
+++ b/catalog/output/runReadFields.json
@@ -1,0 +1,790 @@
+[
+  {
+    "description": "starting paranthesis",
+    "name": "(",
+    "type": "expression"
+  },
+  {
+    "description": "ending paranthesis",
+    "name": ")",
+    "type": "expression"
+  },
+  {
+    "description": "GCF/GCA accession id",
+    "name": "accession",
+    "type": "string"
+  },
+  {
+    "description": "Age when the sample was taken",
+    "name": "age",
+    "type": "text"
+  },
+  {
+    "description": "Altitude (m)",
+    "name": "altitude",
+    "type": "number"
+  },
+  {
+    "description": "AND statment",
+    "name": "AND",
+    "type": "expression"
+  },
+  {
+    "description": "Quality of assembly",
+    "name": "assembly_quality",
+    "type": "text"
+  },
+  {
+    "description": "Assembly software",
+    "name": "assembly_software",
+    "type": "text"
+  },
+  {
+    "description": "number of base pairs",
+    "name": "base_count",
+    "type": "number"
+  },
+  {
+    "description": "Binning software",
+    "name": "binning_software",
+    "type": "text"
+  },
+  {
+    "description": "identifier for biological material including institute and collection code",
+    "name": "bio_material",
+    "type": "text"
+  },
+  {
+    "description": "text",
+    "name": "bisulfite_protocol"
+  },
+  {
+    "description": "Report the major environmental system the sample or specimen came from. The system(s) identified should have a coarse spatial grain, to provide the general environmental context of where the sampling was done (e.g. in the desert or a rainforest). We recommend using subclasses of EnvO’s biome class: http://purl.obolibrary.org/obo/ENVO_00000428. EnvO documentation about how to use the field: https://github.com/EnvironmentOntology/envo/wiki/Using-ENVO-with-MIxS.",
+    "name": "broad_scale_environmental_context",
+    "type": "text"
+  },
+  {
+    "description": "broker name",
+    "name": "broker_name",
+    "type": "controlled value"
+  },
+  {
+    "description": "Link to the protocol for CAGE-seq experiments",
+    "name": "cage_protocol",
+    "type": "text"
+  },
+  {
+    "description": "cell line from which the sample was obtained",
+    "name": "cell_line",
+    "type": "text"
+  },
+  {
+    "description": "cell type from which the sample was obtained",
+    "name": "cell_type",
+    "type": "text"
+  },
+  {
+    "description": "Submitting center",
+    "name": "center_name",
+    "type": "text"
+  },
+  {
+    "description": "ENA metadata reporting standard used to register the biosample (Checklist used)",
+    "name": "checklist",
+    "type": "controlled value"
+  },
+  {
+    "description": "text",
+    "name": "chip_ab_provider"
+  },
+  {
+    "description": "text",
+    "name": "chip_protocol"
+  },
+  {
+    "description": "Chip target",
+    "name": "chip_target",
+    "type": "text"
+  },
+  {
+    "description": "name of the person who collected the specimen",
+    "name": "collected_by",
+    "type": "text"
+  },
+  {
+    "description": "Completeness score (%)",
+    "name": "completeness_score",
+    "type": "number"
+  },
+  {
+    "description": "Contamination score (%)",
+    "name": "contamination_score",
+    "type": "number"
+  },
+  {
+    "description": "Control experiment",
+    "name": "control_experiment",
+    "type": "text"
+  },
+  {
+    "description": "locality of sample isolation: country names, oceans or seas, followed by regions and localities",
+    "name": "country",
+    "type": "text"
+  },
+  {
+    "description": "cultivar (cultivated variety) of plant from which sample was obtained",
+    "name": "cultivar",
+    "type": "text"
+  },
+  {
+    "description": "identifier for the sample culture including institute and collection code",
+    "name": "culture_collection",
+    "type": "text"
+  },
+  {
+    "description": "DCC datahub name",
+    "name": "datahub",
+    "type": "controlled value"
+  },
+  {
+    "description": "brief sequence description",
+    "name": "description",
+    "type": "text"
+  },
+  {
+    "description": "sample obtained from an organism in a specific developmental stage",
+    "name": "dev_stage",
+    "type": "text"
+  },
+  {
+    "description": "Disease associated with the sample",
+    "name": "disease",
+    "type": "text"
+  },
+  {
+    "description": "text",
+    "name": "dnase_protocol"
+  },
+  {
+    "description": "a population within a given species displaying traits that reflect adaptation to a local habitat",
+    "name": "ecotype",
+    "type": "text"
+  },
+  {
+    "description": "Elevation (m)",
+    "name": "elevation",
+    "type": "number"
+  },
+  {
+    "description": "Environment (Biome)",
+    "name": "environment_biome",
+    "type": "text"
+  },
+  {
+    "description": "Environment (Feature)",
+    "name": "environment_feature",
+    "type": "text"
+  },
+  {
+    "description": "Environment (Material)",
+    "name": "environment_material",
+    "type": "text"
+  },
+  {
+    "description": "Report the environmental material(s) immediately surrounding the sample or specimen at the time of sampling. We recommend using subclasses of 'environmental material' (http://purl.obolibrary.org/obo/ENVO_00010483). EnvO documentation about how to use the field: https://github.com/EnvironmentOntology/envo/wiki/Using-ENVO-with-MIxS . Terms from other OBO ontologies are permissible as long as they reference mass/volume nouns (e.g. air, water, blood) and not discrete, countable entities (e.g. a tree, a leaf, a table top).",
+    "name": "environmental_medium",
+    "type": "text"
+  },
+  {
+    "description": "identifies sequences derived by direct molecular isolation from an environmental DNA sample",
+    "name": "environmental_sample",
+    "type": "boolean"
+  },
+  {
+    "description": "experiment accession number",
+    "name": "experiment_accession",
+    "type": "text"
+  },
+  {
+    "description": "submitter's name for the experiment",
+    "name": "experiment_alias",
+    "type": "text"
+  },
+  {
+    "description": "text",
+    "name": "experiment_target"
+  },
+  {
+    "description": "brief experiment title",
+    "name": "experiment_title",
+    "type": "text"
+  },
+  {
+    "description": "variable aspects of the experimental design",
+    "name": "experimental_factor",
+    "type": "text"
+  },
+  {
+    "description": "text",
+    "name": "experimental_protocol"
+  },
+  {
+    "description": "text",
+    "name": "extraction_protocol"
+  },
+  {
+    "description": "Library Selection for FAANG WGS/BS-Seq experiments",
+    "name": "faang_library_selection",
+    "type": "text"
+  },
+  {
+    "description": "date when first created",
+    "name": "first_created",
+    "type": "date"
+  },
+  {
+    "description": "date when made public",
+    "name": "first_public",
+    "type": "date"
+  },
+  {
+    "description": "the sample is an unrearranged molecule that was inherited from the parental germline",
+    "name": "germline",
+    "type": "boolean"
+  },
+  {
+    "description": "Link to Hi-C Protocol for FAANG experiments",
+    "name": "hi_c_protocol",
+    "type": "text"
+  },
+  {
+    "description": "natural (as opposed to laboratory) host to the organism from which sample was obtained",
+    "name": "host",
+    "type": "text"
+  },
+  {
+    "description": "name of body site from where the sample was obtained",
+    "name": "host_body_site",
+    "type": "text"
+  },
+  {
+    "description": "genotype of host",
+    "name": "host_genotype",
+    "type": "text"
+  },
+  {
+    "description": "whether or not subject is gravid, including date due or date post-conception where applicable",
+    "name": "host_gravidity",
+    "type": "text"
+  },
+  {
+    "description": "literature reference giving growth conditions of the host",
+    "name": "host_growth_conditions",
+    "type": "text"
+  },
+  {
+    "description": "phenotype of host",
+    "name": "host_phenotype",
+    "type": "text"
+  },
+  {
+    "description": "Scientific name of the natural (as opposed to laboratory) host to the organism from which sample was obtained",
+    "name": "host_scientific_name",
+    "type": "text"
+  },
+  {
+    "description": "physical sex of the host",
+    "name": "host_sex",
+    "type": "controlled value"
+  },
+  {
+    "description": "condition of host (eg. diseased or healthy)",
+    "name": "host_status",
+    "type": "text"
+  },
+  {
+    "description": "NCBI taxon id of the host",
+    "name": "host_tax_id",
+    "type": "number"
+  },
+  {
+    "description": "name of the taxonomist who identified the specimen",
+    "name": "identified_by",
+    "type": "text"
+  },
+  {
+    "description": "instrument model used in sequencing experiment",
+    "name": "instrument_model",
+    "type": "text"
+  },
+  {
+    "description": "instrument platform used in sequencing experiment",
+    "name": "instrument_platform",
+    "type": "controlled value"
+  },
+  {
+    "description": "the study type targeted by the sequencing",
+    "name": "investigation_type",
+    "type": "text"
+  },
+  {
+    "description": "individual isolate from which sample was obtained",
+    "name": "isolate",
+    "type": "text"
+  },
+  {
+    "description": "describes the physical, environmental and/or local geographical source of the sample",
+    "name": "isolation_source",
+    "type": "text"
+  },
+  {
+    "description": "date when last updated",
+    "name": "last_updated",
+    "type": "date"
+  },
+  {
+    "description": "Library construction protocol",
+    "name": "library_construction_protocol",
+    "type": "text"
+  },
+  {
+    "description": "text",
+    "name": "library_gen_protocol"
+  },
+  {
+    "description": "sequencing library layout",
+    "name": "library_layout",
+    "type": "controlled value"
+  },
+  {
+    "description": "number",
+    "name": "library_max_fragment_size"
+  },
+  {
+    "description": "number",
+    "name": "library_min_fragment_size"
+  },
+  {
+    "description": "sequencing library name",
+    "name": "library_name",
+    "type": "text"
+  },
+  {
+    "description": "text",
+    "name": "library_pcr_isolation_protocol"
+  },
+  {
+    "description": "text",
+    "name": "library_prep_date"
+  },
+  {
+    "description": "text",
+    "name": "library_prep_date_format"
+  },
+  {
+    "description": "number",
+    "name": "library_prep_latitude"
+  },
+  {
+    "description": "text",
+    "name": "library_prep_location"
+  },
+  {
+    "description": "number",
+    "name": "library_prep_longitude"
+  },
+  {
+    "description": "method used to select or enrich the material being sequenced",
+    "name": "library_selection",
+    "type": "text"
+  },
+  {
+    "description": "source material being sequenced",
+    "name": "library_source",
+    "type": "controlled value"
+  },
+  {
+    "description": "sequencing technique intended for the library",
+    "name": "library_strategy",
+    "type": "text"
+  },
+  {
+    "description": "Report the entity or entities which are in the sample or specimen’s local vicinity and which you believe have significant causal influences on your sample or specimen. We recommend using EnvO terms which are of smaller spatial grain than your entry for \"broad-scale environmental context\". Terms, such as anatomical sites, from other OBO Library ontologies which interoperate with EnvO (e.g. UBERON) are accepted in this field. EnvO documentation about how to use the field: https://github.com/EnvironmentOntology/envo/wiki/Using-ENVO-with-MIxS.",
+    "name": "local_environmental_context",
+    "type": "text"
+  },
+  {
+    "description": "geographic location of isolation of the sample",
+    "name": "location",
+    "type": "latlon"
+  },
+  {
+    "description": "latlon",
+    "name": "location_end"
+  },
+  {
+    "description": "latlon",
+    "name": "location_start"
+  },
+  {
+    "description": "geographical origin of the sample as defined by the marine region",
+    "name": "marine_region",
+    "type": "text"
+  },
+  {
+    "description": "mating type of the organism from which the sequence was obtained",
+    "name": "mating_type",
+    "type": "text"
+  },
+  {
+    "description": "NCBI metadata reporting standard used to register the biosample (Package used)",
+    "name": "ncbi_reporting_standard",
+    "type": "controlled value"
+  },
+  {
+    "description": "average fragmentation size of paired reads",
+    "name": "nominal_length",
+    "type": "number"
+  },
+  {
+    "description": "standard deviation of fragmentation size of paired reads",
+    "name": "nominal_sdev",
+    "type": "number"
+  },
+  {
+    "description": "OR statement",
+    "name": "OR",
+    "type": "expression"
+  },
+  {
+    "description": "text",
+    "name": "pcr_isolation_protocol"
+  },
+  {
+    "description": "name of the project within which the sequencing was organized",
+    "name": "project_name",
+    "type": "text"
+  },
+  {
+    "description": "the protocol used to produce the sample",
+    "name": "protocol_label",
+    "type": "text"
+  },
+  {
+    "description": "number of reads",
+    "name": "read_count",
+    "type": "number"
+  },
+  {
+    "description": "text",
+    "name": "read_strand"
+  },
+  {
+    "description": "text",
+    "name": "restriction_enzyme"
+  },
+  {
+    "description": "The DNA sequence targeted by the restrict enzyme",
+    "name": "restriction_enzyme_target_sequence",
+    "type": "text"
+  },
+  {
+    "description": "text",
+    "name": "restriction_site"
+  },
+  {
+    "description": "number",
+    "name": "rna_integrity_num"
+  },
+  {
+    "description": "text",
+    "name": "rna_prep_3_protocol"
+  },
+  {
+    "description": "text",
+    "name": "rna_prep_5_protocol"
+  },
+  {
+    "description": "number",
+    "name": "rna_purity_230_ratio"
+  },
+  {
+    "description": "number",
+    "name": "rna_purity_280_ratio"
+  },
+  {
+    "description": "text",
+    "name": "rt_prep_protocol"
+  },
+  {
+    "description": "accession number",
+    "name": "run_accession",
+    "type": "text"
+  },
+  {
+    "description": "submitter's name for the run",
+    "name": "run_alias",
+    "type": "text"
+  },
+  {
+    "description": "Salinity (PSU)",
+    "name": "salinity",
+    "type": "number"
+  },
+  {
+    "description": "sample accession number",
+    "name": "sample_accession",
+    "type": "text"
+  },
+  {
+    "description": "submitter's name for the sample",
+    "name": "sample_alias",
+    "type": "text"
+  },
+  {
+    "description": "Sample capture status",
+    "name": "sample_capture_status",
+    "type": "text"
+  },
+  {
+    "description": "the method or device employed for collecting the sample",
+    "name": "sample_collection",
+    "type": "text"
+  },
+  {
+    "description": "detailed sample description",
+    "name": "sample_description",
+    "type": "text"
+  },
+  {
+    "description": "sample material label",
+    "name": "sample_material",
+    "type": "text"
+  },
+  {
+    "description": "number",
+    "name": "sample_prep_interval"
+  },
+  {
+    "description": "text",
+    "name": "sample_prep_interval_units"
+  },
+  {
+    "description": "text",
+    "name": "sample_storage"
+  },
+  {
+    "description": "text",
+    "name": "sample_storage_processing"
+  },
+  {
+    "description": "brief sample title",
+    "name": "sample_title",
+    "type": "text"
+  },
+  {
+    "description": "the activity within which this sample was collected",
+    "name": "sampling_campaign",
+    "type": "text"
+  },
+  {
+    "description": "the large infrastructure from which this sample was collected",
+    "name": "sampling_platform",
+    "type": "text"
+  },
+  {
+    "description": "the site/station where this sample was collection",
+    "name": "sampling_site",
+    "type": "text"
+  },
+  {
+    "description": "scientific name of an organism",
+    "name": "scientific_name",
+    "type": "text"
+  },
+  {
+    "description": "Secondary project",
+    "name": "secondary_project",
+    "type": "text"
+  },
+  {
+    "description": "secondary sample accession number",
+    "name": "secondary_sample_accession",
+    "type": "text"
+  },
+  {
+    "description": "secondary study accession number",
+    "name": "secondary_study_accession",
+    "type": "text"
+  },
+  {
+    "description": "text",
+    "name": "sequencing_date"
+  },
+  {
+    "description": "text",
+    "name": "sequencing_date_format"
+  },
+  {
+    "description": "text",
+    "name": "sequencing_location"
+  },
+  {
+    "description": "number",
+    "name": "sequencing_longitude"
+  },
+  {
+    "description": "sequencing method used",
+    "name": "sequencing_method",
+    "type": "text"
+  },
+  {
+    "description": "The catalog from which the sequencing primer library was purchased",
+    "name": "sequencing_primer_catalog",
+    "type": "text"
+  },
+  {
+    "description": "The lot identifier of the sequencing primer library",
+    "name": "sequencing_primer_lot",
+    "type": "text"
+  },
+  {
+    "description": "The name of the company, laboratory or person that provided the sequencing primer library",
+    "name": "sequencing_primer_provider",
+    "type": "text"
+  },
+  {
+    "description": "serological variety of a species characterized by its antigenic properties",
+    "name": "serotype",
+    "type": "text"
+  },
+  {
+    "description": "serological variety of a species (usually a prokaryote) characterized by its antigenic properties",
+    "name": "serovar",
+    "type": "text"
+  },
+  {
+    "description": "sex of the organism from which the sample was obtained",
+    "name": "sex",
+    "type": "controlled value"
+  },
+  {
+    "description": "identifier for the sample culture including institute and collection code",
+    "name": "specimen_voucher",
+    "type": "text"
+  },
+  {
+    "description": "Status",
+    "name": "status",
+    "type": "number"
+  },
+  {
+    "description": "strain from which sample was obtained",
+    "name": "strain",
+    "type": "text"
+  },
+  {
+    "description": "study accession number",
+    "name": "study_accession",
+    "type": "text"
+  },
+  {
+    "description": "submitter's name for the study",
+    "name": "study_alias",
+    "type": "text"
+  },
+  {
+    "description": "brief sequencing study description",
+    "name": "study_title",
+    "type": "text"
+  },
+  {
+    "description": "name of sub-species of organism from which sample was obtained",
+    "name": "sub_species",
+    "type": "text"
+  },
+  {
+    "description": "name or identifier of a genetically or otherwise modified strain from which sample was obtained",
+    "name": "sub_strain",
+    "type": "text"
+  },
+  {
+    "description": "submission accession number",
+    "name": "submission_accession",
+    "type": "text"
+  },
+  {
+    "description": "Submission tool",
+    "name": "submission_tool",
+    "type": "text"
+  },
+  {
+    "description": "format of submitted reads",
+    "name": "submitted_format",
+    "type": "text"
+  },
+  {
+    "description": "physical sex of the host",
+    "name": "submitted_host_sex",
+    "type": "text"
+  },
+  {
+    "description": "MD5 checksum of submitted files",
+    "name": "submitted_md5",
+    "type": "text"
+  },
+  {
+    "description": "submitted FASTQ read type",
+    "name": "submitted_read_type",
+    "type": "list"
+  },
+  {
+    "description": "Classification Tags",
+    "name": "tag",
+    "type": "controlled value"
+  },
+  {
+    "description": "targeted gene or locus name for marker gene studies",
+    "name": "target_gene",
+    "type": "text"
+  },
+  {
+    "description": "NCBI taxonomic classification",
+    "name": "tax_id",
+    "type": "taxonomy"
+  },
+  {
+    "description": "Taxonomic classification",
+    "name": "taxonomic_classification",
+    "type": "text"
+  },
+  {
+    "description": "Taxonomic identity marker",
+    "name": "taxonomic_identity_marker",
+    "type": "text"
+  },
+  {
+    "description": "Temperature (C)",
+    "name": "temperature",
+    "type": "number"
+  },
+  {
+    "description": "tissue library from which sample was obtained",
+    "name": "tissue_lib",
+    "type": "text"
+  },
+  {
+    "description": "tissue type from which the sample was obtained",
+    "name": "tissue_type",
+    "type": "text"
+  },
+  {
+    "description": "text",
+    "name": "transposase_protocol"
+  },
+  {
+    "description": "variety (varietas, a formal Linnaean rank) of organism from which sample was derived",
+    "name": "variety",
+    "type": "text"
+  }
+]


### PR DESCRIPTION
Here’s the first version of a query builder component for constructing valid query strings for the ENA REST API. It still needs some refinements:

1. The UI could use some styling improvements.
2. The dialog for selecting fields and setting values needs:
   1. Styling enhancements.
   2. Support for displaying field descriptions.
   3. The ability to provide example values or validation hints.
3.  would be great if we could extend `runReadFields.json` with information about possible values and improved type validation.

# Screenshoot
  ![querybuilder20250318](https://github.com/user-attachments/assets/65d1c389-3e26-46de-8647-fd6e6b1d273c)

# Example of usage 

## viewBuilders.ts
```javascript
export const buildGenomePrimaryData = (
  genome: BRCDataCatalogGenome
): ComponentProps<typeof C.QueryBuilder> => {
  return {
    initialQuery: `tax_id=${genome.speciesTaxonomyId}`,
    onQueryChange: (query: string): void => {
      console.log(query);
    },
  };
};
```

## analysisMethodMainColumn.ts
```javascript
export const mainColumn: ComponentsConfig = [
  {
    children: [
      {
        component: C.AnalysisMethodsCatalog,
        viewBuilder: V.buildGenomeAnalysisMethods,
      },
      {
        component: C.QueryBuilder,
        viewBuilder: V.buildGenomePrimaryData,
      },
    ],
    component: C.BackPageContentMainColumn,
  },
];
```

# onQueryChange
Implement a version of `onQueryChange` that will query our API to fetch data and populate a table with this information.