### PR TITLE
feat: visibility and navigation improvements for hierarchical viz (#289)

### DIFF
--- a/app/components/Home/components/Section/components/SectionViz/sunburst.tsx
+++ b/app/components/Home/components/Section/components/SectionViz/sunburst.tsx
@@ -201,6 +201,8 @@ export const SectionViz = (): JSX.Element => {
       .style("stroke", "#333")
       .style("stroke-width", "1px")
       .on("mouseover", function (event, d) {
+        // Hghlight the arc, and display the node name and value in the tooltip.
+        d3.select(this).style("stroke-width", "2px");
         tooltip.transition().duration(200).style("opacity", 0.9);
         tooltip
           .html(`<strong>${d.data.name}</strong><br/>Assemblies: ${d.value}`)
@@ -208,6 +210,8 @@ export const SectionViz = (): JSX.Element => {
           .style("top", event.pageY - 28 + "px");
       })
       .on("mouseout", function () {
+        // Restore the original stroke color and width
+        d3.select(this).style("stroke-width", "1px");
         tooltip.transition().duration(500).style("opacity", 0);
       })
       .on("click", clicked);

--- a/app/components/Home/components/Section/components/SectionViz/sunburst.tsx
+++ b/app/components/Home/components/Section/components/SectionViz/sunburst.tsx
@@ -34,7 +34,7 @@ export const SectionViz = (): JSX.Element => {
     const svg = d3
       .select(svgNode)
       .attr("viewBox", [-width / 2, -height / 2, width, width])
-      .style("font", "10px sans-serif");
+      .style("font", "10px 'Inter Tight', sans-serif");
     // Define a color scale for base colors (root and first ring)
     const baseColor = d3.scaleOrdinal(d3.schemeTableau10);
 
@@ -94,8 +94,8 @@ export const SectionViz = (): JSX.Element => {
       .style("position", "absolute")
       .style("text-align", "center")
       .style("padding", "6px")
-      .style("font", "12px sans-serif")
-      .style("background", "lightsteelblue")
+      .style("font", "12px 'Inter Tight', sans-serif")
+      .style("background", smokeLightest)
       .style("border", "0px")
       .style("border-radius", "8px")
       .style("pointer-events", "none");


### PR DESCRIPTION
Adjusts the visual arc stroke on hover to more clearly indicate the highlighted option.

Filters on-arc display to only show when there is sufficient size (an estimate, but tweakable and better than nothing).

Swaps tooltip background to a theme color which looks a lot better.

Screenshots
Before:
![image](https://github.com/user-attachments/assets/f993ea58-66e3-41ae-abda-be8e4e567c42)
After:
![image](https://github.com/user-attachments/assets/24ffa463-da0a-4282-b196-6df0bee6b235)