### PR TITLE
feat: optionally hide 'coming soon' for empty workflow categories (#442)

### DIFF
--- a/app/apis/catalog/brc-analytics-catalog/common/entities.ts
+++ b/app/apis/catalog/brc-analytics-catalog/common/entities.ts
@@ -79,6 +79,7 @@ export interface WorkflowCategory {
   category: string;
   description: string;
   name: string;
+  showComingSoon: boolean;
   workflows: Workflow[];
 }
 

--- a/app/components/Entity/components/AnalysisMethodsCatalog/analysisMethodsCatalog.tsx
+++ b/app/components/Entity/components/AnalysisMethodsCatalog/analysisMethodsCatalog.tsx
@@ -11,12 +11,19 @@ export const AnalysisMethodsCatalog = ({ assembly }: Props): JSX.Element => {
   const {
     query: { entityId },
   } = useRouter();
+
   return (
     <Fragment>
       {workflows.map((workflowCategory) => {
         const compatibleWorkflows = workflowCategory.workflows.filter(
           (workflow) => workflowIsCompatibleWithAssembly(workflow, assembly)
         );
+        if (
+          compatibleWorkflows.length === 0 &&
+          !workflowCategory.showComingSoon
+        ) {
+          return null;
+        }
         return (
           <AnalysisMethod
             entityId={entityId as string}

--- a/catalog/build/py/generated_schema/schema.py
+++ b/catalog/build/py/generated_schema/schema.py
@@ -176,6 +176,7 @@ class WorkflowCategory(ConfiguredBaseModel):
     category: WorkflowCategoryId = Field(default=..., description="""The ID of the workflow category.""", json_schema_extra = { "linkml_meta": {'alias': 'category', 'domain_of': ['WorkflowCategory']} })
     name: str = Field(default=..., description="""The display name of the workflow category.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['WorkflowCategory']} })
     description: str = Field(default=..., description="""The description of the workflow category.""", json_schema_extra = { "linkml_meta": {'alias': 'description', 'domain_of': ['WorkflowCategory']} })
+    show_coming_soon: bool = Field(default=..., description="""Whether to show 'Coming Soon' for the workflow category when it is not available.""", json_schema_extra = { "linkml_meta": {'alias': 'show_coming_soon', 'domain_of': ['WorkflowCategory']} })
 
 
 class Workflows(ConfiguredBaseModel):

--- a/catalog/build/ts/build-catalog.ts
+++ b/catalog/build/ts/build-catalog.ts
@@ -168,10 +168,11 @@ async function buildWorkflows(): Promise<WorkflowCategory[]> {
 
   const workflowCategories: WorkflowCategory[] =
     sourceWorkflowCategories.workflow_categories.map(
-      ({ category, description, name }) => ({
+      ({ category, description, name, show_coming_soon }) => ({
         category,
         description,
         name,
+        showComingSoon: show_coming_soon,
         workflows: [],
       })
     );

--- a/catalog/output/workflows.json
+++ b/catalog/output/workflows.json
@@ -3,6 +3,7 @@
     "category": "VARIANT_CALLING",
     "description": "Identify nucleotide polymorphisms and short indels from Illumina and Element data.",
     "name": "Variant calling",
+    "showComingSoon": true,
     "workflows": [
       {
         "parameters": [
@@ -82,6 +83,7 @@
     "category": "TRANSCRIPTOMICS",
     "description": "Analyze bulk or single-cell RNA seq data using a variety of approaches.",
     "name": "Transcriptomics",
+    "showComingSoon": true,
     "workflows": [
       {
         "parameters": [
@@ -157,6 +159,7 @@
     "category": "REGULATION",
     "description": "Workflows for the analysis of ChIP-seq, ATAC-Seq, and beyond.",
     "name": "Regulation",
+    "showComingSoon": true,
     "workflows": [
       {
         "parameters": [
@@ -224,6 +227,7 @@
     "category": "CONSENSUS_SEQUENCES",
     "description": "Build consensus sequences for related isolates.",
     "name": "Consensus sequences",
+    "showComingSoon": false,
     "workflows": [
       {
         "parameters": [
@@ -244,18 +248,21 @@
     "category": "ASSEMBLY",
     "description": "Assemble prokaryotic and eukaryotic genomes sequenced with a variety of technologies.",
     "name": "Assembly",
+    "showComingSoon": false,
     "workflows": []
   },
   {
     "category": "GENOME_COMPARISONS",
     "description": "Workflows for creation of pairwise and multiple genome alignments.",
     "name": "Genome comparisons",
+    "showComingSoon": true,
     "workflows": []
   },
   {
     "category": "PROTEIN_FOLDING",
     "description": "Analysis of protein folding using the ColabFold framework.",
     "name": "Protein folding",
+    "showComingSoon": true,
     "workflows": []
   }
 ]

--- a/catalog/schema/generated/schema.ts
+++ b/catalog/schema/generated/schema.ts
@@ -99,6 +99,8 @@ export interface WorkflowCategory {
     name: string,
     /** The description of the workflow category. */
     description: string,
+    /** Whether to show 'Coming Soon' for the workflow category when it is not available. */
+    show_coming_soon: boolean,
 }
 
 

--- a/catalog/schema/generated/workflow_categories.json
+++ b/catalog/schema/generated/workflow_categories.json
@@ -33,12 +33,17 @@
                 "name": {
                     "description": "The display name of the workflow category.",
                     "type": "string"
+                },
+                "show_coming_soon": {
+                    "description": "Whether to show 'Coming Soon' for the workflow category when it is not available.",
+                    "type": "boolean"
                 }
             },
             "required": [
                 "category",
                 "name",
-                "description"
+                "description",
+                "show_coming_soon"
             ],
             "title": "WorkflowCategory",
             "type": "object"

--- a/catalog/schema/workflow_categories.yaml
+++ b/catalog/schema/workflow_categories.yaml
@@ -35,3 +35,7 @@ classes:
         description: The description of the workflow category.
         required: true
         range: string
+      show_coming_soon:
+        description: Whether to show 'Coming Soon' for the workflow category when it is not available.
+        required: true
+        range: boolean

--- a/catalog/source/workflow_categories.yml
+++ b/catalog/source/workflow_categories.yml
@@ -2,27 +2,34 @@ workflow_categories:
   - category: "VARIANT_CALLING"
     name: "Variant calling"
     description: "Identify nucleotide polymorphisms and short indels from Illumina and Element data."
+    show_coming_soon: true
 
   - category: "TRANSCRIPTOMICS"
     name: "Transcriptomics"
     description: "Analyze bulk or single-cell RNA seq data using a variety of approaches."
+    show_coming_soon: true
 
   - category: "REGULATION"
     name: "Regulation"
     description: "Workflows for the analysis of ChIP-seq, ATAC-Seq, and beyond."
+    show_coming_soon: true
 
   - category: "CONSENSUS_SEQUENCES"
     name: "Consensus sequences"
     description: "Build consensus sequences for related isolates."
+    show_coming_soon: false
 
   - category: "ASSEMBLY"
     name: "Assembly"
     description: "Assemble prokaryotic and eukaryotic genomes sequenced with a variety of technologies."
+    show_coming_soon: false
 
   - category: "GENOME_COMPARISONS"
     name: "Genome comparisons"
     description: "Workflows for creation of pairwise and multiple genome alignments."
+    show_coming_soon: true
 
   - category: "PROTEIN_FOLDING"
     name: "Protein folding"
     description: "Analysis of protein folding using the ColabFold framework."
+    show_coming_soon: true


### PR DESCRIPTION
resolves #442 

sets 'assembly' and 'consensus sequence' to not show as coming soon when an assembly doesnt have a compatible workflow

open to better names for the new 'show_coming_soon' if someone has one