### PR TITLE
feat: add outbreak schema and initial outbreaks (#450)

### DIFF
--- a/catalog/build/py/generated_schema/schema.py
+++ b/catalog/build/py/generated_schema/schema.py
@@ -92,7 +92,7 @@ class OutbreakPriority(str, Enum):
     HIGHEST = "HIGHEST"
     CRITICAL = "CRITICAL"
     HIGH = "HIGH"
-    MODERATE_HIGH = "MODERATE-HIGH"
+    MODERATE_HIGH = "MODERATE_HIGH"
     MODERATE = "MODERATE"
 
 

--- a/catalog/build/py/generated_schema/schema.py
+++ b/catalog/build/py/generated_schema/schema.py
@@ -203,6 +203,7 @@ class Outbreak(ConfiguredBaseModel):
     resources: List[OutbreakResource] = Field(default=..., description="""The resources associated with the outbreak.""", json_schema_extra = { "linkml_meta": {'alias': 'resources', 'domain_of': ['Outbreak']} })
     description: MarkdownFileReference = Field(default=..., description="""The description of the outbreak.""", json_schema_extra = { "linkml_meta": {'alias': 'description', 'domain_of': ['Outbreak', 'WorkflowCategory']} })
     active: bool = Field(default=..., description="""Determines if outbreak should be included, as they presumably change over time.""", json_schema_extra = { "linkml_meta": {'alias': 'active', 'domain_of': ['Outbreak', 'Workflow']} })
+    highlight_descendant_taxonomy_ids: Optional[List[int]] = Field(default=None, description="""Taxonomy IDs of child taxa that should be highlighted.""", json_schema_extra = { "linkml_meta": {'alias': 'highlight_descendant_taxonomy_ids', 'domain_of': ['Outbreak']} })
 
 
 class OutbreakResource(ConfiguredBaseModel):

--- a/catalog/build/py/generated_schema/schema.py
+++ b/catalog/build/py/generated_schema/schema.py
@@ -68,6 +68,7 @@ linkml_meta = LinkMLMeta({'default_prefix': 'https://github.com/galaxyproject/br
      'id': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/schema.yaml#',
      'imports': ['./assemblies',
                  './organisms',
+                 './outbreaks',
                  './workflow_categories',
                  './workflows'],
      'name': 'schema',
@@ -82,6 +83,29 @@ class OrganismPloidy(str, Enum):
     DIPLOID = "DIPLOID"
     HAPLOID = "HAPLOID"
     POLYPLOID = "POLYPLOID"
+
+
+class OutbreakPriority(str, Enum):
+    """
+    Possible priorities of an outbreak.
+    """
+    HIGHEST = "HIGHEST"
+    CRITICAL = "CRITICAL"
+    HIGH = "HIGH"
+    MODERATE_HIGH = "MODERATE-HIGH"
+    MODERATE = "MODERATE"
+
+
+class OutbreakResourceType(str, Enum):
+    """
+    Possible types of an outbreak resource.
+    """
+    PUBLICATION = "PUBLICATION"
+    REFERENCE = "REFERENCE"
+    NEWS = "NEWS"
+    WORKFLOW = "WORKFLOW"
+    DATA = "DATA"
+    OTHER = "OTHER"
 
 
 class WorkflowCategoryId(str, Enum):
@@ -154,8 +178,63 @@ class Organism(ConfiguredBaseModel):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/organisms.yaml#'})
 
-    taxonomy_id: int = Field(default=..., description="""The organism's NCBI taxonomy ID.""", json_schema_extra = { "linkml_meta": {'alias': 'taxonomy_id', 'domain_of': ['Organism', 'Workflow']} })
+    taxonomy_id: int = Field(default=..., description="""The organism's NCBI taxonomy ID.""", json_schema_extra = { "linkml_meta": {'alias': 'taxonomy_id', 'domain_of': ['Organism', 'Outbreak', 'Workflow']} })
     ploidy: List[OrganismPloidy] = Field(default=..., description="""The ploidies that the organism may have.""", json_schema_extra = { "linkml_meta": {'alias': 'ploidy', 'domain_of': ['Organism', 'Workflow']} })
+
+
+class Outbreaks(ConfiguredBaseModel):
+    """
+    Object containing list of outbreaks.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/outbreaks.yaml#',
+         'tree_root': True})
+
+    outbreaks: List[Outbreak] = Field(default=..., description="""List of outbreaks.""", json_schema_extra = { "linkml_meta": {'alias': 'outbreaks', 'domain_of': ['Outbreaks']} })
+
+
+class Outbreak(ConfiguredBaseModel):
+    """
+    Info for an outbreak.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/outbreaks.yaml#'})
+
+    taxonomy_id: int = Field(default=..., description="""The outbreak's NCBI taxonomy ID.""", json_schema_extra = { "linkml_meta": {'alias': 'taxonomy_id', 'domain_of': ['Organism', 'Outbreak', 'Workflow']} })
+    priority: OutbreakPriority = Field(default=..., description="""The priority of the outbreak.""", json_schema_extra = { "linkml_meta": {'alias': 'priority', 'domain_of': ['Outbreak']} })
+    resources: List[OutbreakResource] = Field(default=..., description="""The resources associated with the outbreak.""", json_schema_extra = { "linkml_meta": {'alias': 'resources', 'domain_of': ['Outbreak']} })
+    description: MarkdownFileReference = Field(default=..., description="""The description of the outbreak.""", json_schema_extra = { "linkml_meta": {'alias': 'description', 'domain_of': ['Outbreak', 'WorkflowCategory']} })
+    active: bool = Field(default=..., description="""Determines if outbreak should be included, as they presumably change over time.""", json_schema_extra = { "linkml_meta": {'alias': 'active', 'domain_of': ['Outbreak', 'Workflow']} })
+
+
+class OutbreakResource(ConfiguredBaseModel):
+    """
+    A resource associated with an outbreak.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/outbreaks.yaml#'})
+
+    url: str = Field(default=..., description="""The URL of the resource.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['OutbreakResource', 'WorkflowUrlSpec']} })
+    title: str = Field(default=..., description="""The title of the resource.""", json_schema_extra = { "linkml_meta": {'alias': 'title', 'domain_of': ['OutbreakResource']} })
+    type: OutbreakResourceType = Field(default=..., description="""The type of the resource.""", json_schema_extra = { "linkml_meta": {'alias': 'type', 'domain_of': ['OutbreakResource']} })
+
+
+class MarkdownFileReference(ConfiguredBaseModel):
+    """
+    A reference to a markdown file
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/outbreaks.yaml#'})
+
+    path: str = Field(default=..., description="""Path to the markdown file""", json_schema_extra = { "linkml_meta": {'alias': 'path', 'domain_of': ['MarkdownFileReference']} })
+
+    @field_validator('path')
+    def pattern_path(cls, v):
+        pattern=re.compile(r".*\.md$")
+        if isinstance(v,list):
+            for element in v:
+                if isinstance(v, str) and not pattern.match(element):
+                    raise ValueError(f"Invalid path format: {element}")
+        elif isinstance(v,str):
+            if not pattern.match(v):
+                raise ValueError(f"Invalid path format: {v}")
+        return v
 
 
 class WorkflowCategories(ConfiguredBaseModel):
@@ -176,7 +255,7 @@ class WorkflowCategory(ConfiguredBaseModel):
 
     category: WorkflowCategoryId = Field(default=..., description="""The ID of the workflow category.""", json_schema_extra = { "linkml_meta": {'alias': 'category', 'domain_of': ['WorkflowCategory']} })
     name: str = Field(default=..., description="""The display name of the workflow category.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['WorkflowCategory']} })
