### PR TITLE
fix: adjust color application at root node of hierarchy

### DIFF
--- a/app/components/Home/components/Section/components/SectionViz/sunburst.tsx
+++ b/app/components/Home/components/Section/components/SectionViz/sunburst.tsx
@@ -42,8 +42,13 @@ export const SectionViz = (): JSX.Element => {
       // Adjust depth relative to current root
       const relativeDepth = d.depth - root.depth;
 
-      if (relativeDepth === 0 || relativeDepth === 1)
-        return baseColor(d.data.name); // Direct children of root get base colors
+      if (relativeDepth === 0) {
+        // Keep center node color consistent, background-light
+        return "#eee";
+      } else if (relativeDepth === 1) {
+        // Direct children of root get base colors
+        return baseColor(d.data.name);
+      }
 
       // For descendants, get the color of their direct child of the root ancestor and modify it
       const rootChild = findRootChild(d, root);


### PR DESCRIPTION
This avoids issues where the re-flowed child colors don't make any sense relative the parent