### PR TITLE
feat: add stub of SANGER_READ_RUN workflow parameter variable (#459)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -58,7 +58,8 @@
     "jsdoc/check-alignment": "error",
     "jsdoc/check-param-names": "error",
     "react-hooks/exhaustive-deps": "error",
-    "sonarjs/redundant-type-aliases": "warn"
+    "sonarjs/redundant-type-aliases": "warn",
+    "sonarjs/todo-tag": "warn"
   },
   "overrides": [
     {

--- a/app/utils/galaxy-api.ts
+++ b/app/utils/galaxy-api.ts
@@ -95,6 +95,8 @@ function paramVariableToRequestValue(
             url: geneModelUrl,
           }
         : null;
+    case WORKFLOW_PARAMETER_VARIABLE.SANGER_READ_RUN:
+      return null; // TODO pass in necessary information and generate an actual value for this
   }
 }
 

--- a/app/utils/galaxy-api.ts
+++ b/app/utils/galaxy-api.ts
@@ -75,7 +75,9 @@ function paramVariableToRequestValue(
   variable: WORKFLOW_PARAMETER_VARIABLE,
   geneModelUrl: string | null,
   referenceGenome: string
-): WorkflowLandingsBodyRequestState[string] | undefined {
+): WorkflowLandingsBodyRequestState[string] | null {
+  // Because this `switch` has no default case, and the function doesn't allow `undefined` as a return type,
+  // we ensure through TypeScript that all possible variables are handled.
   switch (variable) {
     case WORKFLOW_PARAMETER_VARIABLE.ASSEMBLY_ID:
       return referenceGenome;
@@ -92,7 +94,7 @@ function paramVariableToRequestValue(
             src: "url",
             url: geneModelUrl,
           }
-        : undefined;
+        : null;
   }
 }
 
@@ -120,7 +122,7 @@ function getWorkflowLandingsRequestState(
         geneModelUrl,
         referenceGenome
       );
-      if (value !== undefined) result[key] = value;
+      if (value !== null) result[key] = value;
     }
   }
   return result;

--- a/catalog/build/py/generated_schema/schema.py
+++ b/catalog/build/py/generated_schema/schema.py
@@ -105,6 +105,7 @@ class WorkflowParameterVariable(str, Enum):
     ASSEMBLY_ID = "ASSEMBLY_ID"
     ASSEMBLY_FASTA_URL = "ASSEMBLY_FASTA_URL"
     GENE_MODEL_URL = "GENE_MODEL_URL"
+    SANGER_READ_RUN = "SANGER_READ_RUN"
 
 
 class WorkflowPloidy(str, Enum):

--- a/catalog/schema/enums/workflow_parameter_variable.yaml
+++ b/catalog/schema/enums/workflow_parameter_variable.yaml
@@ -8,3 +8,4 @@ enums:
       ASSEMBLY_ID:
       ASSEMBLY_FASTA_URL:
       GENE_MODEL_URL:
+      SANGER_READ_RUN:

--- a/catalog/schema/generated/schema.ts
+++ b/catalog/schema/generated/schema.ts
@@ -29,6 +29,7 @@ export enum WorkflowParameterVariable {
     ASSEMBLY_ID = "ASSEMBLY_ID",
     ASSEMBLY_FASTA_URL = "ASSEMBLY_FASTA_URL",
     GENE_MODEL_URL = "GENE_MODEL_URL",
+    SANGER_READ_RUN = "SANGER_READ_RUN",
 };
 /**
 * Possible ploidies supported by workflows.

--- a/catalog/schema/generated/workflows.json
+++ b/catalog/schema/generated/workflows.json
@@ -131,7 +131,8 @@
             "enum": [
                 "ASSEMBLY_ID",
                 "ASSEMBLY_FASTA_URL",
-                "GENE_MODEL_URL"
+                "GENE_MODEL_URL",
+                "SANGER_READ_RUN"
             ],
             "title": "WorkflowParameterVariable",
             "type": "string"


### PR DESCRIPTION
Very minimal (just adding a new value to the enum and a placeholder case to the switch statement), but I think this is all that's useful to do unless we have a specific plan for what the relevant input and output to `paramVariableToRequestValue` needs to look like

Hopefully I spelled "Sanger" correctly -- I think it's misspelled in the ticket