-    description: str = Field(default=..., description="""The description of the workflow category.""", json_schema_extra = { "linkml_meta": {'alias': 'description', 'domain_of': ['WorkflowCategory']} })
+    description: str = Field(default=..., description="""The description of the workflow category.""", json_schema_extra = { "linkml_meta": {'alias': 'description', 'domain_of': ['Outbreak', 'WorkflowCategory']} })
     show_coming_soon: bool = Field(default=..., description="""Whether to show 'Coming Soon' for the workflow category when it is not available.""", json_schema_extra = { "linkml_meta": {'alias': 'show_coming_soon', 'domain_of': ['WorkflowCategory']} })
 
 
@@ -201,9 +280,9 @@ class Workflow(ConfiguredBaseModel):
     workflow_name: str = Field(default=..., description="""The display name of the workflow.""", json_schema_extra = { "linkml_meta": {'alias': 'workflow_name', 'domain_of': ['Workflow']} })
     workflow_description: str = Field(default=..., description="""The description of the workflow.""", json_schema_extra = { "linkml_meta": {'alias': 'workflow_description', 'domain_of': ['Workflow']} })
     ploidy: WorkflowPloidy = Field(default=..., description="""The ploidy supported by the workflow.""", json_schema_extra = { "linkml_meta": {'alias': 'ploidy', 'domain_of': ['Organism', 'Workflow']} })
-    taxonomy_id: Optional[int] = Field(default=None, description="""The NCBI ID of the taxon supported by the workflow.""", json_schema_extra = { "linkml_meta": {'alias': 'taxonomy_id', 'domain_of': ['Organism', 'Workflow']} })
+    taxonomy_id: Optional[int] = Field(default=None, description="""The NCBI ID of the taxon supported by the workflow.""", json_schema_extra = { "linkml_meta": {'alias': 'taxonomy_id', 'domain_of': ['Organism', 'Outbreak', 'Workflow']} })
     parameters: List[WorkflowParameter] = Field(default=..., description="""The parameters of the workflow.""", json_schema_extra = { "linkml_meta": {'alias': 'parameters', 'domain_of': ['Workflow']} })
-    active: bool = Field(default=..., description="""Determines if workflow should be included.""", json_schema_extra = { "linkml_meta": {'alias': 'active', 'domain_of': ['Workflow']} })
+    active: bool = Field(default=..., description="""Determines if workflow should be included.""", json_schema_extra = { "linkml_meta": {'alias': 'active', 'domain_of': ['Outbreak', 'Workflow']} })
 
 
 class WorkflowParameter(ConfiguredBaseModel):
@@ -226,7 +305,7 @@ class WorkflowUrlSpec(ConfiguredBaseModel):
 
     ext: str = Field(default=..., description="""The file extension of the URL.""", json_schema_extra = { "linkml_meta": {'alias': 'ext', 'domain_of': ['WorkflowUrlSpec']} })
     src: str = Field(default=..., description="""The source type, typically 'url'.""", json_schema_extra = { "linkml_meta": {'alias': 'src', 'domain_of': ['WorkflowUrlSpec']} })
-    url: str = Field(default=..., description="""The URL to the resource.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['WorkflowUrlSpec']} })
+    url: str = Field(default=..., description="""The URL to the resource.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['OutbreakResource', 'WorkflowUrlSpec']} })
 
 
 # Model rebuild
@@ -235,6 +314,10 @@ Assemblies.model_rebuild()
 Assembly.model_rebuild()
 Organisms.model_rebuild()
 Organism.model_rebuild()
+Outbreaks.model_rebuild()
+Outbreak.model_rebuild()
+OutbreakResource.model_rebuild()
+MarkdownFileReference.model_rebuild()
 WorkflowCategories.model_rebuild()
 WorkflowCategory.model_rebuild()
 Workflows.model_rebuild()

--- a/catalog/schema/enums/outbreak_priority.yaml
+++ b/catalog/schema/enums/outbreak_priority.yaml
@@ -1,0 +1,12 @@
+id: https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/enums/outbreak_priority.yaml#
+name: enums_outbreak_priority
+
+enums:
+  OutbreakPriority:
+    description: Possible priorities of an outbreak.
+    permissible_values:
+      HIGHEST:
+      CRITICAL:
+      HIGH:
+      MODERATE-HIGH:
+      MODERATE:

--- a/catalog/schema/enums/outbreak_priority.yaml
+++ b/catalog/schema/enums/outbreak_priority.yaml
@@ -8,5 +8,5 @@ enums:
       HIGHEST:
       CRITICAL:
       HIGH:
-      MODERATE-HIGH:
+      MODERATE_HIGH:
       MODERATE:

--- a/catalog/schema/enums/outbreak_resource_type.yaml
+++ b/catalog/schema/enums/outbreak_resource_type.yaml
@@ -1,0 +1,13 @@
+id: https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/enums/outbreak_resource_type.yaml#
+name: enums_outbreak_resource_type
+
+enums:
+  OutbreakResourceType:
+    description: Possible types of an outbreak resource.
+    permissible_values:
+      - PUBLICATION:
+      - REFERENCE:
+      - NEWS:
+      - WORKFLOW:
+      - DATA:
+      - OTHER:

--- a/catalog/schema/enums/outbreak_resource_type.yaml
+++ b/catalog/schema/enums/outbreak_resource_type.yaml
@@ -5,9 +5,9 @@ enums:
   OutbreakResourceType:
     description: Possible types of an outbreak resource.
     permissible_values:
-      - PUBLICATION:
-      - REFERENCE:
-      - NEWS:
-      - WORKFLOW:
-      - DATA:
-      - OTHER:
+      PUBLICATION:
+      REFERENCE:
+      NEWS:
+      WORKFLOW:
+      DATA:
+      OTHER:

