### PR TITLE
feat: return collection for `SANGER_READ_RUN` workflow parameter variable (#468)

### DIFF
--- a/app/apis/catalog/brc-analytics-catalog/common/entities.ts
+++ b/app/apis/catalog/brc-analytics-catalog/common/entities.ts
@@ -1,14 +1,9 @@
+import { WorkflowUrlParameter } from "../../../../utils/galaxy-api/entities";
 import {
   ORGANISM_PLOIDY,
   WORKFLOW_PARAMETER_VARIABLE,
   WORKFLOW_PLOIDY,
 } from "./schema-entities";
-
-export interface WorkflowUrlParameter {
-  ext: string;
-  src: string;
-  url: string;
-}
 
 export type BRCCatalog = BRCDataCatalogGenome;
 

--- a/app/components/Entity/components/AnalysisMethod/components/Workflow/workflow.tsx
+++ b/app/components/Entity/components/AnalysisMethod/components/Workflow/workflow.tsx
@@ -6,7 +6,7 @@ import { TEXT_BODY_500 } from "@databiosphere/findable-ui/lib/theme/common/typog
 import { StyledGrid2 } from "./workflow.styles";
 import { TYPOGRAPHY_PROPS } from "../../constants";
 import { BUTTON_PROPS, GRID2_PROPS } from "./constants";
-import { getWorkflowLandingUrl } from "../../../../../../utils/galaxy-api";
+import { getWorkflowLandingUrl } from "../../../../../../utils/galaxy-api/galaxy-api";
 import {
   ANCHOR_TARGET,
   REL_ATTRIBUTE,

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/hooks/UseLaunchGalaxy/useLaunchGalaxy.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/hooks/UseLaunchGalaxy/useLaunchGalaxy.ts
@@ -1,6 +1,6 @@
 import { useAsync } from "@databiosphere/findable-ui/lib/hooks/useAsync";
 import { useCallback, useEffect } from "react";
-import { getWorkflowLandingUrl } from "../../../../../../../../../../../../utils/galaxy-api";
+import { getWorkflowLandingUrl } from "../../../../../../../../../../../../utils/galaxy-api/galaxy-api";
 import {
   ANCHOR_TARGET,
   REL_ATTRIBUTE,

--- a/app/utils/galaxy-api/entities.ts
+++ b/app/utils/galaxy-api/entities.ts
@@ -1,0 +1,52 @@
+export interface WorkflowLandingsBody {
+  public: true;
+  request_state: WorkflowLandingsBodyRequestState;
+  workflow_id: string;
+  workflow_target_type: "trs_url";
+}
+
+export type WorkflowLandingsBodyRequestState = {
+  [key: string]: WorkflowParameterValue;
+};
+
+export type WorkflowParameterValue =
+  | string
+  | WorkflowUrlParameter
+  | WorkflowPairedCollectionParameter;
+
+export interface WorkflowUrlParameter {
+  ext: string;
+  src: string;
+  url: string;
+}
+
+// Narrow type specific to the one kind of collection we use -- might be worth defining a more general collection type if we need other kinds of collections
+interface WorkflowPairedCollectionParameter {
+  class: "Collection";
+  collection_type: "list:paired";
+  elements: [
+    {
+      class: "Collection";
+      elements: [
+        {
+          class: "File";
+          filetype: string;
+          identifier: "forward";
+          location: string;
+        },
+        {
+          class: "File";
+          filetype: string;
+          identifier: "reverse";
+          location: string;
+        },
+      ];
+      identifier: string;
+      type: "paired";
+    },
+  ];
+}
+
+export interface WorkflowLanding {
+  uuid: string;
+}

--- a/app/utils/galaxy-api/galaxy-api.ts
+++ b/app/utils/galaxy-api/galaxy-api.ts
@@ -118,9 +118,9 @@ function paramVariableToRequestValue(
 }
 
 /**
- * Get run accession and full URL for the given pair run URLs from ENA.
+ * Get run accession and full URLs for the given paired run URLs from ENA.
  * @param enaUrls - Concatenated paired run URLs, as provided by ENA.
- * @returns info for forward and reverse runs.
+ * @returns accession and URLs for forward and reverse runs.
  */
 function getPairedRunUrlsInfo(enaUrls: string): {
   forwardUrl: string;

--- a/app/utils/galaxy-api/galaxy-api.ts
+++ b/app/utils/galaxy-api/galaxy-api.ts
@@ -86,6 +86,7 @@ function paramVariableToRequestValue(
         : null;
     case WORKFLOW_PARAMETER_VARIABLE.SANGER_READ_RUN: {
       if (!readRuns) return null;
+      // TODO get this info earlier? In particular, it might be better to explicitly get the run accession from ENA rather than getting it from the filenames.
       const { forwardUrl, reverseUrl, runAccession } =
         getPairedRunUrlsInfo(readRuns);
       return {
@@ -172,7 +173,7 @@ function getWorkflowLandingsRequestState(
       const value = paramVariableToRequestValue(
         variable,
         geneModelUrl,
-        null,
+        null, // TODO pass in actual read run URLs
         referenceGenome
       );
       if (value !== null) result[key] = value;

--- a/app/utils/galaxy-api/galaxy-api.ts
+++ b/app/utils/galaxy-api/galaxy-api.ts
@@ -88,7 +88,7 @@ function paramVariableToRequestValue(
       if (!readRuns) return null;
       const [forwardUrl, reverseUrl] = readRuns
         .split(";")
-        .map((url) => `http://${url}`);
+        .map((url) => `http://${url}`); // Using HTTP because ENA's download URLs don't support HTTPS
       return {
         class: "Collection",
         collection_type: "list:paired",

--- a/app/utils/galaxy-api/galaxy-api.ts
+++ b/app/utils/galaxy-api/galaxy-api.ts
@@ -139,7 +139,7 @@ function getPairedRunUrlsInfo(enaUrls: string): {
       throw new Error(
         `Inconsistent run accessions: ${JSON.stringify(runAccession)} and ${JSON.stringify(accession)}`
       );
-    const fullUrl = `http://${url}`; // Using HTTP because ENA's download URLs don't support HTTPS
+    const fullUrl = `ftp://${url}`;
     if (readIndex === "1") forwardUrl = fullUrl;
     else reverseUrl = fullUrl;
   }

--- a/app/utils/galaxy-api/galaxy-api.ts
+++ b/app/utils/galaxy-api/galaxy-api.ts
@@ -132,6 +132,7 @@ function getPairedRunUrlsInfo(enaUrls: string): {
   let reverseUrl: string | null = null;
   let runAccession: string | null = null;
   for (const url of enaUrls.split(";")) {
+    // Regarding file name format, see https://ena-docs.readthedocs.io/en/latest/faq/archive-generated-files.html#generated-fastq-files and https://ena-docs.readthedocs.io/en/latest/submit/general-guide/accessions.html#accession-numbers
     const urlMatch = /\/([EDS]RR\d{6,})_([12])\.fastq\.gz$/.exec(url);
     if (!urlMatch) continue;
     const [, accession, readIndex] = urlMatch;


### PR DESCRIPTION
Closes #468

Based on `main` as opposed to (as suggested in the ticket) `fran/456-paired-end-step` because the latter has linting errors which would make things awkward