### PR TITLE
feat: add simple feature flag defaulting viz to off, for now (#289)

### DIFF
--- a/app/views/HomeView/homeView.tsx
+++ b/app/views/HomeView/homeView.tsx
@@ -1,16 +1,32 @@
-import { Fragment } from "react";
+import { Fragment, useEffect, useState } from "react";
 import { SectionAnalytics } from "../../components/Home/components/Section/components/SectionAnalytics/sectionAnalytics";
 import { SectionAssemblies } from "../../components/Home/components/Section/components/SectionAssemblies/sectionAssemblies";
 import { SectionHelp } from "../../components/Home/components/Section/components/SectionHelp/sectionHelp";
 import { SectionHero } from "../../components/Home/components/Section/components/SectionHero/sectionHero";
 import { SectionSubHero } from "../../components/Home/components/Section/components/SectionSubHero/sectionSubHero";
 
+// Feature flag name
+const SHOW_ASSEMBLIES_SECTION = "show_assemblies_section";
+
 export const HomeView = (): JSX.Element => {
+  // State for the feature flag
+  const [showAssembliesSection, setShowAssembliesSection] = useState(false);
+
+  // Load the feature flag from localStorage on mount
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const storedValue = localStorage.getItem(SHOW_ASSEMBLIES_SECTION);
+      if (storedValue !== null) {
+        setShowAssembliesSection(storedValue === "true");
+      }
+    }
+  }, []);
+
   return (
     <Fragment>
       <SectionHero />
       <SectionSubHero />
-      <SectionAssemblies />
+      {showAssembliesSection && <SectionAssemblies />}
       <SectionAnalytics />
       <SectionHelp />
     </Fragment>


### PR DESCRIPTION
Per discussion, for now, this provides a simple feature flag defaulting homepage genome viz to off.

To play with it, demo it, whatever: `localStorage.setItem("show_assemblies_section", "true");`