--- a/catalog/schema/generated/outbreaks.json
+++ b/catalog/schema/generated/outbreaks.json
@@ -1,0 +1,156 @@
+{
+    "$defs": {
+        "MarkdownFileReference": {
+            "additionalProperties": false,
+            "description": "A reference to a markdown file",
+            "properties": {
+                "path": {
+                    "description": "Path to the markdown file",
+                    "pattern": ".*\\.md$",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "path"
+            ],
+            "title": "MarkdownFileReference",
+            "type": "object"
+        },
+        "Outbreak": {
+            "additionalProperties": false,
+            "description": "Info for an outbreak.",
+            "properties": {
+                "active": {
+                    "description": "Determines if outbreak should be included, as they presumably change over time.",
+                    "type": "boolean"
+                },
+                "description": {
+                    "$ref": "#/$defs/MarkdownFileReference",
+                    "description": "The description of the outbreak."
+                },
+                "highlight_descendant_taxonomy_ids": {
+                    "description": "Taxonomy IDs of child taxa that should be highlighted.",
+                    "items": {
+                        "type": "integer"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "priority": {
+                    "$ref": "#/$defs/OutbreakPriority",
+                    "description": "The priority of the outbreak."
+                },
+                "resources": {
+                    "description": "The resources associated with the outbreak.",
+                    "items": {
+                        "$ref": "#/$defs/OutbreakResource"
+                    },
+                    "type": "array"
+                },
+                "taxonomy_id": {
+                    "description": "The outbreak's NCBI taxonomy ID.",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "taxonomy_id",
+                "priority",
+                "resources",
+                "description",
+                "active"
+            ],
+            "title": "Outbreak",
+            "type": "object"
+        },
+        "OutbreakPriority": {
+            "description": "Possible priorities of an outbreak.",
+            "enum": [
+                "HIGHEST",
+                "CRITICAL",
+                "HIGH",
+                "MODERATE-HIGH",
+                "MODERATE"
+            ],
+            "title": "OutbreakPriority",
+            "type": "string"
+        },
+        "OutbreakResource": {
+            "additionalProperties": false,
+            "description": "A resource associated with an outbreak.",
+            "properties": {
+                "title": {
+                    "description": "The title of the resource.",
+                    "type": "string"
+                },
+                "type": {
+                    "$ref": "#/$defs/OutbreakResourceType",
+                    "description": "The type of the resource."
+                },
+                "url": {
+                    "description": "The URL of the resource.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "url",
+                "title",
+                "type"
+            ],
+            "title": "OutbreakResource",
+            "type": "object"
+        },
+        "OutbreakResourceType": {
+            "description": "Possible types of an outbreak resource.",
+            "enum": [
+                "PUBLICATION",
+                "REFERENCE",
+                "NEWS",
+                "WORKFLOW",
+                "DATA",
+                "OTHER"
+            ],
+            "title": "OutbreakResourceType",
+            "type": "string"
+        },
+        "Outbreaks": {
+            "additionalProperties": false,
+            "description": "Object containing list of outbreaks.",
+            "properties": {
+                "outbreaks": {
+                    "description": "List of outbreaks.",
+                    "items": {
+                        "$ref": "#/$defs/Outbreak"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "outbreaks"
+            ],
+            "title": "Outbreaks",
+            "type": "object"
+        }
+    },
+    "$id": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/outbreaks.yaml#",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "additionalProperties": true,
+    "description": "Object containing list of outbreaks.",
+    "metamodel_version": "1.7.0",
+    "properties": {
+        "outbreaks": {
+            "description": "List of outbreaks.",
+            "items": {
+                "$ref": "#/$defs/Outbreak"
+            },
+            "type": "array"
+        }
+    },
+    "required": [
+        "outbreaks"
+    ],
+    "title": "outbreaks",
+    "type": "object",
+    "version": null
+}

--- a/catalog/schema/generated/outbreaks.json
+++ b/catalog/schema/generated/outbreaks.json
@@ -70,7 +70,7 @@
                 "HIGHEST",
                 "CRITICAL",
                 "HIGH",
-                "MODERATE-HIGH",
+                "MODERATE_HIGH",
                 "MODERATE"
             ],
             "title": "OutbreakPriority",

--- a/catalog/schema/generated/schema.ts
+++ b/catalog/schema/generated/schema.ts
@@ -127,6 +127,8 @@ export interface Outbreak {
     description: MarkdownFileReference,
     /** Determines if outbreak should be included, as they presumably change over time. */
     active: boolean,
+    /** Taxonomy IDs of child taxa that should be highlighted. */
+    highlight_descendant_taxonomy_ids?: number[] | null,
 }
 
 

--- a/catalog/schema/generated/schema.ts
+++ b/catalog/schema/generated/schema.ts
@@ -15,7 +15,7 @@ export enum OutbreakPriority {
     HIGHEST = "HIGHEST",
     CRITICAL = "CRITICAL",
     HIGH = "HIGH",
-    MODERATE_HIGH = "MODERATE-HIGH",
+    MODERATE_HIGH = "MODERATE_HIGH",
     MODERATE = "MODERATE",
 };
 /**

--- a/catalog/schema/generated/schema.ts
+++ b/catalog/schema/generated/schema.ts
@@ -8,6 +8,29 @@ export enum OrganismPloidy {
     POLYPLOID = "POLYPLOID",
 };
 /**
+* Possible priorities of an outbreak.
+*/
+export enum OutbreakPriority {
+    
+    HIGHEST = "HIGHEST",
+    CRITICAL = "CRITICAL",
+    HIGH = "HIGH",
+    MODERATE_HIGH = "MODERATE-HIGH",
+    MODERATE = "MODERATE",
+};
+/**
+* Possible types of an outbreak resource.
+*/
+export enum OutbreakResourceType {
+    
+    PUBLICATION = "PUBLICATION",
+    REFERENCE = "REFERENCE",
+    NEWS = "NEWS",
+    WORKFLOW = "WORKFLOW",
+    DATA = "DATA",
+    OTHER = "OTHER",
+};
+/**
 * Set of IDs of workflow categories.
 */
 export enum WorkflowCategoryId {
@@ -78,6 +101,54 @@ export interface Organism {
     taxonomy_id: number,
     /** The ploidies that the organism may have. */
     ploidy: OrganismPloidy[],
+}
+
+
+/**
+ * Object containing list of outbreaks.
+ */
+export interface Outbreaks {
+    /** List of outbreaks. */
+    outbreaks: Outbreak[],
+}
+
+
+/**
+ * Info for an outbreak.
+ */
+export interface Outbreak {
+    /** The outbreak's NCBI taxonomy ID. */
+    taxonomy_id: number,
+    /** The priority of the outbreak. */
+    priority: OutbreakPriority,
+    /** The resources associated with the outbreak. */
+    resources: OutbreakResource[],
+    /** The description of the outbreak. */
+    description: MarkdownFileReference,
+    /** Determines if outbreak should be included, as they presumably change over time. */
+    active: boolean,
+}
+
+
+/**
+ * A resource associated with an outbreak.
+ */
+export interface OutbreakResource {
+    /** The URL of the resource. */
+    url: string,
+    /** The title of the resource. */
+    title: string,
+    /** The type of the resource. */
+    type: OutbreakResourceType,
+}
+
+
+/**
+ * A reference to a markdown file
+ */
+export interface MarkdownFileReference {
+    /** Path to the markdown file */
+    path: string,
 }
 
 

--- a/catalog/schema/outbreaks.yaml
+++ b/catalog/schema/outbreaks.yaml
@@ -45,6 +45,11 @@ classes:
         description: Determines if outbreak should be included, as they presumably change over time.
         required: true
         range: boolean
+      highlight_descendant_taxonomy_ids:
+        description: Taxonomy IDs of child taxa that should be highlighted.
+        required: false
+        multivalued: true
+        range: integer
 
   OutbreakResource:
     description: A resource associated with an outbreak.

--- a/catalog/schema/outbreaks.yaml
+++ b/catalog/schema/outbreaks.yaml
@@ -1,0 +1,72 @@
+id: https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/outbreaks.yaml#
+name: outbreaks
+description: Schema for source outbreak info.
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+
+imports:
+  - linkml:types
+  - enums/outbreak_priority
+  - enums/outbreak_resource_type
+
+classes:
+  Outbreaks:
+    description: Object containing list of outbreaks.
+    tree_root: true
+    attributes:
+      outbreaks:
+        description: List of outbreaks.
+        required: true
+        multivalued: true
+        range: Outbreak
+
+  Outbreak:
+    description: Info for an outbreak.
+    attributes:
+      taxonomy_id:
+        description: The outbreak's NCBI taxonomy ID.
+        required: true
+        range: integer
+      priority:
+        description: The priority of the outbreak.
+        required: true
+        range: OutbreakPriority
+      resources:
+        description: The resources associated with the outbreak.
+        required: true
+        multivalued: true
+        range: OutbreakResource
+      description:
+        description: The description of the outbreak.
+        required: true
+        range: MarkdownFileReference
+      active:
+        description: Determines if outbreak should be included, as they presumably change over time.
+        required: true
+        range: boolean
+
+  OutbreakResource:
+    description: A resource associated with an outbreak.
+    attributes:
+      url:
+        description: The URL of the resource.
+        required: true
+        range: string
+      title:
+        description: The title of the resource.
+        required: true
+        range: string
+      type:
+        description: The type of the resource.
+        required: true
+        range: OutbreakResourceType
+
+  MarkdownFileReference:
+    description: A reference to a markdown file
+    attributes:
+      path:
+        description: Path to the markdown file
+        required: true
+        range: string
+        pattern: '.*\.md$'

--- a/catalog/schema/schema.yaml
+++ b/catalog/schema/schema.yaml
@@ -8,5 +8,6 @@ prefixes:
 imports:
   - ./assemblies
   - ./organisms
+  - ./outbreaks
   - ./workflow_categories
   - ./workflows

--- a/catalog/schema/scripts/source-file-schema-names.sh
+++ b/catalog/schema/scripts/source-file-schema-names.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-export SOURCE_FILE_SCHEMA_NAMES=(assemblies organisms workflow_categories workflows)
+export SOURCE_FILE_SCHEMA_NAMES=(assemblies organisms workflow_categories workflows outbreaks)

--- a/catalog/source/outbreaks.yml
+++ b/catalog/source/outbreaks.yml
@@ -181,3 +181,32 @@ outbreaks:
       - title: "FungiDB | Genome Info and Stats"
         url: "https://fungidb.org/fungidb/app/search/organism/GenomeDataTypes/result?filterTerm=Histoplasma%20capsulatum"
         type: REFERENCE
+
+  - taxonomy_id: 5807
+    priority: MODERATE-HIGH
+    active: true
+    description:
+      path: outbreaks/cryptosporidium_parvum.md
+    resources:
+      - title: "CryptoDB | Genome Info and Stats"
+        url: "https://cryptodb.org/cryptodb/app/search/organism/GenomeDataTypes/result?filterTerm=Cryptosporidium%20parvum"
+        type: REFERENCE
+      - title: "CDC | Cryptosporidiosis Outbreaks — United States, 2009–2017"
+        url: "https://www.cdc.gov/mmwr/volumes/68/wr/mm6825a3.htm"
+        type: REFERENCE
+
+  - taxonomy_id: 5763
+    priority: MODERATE
+    active: true
+    description:
+      path: outbreaks/naegleria_fowleri.md
+    resources:
+      - title: "Oxford Academic | Fatal Naegleria fowleri Infection Acquired in Minnesota"
+        url: "https://academic.oup.com/cid/article-abstract/54/6/805/290592"
+        type: PUBLICATION
+      - title: "PLOS Pathogens | Enolase Inhibitors Research"
+        url: "https://journals.plos.org/plospathogens/article?id=10.1371/journal.ppat.1012412"
+        type: PUBLICATION
+      - title: "AmoebaDB | Genome Info and Stats"
+        url: "https://amoebadb.org/amoeba/app/search/organism/GenomeDataTypes/result?filterTerm=Naegleria%20fowleri"
+        type: REFERENCE

--- a/catalog/source/outbreaks.yml
+++ b/catalog/source/outbreaks.yml
@@ -76,3 +76,41 @@ outbreaks:
       - title: "Galaxy tutorial: Pox virus genome analysis from tiled-amplicon sequencing data"
         url: "https://gxy.io/GTN:T00347"
         type: REFERENCE
+
+  - taxonomy_id: 1773
+    priority: CRITICAL
+    active: true
+    description:
+      path: outbreaks/tuberculosis.md
+    resources:
+      - title: "WHO | Tuberculosis Fact Sheet"
+        url: "https://www.who.int/news-room/fact-sheets/detail/tuberculosis"
+        type: REFERENCE
+      - title: "BV-BRC: Mycobacterium tuberculosis"
+        url: "https://www.bv-brc.org/view/Taxonomy/1773"
+        type: REFERENCE
+      - title: "NIH | TB Research Information"
+        url: "https://www.niaid.nih.gov/diseases-conditions/tuberculosis"
+        type: REFERENCE
+      - title: "WHO | Tuberculosis Deaths and Disease Increase During the COVID-19 Pandemic"
+        url: "https://www.who.int/news/item/27-10-2022-tuberculosis-deaths-and-disease-increase-during-the-covid-19-pandemic"
+        type: REFERENCE
+
+  - taxonomy_id: 5833
+    priority: HIGH
+    active: true
+    description:
+      path: outbreaks/malaria.md
+    resources:
+      - title: "WHO | Malaria Fact Sheet"
+        url: "https://www.who.int/news-room/fact-sheets/detail/malaria"
+        type: REFERENCE
+      - title: "NIH | Malaria Research Information"
+        url: "https://www.niaid.nih.gov/diseases-conditions/malaria"
+        type: REFERENCE
+      - title: "PlasmoDB: Genome Info and Stats"
+        url: "https://plasmodb.org/plasmo/app/search/organism/GenomeDataTypes/result?filterTerm=Plasmodium%20falciparum"
+        type: REFERENCE
+      - title: "Global malaria predictors at a localized scale"
+        url: "https://pubmed.ncbi.nlm.nih.gov/38045403/"
+        type: PUBLICATION

--- a/catalog/source/outbreaks.yml
+++ b/catalog/source/outbreaks.yml
@@ -108,9 +108,76 @@ outbreaks:
       - title: "NIH | Malaria Research Information"
         url: "https://www.niaid.nih.gov/diseases-conditions/malaria"
         type: REFERENCE
-      - title: "PlasmoDB: Genome Info and Stats"
+      - title: "PlasmoDB | Genome Info and Stats"
         url: "https://plasmodb.org/plasmo/app/search/organism/GenomeDataTypes/result?filterTerm=Plasmodium%20falciparum"
         type: REFERENCE
       - title: "Global malaria predictors at a localized scale"
         url: "https://pubmed.ncbi.nlm.nih.gov/38045403/"
         type: PUBLICATION
+
+  - taxonomy_id: 498019
+    priority: HIGH
+    active: true
+    description:
+      path: outbreaks/candida_auris.md
+    resources:
+      - title: "UC Davis Health | Candida auris Warning"
+        url: "https://health.ucdavis.edu/news/headlines/cdc-issues-warning-about-increase-of-drug-resistant-candida-auris-infections/2023/03"
+        type: OTHER
+      - title: "FungiDB | Genome Info and Stats"
+        url: "https://fungidb.org/fungidb/app/search/organism/GenomeDataTypes/result?filterTerm=Candida%20auris"
+        type: REFERENCE
+      - title: "NIH | Fungal Disease-Specific Research"
+        url: "https://www.niaid.nih.gov/diseases-conditions/fungal-disease-specific-research"
+        type: REFERENCE
+
+  - taxonomy_id: 5207
+    priority: HIGH
+    active: true
+    description:
+      path: outbreaks/cryptococcus_neoformans.md
+    resources:
+      - title: "DNDi | On World Meningitis Day, too many people are dying of cryptococcal meningitis in Africa"
+        url: "https://dndi.org/viewpoints/2024/on-world-meningitis-day-too-many-people-are-dying-of-cryptococcal-meningitis-in-africa/"
+        type: OTHER
+      - title: "Cryptococcal meningitis causes 15% of AIDS-related deaths globally"
+        url: "https://www.healio.com/news/infectious-disease/20170512/cryptococcal-meningitis-causes-15-of-aidsrelated-deaths-globally"
+        type: OTHER
+      - title: "The WHO fungal priority pathogens list as a game-changer"
+        url: "https://www.cidrap.umn.edu/antimicrobial-stewardship/who-fungal-priority-pathogens-list-game-changer"
+        type: OTHER
+      - title: "FungiDB | Genome Info and Stats"
+        url: "https://fungidb.org/fungidb/app/search/organism/GenomeDataTypes/result?filterTerm=Cryptococcus%20neoformans"
+        type: REFERENCE
+      - title: "NIH | Fungal Disease-Specific Research"
+        url: "https://www.niaid.nih.gov/diseases-conditions/fungal-disease-specific-research"
+        type: REFERENCE
+
+  - taxonomy_id: 199306
+    priority: HIGH
+    active: true
+    description:
+      path: outbreaks/coccidioides_posadasii.md
+    resources:
+      - title: "CDPH | Valley Fever Information"
+        url: "https://www.cdph.ca.gov/Programs/CID/DCDC/pages/Coccidioidomycosis.aspx"
+        type: REFERENCE
+      - title: "NIAID | Fungal Disease-Specific Research"
+        url: "https://www.niaid.nih.gov/diseases-conditions/fungal-disease-specific-research"
+        type: REFERENCE
+      - title: "FungiDB | Genome Info and Stats"
+        url: "https://fungidb.org/fungidb/app/search/organism/GenomeDataTypes/result?filterTerm=Coccidioides%20posadasii"
+        type: REFERENCE
+
+  - taxonomy_id: 5037
+    priority: HIGH
+    active: true
+    description:
+      path: outbreaks/histoplasma_capsulatum.md
+    resources:
+      - title: "NIH | Fungal Disease-Specific Research"
+        url: "https://www.niaid.nih.gov/diseases-conditions/fungal-disease-specific-research"
+        type: REFERENCE
+      - title: "FungiDB | Genome Info and Stats"
+        url: "https://fungidb.org/fungidb/app/search/organism/GenomeDataTypes/result?filterTerm=Histoplasma%20capsulatum"
+        type: REFERENCE

--- a/catalog/source/outbreaks.yml
+++ b/catalog/source/outbreaks.yml
@@ -53,7 +53,7 @@ outbreaks:
         type: REFERENCE
 
   - taxonomy_id: 10244
-    priority: MODERATE-HIGH
+    priority: MODERATE_HIGH
     active: true
     description:
       path: outbreaks/mpox.md
@@ -183,7 +183,7 @@ outbreaks:
         type: REFERENCE
 
   - taxonomy_id: 5807
-    priority: MODERATE-HIGH
+    priority: MODERATE_HIGH
     active: true
     description:
       path: outbreaks/cryptosporidium_parvum.md

--- a/catalog/source/outbreaks.yml
+++ b/catalog/source/outbreaks.yml
@@ -1,0 +1,78 @@
+outbreaks:
+  - taxonomy_id: 11320
+    priority: MODERATE
+    active: true
+    description:
+      path: outbreaks/avian_influenza.md
+    resources:
+      - title: "CDC: Current U.S. H5 bird flu situation summary"
+        url: "https://www.cdc.gov/bird-flu/situation-summary/?CDC_AAref_Val=https://www.cdc.gov/flu/avianflu/avian-flu-summary.htm"
+        type: REFERENCE
+      - title: "NCBI BioProject: U.S. H5N1 clade 2.3.4.4b immediate releases related to emergence and spread in dairy cattle"
+        url: "https://www.ncbi.nlm.nih.gov/bioproject/PRJNA1102327"
+        type: DATA
+      - title: "NCBI Virus: Worldwide H5N1 sequence data since 2024"
+        url: "https://www.ncbi.nlm.nih.gov/labs/virus/vssi/#/virus?SeqType_s=Nucleotide&VirusLineage_ss=Influenza%20A%20virus,%20taxid:11320&CollectionDate_dr=2024-01-01%20TO%202030-01-01&Serotype_s=H5N1"
+        type: DATA
+      - title: "Galaxy workflow for analysis of avian influenza sequencing data"
+        url: "https://iwc.galaxyproject.org/workflow/%23workflow%2Fgithub.com%2Fiwc-workflows%2Finfluenza-isolates-consensus-and-subtyping%2Fmain/"
+        type: WORKFLOW
+      - title: "Galaxy tutorial: Avian influenza viral strain analysis from gene segment sequencing data"
+        url: "https://gxy.io/GTN:T00308"
+        type: REFERENCE
+      - title: "BV-BRC: Influenza A virus Taxonomy View"
+        url: "https://www.bv-brc.org/view/Taxonomy/11320"
+        type: REFERENCE
+
+  - taxonomy_id: 2697049
+    priority: HIGHEST
+    active: true
+    description:
+      path: outbreaks/covid19.md
+    resources:
+      - title: "WHO: Coronavirus disease (COVID-19) situation reports"
+        url: "https://www.who.int/emergencies/diseases/novel-coronavirus-2019/situation-reports"
+        type: REFERENCE
+      - title: "WHO COVID-19 Fact Sheet"
+        url: "https://www.who.int/news-room/fact-sheets/detail/coronavirus-disease-(covid-19)"
+        type: REFERENCE
+      - title: "BV-BRC: SARS-CoV-2 variants and lineages information"
+        url: "https://www.bv-brc.org/outbreaks/SARSCoV2/"
+        type: REFERENCE
+      - title: "CoVariants: Explore the SARS-CoV-2 lineage spectrum"
+        url: "https://covariants.org/"
+        type: REFERENCE
+      - title: "covSPECTRUM: In-depth exploration of public SARS-CoV-2 molecular surveillance data"
+        url: "https://open.cov-spectrum.org/explore/United%20States/AllSamples/Past6M"
+        type: REFERENCE
+      - title: "Galaxy workflows for analysis of SARS-CoV-2 sequencing data"
+        url: "https://galaxyproject.org/projects/covid19/workflows/"
+        type: WORKFLOW
+      - title: "Galaxy tutorial: Mutation calling, viral genome reconstruction and lineage/clade assignment from SARS-CoV-2 sequencing data"
+        url: "https://gxy.io/GTN:T00316"
+        type: REFERENCE
+
+  - taxonomy_id: 10244
+    priority: MODERATE-HIGH
+    active: true
+    description:
+      path: outbreaks/mpox.md
+    resources:
+      - title: "WHO | Mpox outbreak: global trends"
+        url: "https://worldhealthorg.shinyapps.io/mpx_global/"
+        type: REFERENCE
+      - title: "NIH Mpox Research Agenda"
+        url: "https://www.niaid.nih.gov/news-events/nih-releases-mpox-research-agenda"
+        type: REFERENCE
+      - title: "Yale Medicine Mpox Fact Sheet"
+        url: "https://www.yalemedicine.org/conditions/monkeypox-mpox"
+        type: REFERENCE
+      - title: "Galaxy workflows for analysis of Mpox virus sequencing data"
+        url: "https://galaxyproject.org/projects/mpxv/"
+        type: WORKFLOW
+      - title: "Galaxy workflow for pox virus Illumina half-genome amplicon sequencing data"
+        url: "https://iwc.galaxyproject.org/workflow/%23workflow%2Fgithub.com%2Fiwc-workflows%2Fpox-virus-amplicon%2Fmain/"
+        type: WORKFLOW
+      - title: "Galaxy tutorial: Pox virus genome analysis from tiled-amplicon sequencing data"
+        url: "https://gxy.io/GTN:T00347"
+        type: REFERENCE

--- a/catalog/source/outbreaks.yml
+++ b/catalog/source/outbreaks.yml
@@ -210,3 +210,59 @@ outbreaks:
       - title: "AmoebaDB | Genome Info and Stats"
         url: "https://amoebadb.org/amoeba/app/search/organism/GenomeDataTypes/result?filterTerm=Naegleria%20fowleri"
         type: REFERENCE
+
+  - taxonomy_id: 5052
+    priority: HIGH
+    active: true
+    description:
+      path: outbreaks/aspergillus.md
+    highlight_descendant_taxonomy_ids:
+      - 746128
+      - 5059
+    resources:
+      - title: "NIAID | Fungal Disease-Specific Research"
+        url: "https://www.niaid.nih.gov/diseases-conditions/fungal-disease-specific-research"
+        type: REFERENCE
+      - title: "FungiDB | Genome Info and Stats"
+        url: "https://fungidb.org/fungidb/app/search/organism/GenomeDataTypes/result?filterTerm=Aspergillus"
+        type: REFERENCE
+
+  - taxonomy_id: 38574
+    priority: MODERATE
+    active: true
+    description:
+      path: outbreaks/leishmania.md
+    highlight_descendant_taxonomy_ids:
+      - 5661
+      - 5671
+    resources:
+      - title: "WHO | Leishmaniasis Information"
+        url: "https://www.who.int/news-room/fact-sheets/detail/leishmaniasis"
+        type: REFERENCE
+      - title: "NIAID | Leishmaniasis Research"
+        url: "https://www.niaid.nih.gov/diseases-conditions/leishmaniasis"
+        type: REFERENCE
+      - title: "TriTrypDB | Genome Info and Stats"
+        url: "https://tritrypdb.org/tritrypdb/app/search/organism/GenomeDataTypes/result?filterTerm=Leishmania%20donovani"
+        type: REFERENCE
+
+  - taxonomy_id: 4827
+    priority: MODERATE
+    active: true
+    description:
+      path: outbreaks/mucorales.md
+    highlight_descendant_taxonomy_ids:
+      - 688394
+      - 42458
+      - 58291
+      - 936053
+    resources:
+      - title: "WHO | COVID-19 associated mucormycosis"
+        url: "https://www.who.int/india/home/emergencies/coronavirus-disease-(covid-19)/mucormycosis"
+        type: REFERENCE
+      - title: "PubMed | Epidemiology and Pathophysiology of COVID-19-Associated Mucormycosis"
+        url: "https://pmc.ncbi.nlm.nih.gov/articles/PMC8375614/"
+        type: PUBLICATION
+      - title: "FungiDB | Genome Info and Stats"
+        url: "https://fungidb.org/fungidb/app/search/organism/GenomeDataTypes/result?filterTerm=Mucor"
+        type: REFERENCE

--- a/catalog/source/outbreaks/aspergillus.md
+++ b/catalog/source/outbreaks/aspergillus.md
@@ -1,0 +1,13 @@
+# Aspergillus
+
+## Overview
+
+Aspergillus molds are ubiquitous in the environment and cause a range of diseases, from allergies to deadly invasive infections. A. fumigatus is the most common cause of invasive aspergillosis in immunosuppressed patients.
+
+## Impact
+
+- **Public Health**: ~1.5 million deaths annually from serious fungal diseases, including invasive aspergillosis
+- **Mortality**: Invasive pulmonary aspergillosis has ~50% mortality even with treatment
+- **Geography**: Global distribution with significant impact in healthcare settings
+- **Antifungal Resistance**: Emerging resistance complicates treatment
+- **Toxins**: A. flavus produces aflatoxin, contributing to liver cancer risk

--- a/catalog/source/outbreaks/avian_influenza.md
+++ b/catalog/source/outbreaks/avian_influenza.md
@@ -1,4 +1,4 @@
-# Avian Influenza
+# Influenza A
 
 ## Overview
 

--- a/catalog/source/outbreaks/avian_influenza.md
+++ b/catalog/source/outbreaks/avian_influenza.md
@@ -1,0 +1,12 @@
+# Avian Influenza
+
+## Overview
+
+Avian influenza, commonly known as bird flu, is a highly contagious viral disease that primarily affects birds but can occasionally infect humans. The virus belongs to the influenza A family and is classified into different subtypes based on surface proteins (H and N).
+
+## Impact
+
+- **Wildlife**: Significant mortality in wild bird populations
+- **Agriculture**: Severe economic impacts on poultry industries
+- **Human Health**: While human infections are rare, they can be severe when they occur
+- **Trade**: Restrictions on international poultry trade

--- a/catalog/source/outbreaks/candida_auris.md
+++ b/catalog/source/outbreaks/candida_auris.md
@@ -1,0 +1,13 @@
+# Candida auris
+
+## Overview
+
+Candida auris is an emerging multidrug-resistant fungus that has caused hospital outbreaks worldwide. Identified in 2009, it has spread to dozens of countries and is difficult to eradicate in healthcare settings.
+
+## Impact
+
+- **Public Health**: Rapidly increasing cases globally
+- **Healthcare**: Major infection control challenge in hospitals
+- **Mortality**: Over 1 in 3 patients with bloodstream infection die
+- **Drug Resistance**: Often resistant to multiple antifungal drugs
+- **Growth**: U.S. infections jumped from 173 in 2017 to 2,377 in 2022

--- a/catalog/source/outbreaks/coccidioides_posadasii.md
+++ b/catalog/source/outbreaks/coccidioides_posadasii.md
@@ -1,4 +1,4 @@
-# Coccidioides posadasii (Valley Fever)
+# Coccidioides posadasii
 
 ## Overview
 

--- a/catalog/source/outbreaks/coccidioides_posadasii.md
+++ b/catalog/source/outbreaks/coccidioides_posadasii.md
@@ -1,0 +1,13 @@
+# Coccidioides posadasii (Valley Fever)
+
+## Overview
+
+Coccidioides causes coccidioidomycosis, known as Valley Fever, a respiratory disease endemic in the arid Americas (southwestern US, parts of Latin America). Infection is acquired by inhaling airborne fungal spores from soil.
+
+## Impact
+
+- **Public Health**: Significant impact in endemic areas
+- **Geography**: Endemic in southwestern US and parts of Latin America
+- **Severity**: Can lead to severe pneumonia or disseminated disease
+- **Growth**: California cases tripled from 2014 to 2018 (7,000-9,000 cases annually)
+- **Climate Impact**: Range and incidence expanding due to climate change

--- a/catalog/source/outbreaks/covid19.md
+++ b/catalog/source/outbreaks/covid19.md
@@ -1,0 +1,14 @@
+# SARS-CoV-2
+
+## Overview
+
+This novel coronavirus emerged in late 2019 and caused a global pandemic with unprecedented impact. It has infected over 760 million people and caused roughly 6.9 million reported deaths worldwide as of 2023, making it one of the deadliest outbreaks in modern history.
+
+## Impact
+
+- **Public Health**: Global health crisis with millions of cases and deaths
+- **Healthcare**: Strained healthcare systems worldwide
+- **Economy**: Major economic disruptions and recessions
+- **Society**: Changes in social behavior and public gatherings
+- **Travel**: Severe restrictions on international travel
+- **Mortality**: Over 6.9 million reported deaths (2023)

--- a/catalog/source/outbreaks/cryptococcus_neoformans.md
+++ b/catalog/source/outbreaks/cryptococcus_neoformans.md
@@ -1,0 +1,13 @@
+# Cryptococcus neoformans
+
+## Overview
+
+Cryptococcus neoformans is a leading cause of deadly meningitis in immunocompromised individuals, especially those with advanced HIV/AIDS. It causes an estimated ~220,000 new cases of cryptococcal meningitis each year, resulting in about 181,000 deaths – roughly 15% of all AIDS-related deaths globally.
+
+## Impact
+
+- **Public Health**: Leading cause of meningitis in immunocompromised individuals
+- **Healthcare**: Significant burden on healthcare systems
+- **Mortality**: ~181,000 deaths annually
+- **HIV Impact**: Major cause of AIDS-related deaths
+- **Geography**: Highest burden in sub-Saharan Africa

--- a/catalog/source/outbreaks/cryptosporidium_parvum.md
+++ b/catalog/source/outbreaks/cryptosporidium_parvum.md
@@ -1,0 +1,13 @@
+# Cryptosporidium parvum
+
+## Overview
+
+Cryptosporidium is a protozoan parasite that causes diarrheal illness, which can be severe in young children and immunocompromised individuals. It spreads through waterborne transmission, with oocysts that are resistant to chlorine.
+
+## Impact
+
+- **Public Health**: Leading cause of waterborne diarrheal outbreaks in the U.S.
+- **Child Health**: Major contributor to child mortality and malnutrition
+- **Geography**: Global distribution with significant impact in developing regions
+- **Severity**: Can cause chronic, life-threatening diarrhea in immunocompromised individuals
+- **Treatment**: Limited treatment options (nitazoxanide with variable efficacy)

--- a/catalog/source/outbreaks/histoplasma_capsulatum.md
+++ b/catalog/source/outbreaks/histoplasma_capsulatum.md
@@ -1,4 +1,4 @@
-# Histoplasma capsulatum (Histoplasmosis)
+# Histoplasma capsulatum
 
 ## Overview
 

--- a/catalog/source/outbreaks/histoplasma_capsulatum.md
+++ b/catalog/source/outbreaks/histoplasma_capsulatum.md
@@ -1,0 +1,13 @@
+# Histoplasma capsulatum (Histoplasmosis)
+
+## Overview
+
+Histoplasma is a soil-based fungus (often associated with bird or bat droppings) that causes histoplasmosis when its spores are inhaled. It is endemic in parts of North America (Ohio/Mississippi River valleys), Latin America, Asia, and Africa.
+
+## Impact
+
+- **Geography**: Endemic in multiple continents
+- **Severity**: Can cause acute pulmonary infection or disseminated disease
+- **HIV Impact**: Major cause of death in HIV-positive patients
+- **Mortality**: 50-80% mortality in AIDS-associated cases without proper therapy
+- **Treatment**: Requires antifungal therapy like liposomal amphotericin B

--- a/catalog/source/outbreaks/leishmania.md
+++ b/catalog/source/outbreaks/leishmania.md
@@ -1,0 +1,13 @@
+# Leishmania donovani species complex
+
+## Overview
+
+Leishmania donovani complex causes visceral leishmaniasis (VL), the most severe form of leishmaniasis. Transmitted by sandfly bites, it affects poor, rural populations in South Asia, East Africa, and Brazil. WHO and NIAID prioritize VL as a neglected tropical disease, focusing on developing better drugs and vaccines. Despite being geographically limited, VL remains a deadly disease of poverty with high untreated fatality rates.
+
+## Impact
+
+- **Public Health**: ~50,000–90,000 new cases annually worldwide
+- **Geography**: Endemic in South Asia, East Africa, and Brazil
+- **Mortality**: Typically fatal if untreated
+- **Treatment**: Increasing reports of treatment failure in India
+- **Control**: Risk of resurgence if control measures lapse

--- a/catalog/source/outbreaks/malaria.md
+++ b/catalog/source/outbreaks/malaria.md
@@ -1,0 +1,13 @@
+# Malaria (Plasmodium falciparum)
+
+## Overview
+
+Plasmodium falciparum causes the most lethal form of malaria, a disease that remains a massive global burden especially in sub-Saharan Africa. In 2021, there were over 247 million malaria cases worldwide and about 619,000 deaths, mostly in young children.
+
+## Impact
+
+- **Public Health**: Leading cause of childhood mortality in endemic regions
+- **Healthcare**: Significant economic impacts
+- **Mortality**: ~619,000 deaths annually
+- **Geography**: Highest burden in sub-Saharan Africa
+- **Economic Impact**: Major economic burden in affected regions

--- a/catalog/source/outbreaks/mpox.md
+++ b/catalog/source/outbreaks/mpox.md
@@ -1,0 +1,13 @@
+# Mpox
+
+## Overview
+
+Mpox, formerly known as monkeypox, is a viral zoonotic disease caused by the mpox virus. Historically, it caused sporadic outbreaks in Central and West African countries. In 2022, it emerged as a large multinational outbreak, growing from a handful of cases to over 80,000 confirmed cases across more than 100 countries by late 2022. This prompted the WHO to declare a Public Health Emergency.
+
+## Impact
+
+- **Public Health**: Global outbreak with cases in multiple countries
+- **Healthcare**: Increased demand for diagnostic testing and treatment
+- **Community**: Disproportionate impact on certain populations
+- **Travel**: Enhanced screening at international borders
+- **Mortality**: Case-fatality rate <0.1% in non-endemic countries (2022), ~10% in Africa for more virulent clades

--- a/catalog/source/outbreaks/mucorales.md
+++ b/catalog/source/outbreaks/mucorales.md
@@ -1,0 +1,13 @@
+# Mucorales
+
+## Overview
+
+Mucorales cause mucormycosis, a severe infection affecting immunocompromised individuals and those with uncontrolled diabetes. These environmental molds can invade blood vessels and cause rapid tissue necrosis in sinuses, lungs, or skin.
+
+## Impact
+
+- **Public Health**: ~46% overall mortality rate, up to 68% in disseminated cases
+- **Emerging Threat**: Major surge during COVID-19 pandemic
+- **Geography**: Global distribution with significant impact during outbreaks
+- **Treatment**: Requires aggressive surgery and antifungals
+- **Disfigurement**: Survivors often suffer significant disfigurement

--- a/catalog/source/outbreaks/naegleria_fowleri.md
+++ b/catalog/source/outbreaks/naegleria_fowleri.md
@@ -1,0 +1,13 @@
+# Naegleria fowleri
+
+## Overview
+
+Naegleria fowleri is a free-living amoeba that causes Primary Amoebic Meningoencephalitis (PAM), an acute brain infection. It enters the nasal passages during freshwater activities and migrates to the brain.
+
+## Impact
+
+- **Public Health**: Extremely rare but highly fatal (95%+ case fatality rate)
+- **Geography**: Historically in warm freshwater regions, expanding northward
+- **Severity**: Destroys brain tissue, death occurs within days
+- **Treatment**: No reliably effective treatments once symptoms begin
+- **Climate Impact**: Cases potentially increasing with rising global temperatures

--- a/catalog/source/outbreaks/plasmodium_falciparum.md
+++ b/catalog/source/outbreaks/plasmodium_falciparum.md
@@ -1,4 +1,4 @@
-# Malaria (Plasmodium falciparum)
+# Plasmodium falciparum
 
 ## Overview
 

--- a/catalog/source/outbreaks/tuberculosis.md
+++ b/catalog/source/outbreaks/tuberculosis.md
@@ -1,0 +1,13 @@
+# Tuberculosis
+
+## Overview
+
+Tuberculosis (TB) is a centuries-old pathogen that remains one of the leading causes of infectious death globally. In 2021 alone, an estimated 10.6 million people fell ill with TB and 1.6 million died from it, a toll only recently eclipsed by COVID-19. Drug-resistant TB strains are an increasing concern, with ~450,000 new cases of rifampicin-resistant TB in 2021.
+
+## Impact
+
+- **Public Health**: Leading cause of infectious death globally
+- **Healthcare**: Significant burden on healthcare systems
+- **Mortality**: 1.6 million deaths in 2021
+- **Drug Resistance**: ~450,000 new cases of rifampicin-resistant TB annually
+- **HIV Synergy**: Increased risk in HIV-positive individuals


### PR DESCRIPTION
resolves #450

supersedes #242, but lifts information from it

based on the list and info from #353 

makes some hopefully well-informed assumptions:
1. that for organism groups like the mucorales fungi, we want a single entry under outbreaks that can highlight specific descendants
2. we may want to stop showing certain entries without having to remove them, as the status of things change
3. we may want to display different types of resources about an outbreak slightly differently
4. we can figure out a way to meaningfully associate arbitrary taxonomic ranks (ex: 38574) with their descendant organisms and assemblies (outside of just the highlighted ones) if we would like
5. when the taxonomy id associated w an outbreak is actually mapped to an organism specifically (rather than a group of them) then we can highlight that organism in the same way we do the case of groups. that is to say, i dont need to duplicate the taxonomy_id under descendants to highlight

im very happy to revisit any of these as we start to actually use these and learn more about our needs. my aim was to put together something that seemed like it represented the most likely needs given the outbreaks list we already had in hand.