### PR TITLE
feat: add support for multiple pairs in `SANGER_READ_RUN` value (#473)

### DIFF
--- a/app/utils/galaxy-api/entities.ts
+++ b/app/utils/galaxy-api/entities.ts
@@ -24,27 +24,25 @@ export interface WorkflowUrlParameter {
 interface WorkflowPairedCollectionParameter {
   class: "Collection";
   collection_type: "list:paired";
-  elements: [
-    {
-      class: "Collection";
-      elements: [
-        {
-          class: "File";
-          filetype: string;
-          identifier: "forward";
-          location: string;
-        },
-        {
-          class: "File";
-          filetype: string;
-          identifier: "reverse";
-          location: string;
-        },
-      ];
-      identifier: string;
-      type: "paired";
-    },
-  ];
+  elements: Array<{
+    class: "Collection";
+    elements: [
+      {
+        class: "File";
+        filetype: string;
+        identifier: "forward";
+        location: string;
+      },
+      {
+        class: "File";
+        filetype: string;
+        identifier: "reverse";
+        location: string;
+      },
+    ];
+    identifier: string;
+    type: "paired";
+  }>;
 }
 
 export interface WorkflowLanding {

--- a/app/utils/galaxy-api/galaxy-api.ts
+++ b/app/utils/galaxy-api/galaxy-api.ts
@@ -62,7 +62,7 @@ function buildFastaUrl(identifier: string): string {
 function paramVariableToRequestValue(
   variable: WORKFLOW_PARAMETER_VARIABLE,
   geneModelUrl: string | null,
-  readRuns: string | null,
+  readRuns: string[] | null,
   referenceGenome: string
 ): WorkflowParameterValue | null {
   // Because this `switch` has no default case, and the function doesn't allow `undefined` as a return type,
@@ -85,15 +85,15 @@ function paramVariableToRequestValue(
           }
         : null;
     case WORKFLOW_PARAMETER_VARIABLE.SANGER_READ_RUN: {
-      if (!readRuns) return null;
-      // TODO get this info earlier? In particular, it might be better to explicitly get the run accession from ENA rather than getting it from the filenames.
-      const { forwardUrl, reverseUrl, runAccession } =
-        getPairedRunUrlsInfo(readRuns);
+      if (!readRuns?.length) return null;
       return {
         class: "Collection",
         collection_type: "list:paired",
-        elements: [
-          {
+        elements: readRuns.map((readRunsPair) => {
+          // TODO get this info earlier? In particular, it might be better to explicitly get the run accession from ENA rather than getting it from the filenames.
+          const { forwardUrl, reverseUrl, runAccession } =
+            getPairedRunUrlsInfo(readRunsPair);
+          return {
             class: "Collection",
             elements: [
               {
@@ -111,8 +111,8 @@ function paramVariableToRequestValue(
             ],
             identifier: runAccession,
             type: "paired",
-          },
-        ],
+          };
+        }),
       };
     }
   }


### PR DESCRIPTION
Closes #473

Updated `paramVariableToRequestValue` to take an array of strings, rather than a single string, in the `readRuns` parameter; as before, each string is a comma-separated pair of URLs used to generate a paired collection for the `SANGER_READ_RUN` workflow parameter variable