### PR TITLE
feat: allow multiple accessions to be specified when getting data from ena (#513)

### DIFF
--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PairedEndStep/components/ENASequencingData/components/AccessionSelector/accessionSelector.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PairedEndStep/components/ENASequencingData/components/AccessionSelector/accessionSelector.tsx
@@ -62,8 +62,8 @@ export const AccessionSelector = ({
               component="div"
               color={TYPOGRAPHY_PROPS.COLOR.INK_LIGHT}
             >
-              Separate multiple accessions with any character (like commas or
-              spaces).
+              Separate multiple accessions with any combination of commas and
+              spaces.
             </Typography>
             {status.errors?.accession && (
               <Grid alignItems="center" columnGap={1} container direction="row">

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PairedEndStep/components/ENASequencingData/hooks/UseENA/constants.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PairedEndStep/components/ENASequencingData/hooks/UseENA/constants.ts
@@ -1,3 +1,5 @@
+export const ACCESSION_SEPARATOR_REGEX = /[\s,]+/;
+
 export const ENA_ACCESSION_REGEX_PATTERN: Record<string, RegExp> = {
   experiment_accession: /^(?:[EDS]RX\d{6,})$/i,
   run_accession: /^(?:[EDS]RR\d{6,})$/i,

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PairedEndStep/components/ENASequencingData/hooks/UseENA/entities.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PairedEndStep/components/ENASequencingData/hooks/UseENA/entities.ts
@@ -1,0 +1,4 @@
+export interface AccessionInfo {
+  accession: string;
+  accessionType: string;
+}

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PairedEndStep/components/ENASequencingData/hooks/UseENA/request.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PairedEndStep/components/ENASequencingData/hooks/UseENA/request.ts
@@ -1,29 +1,37 @@
 import { replaceParameters } from "@databiosphere/findable-ui/lib/utils/replaceParameters";
 import { ENA_FIELDS } from "./constants";
 import { SubmitOptions } from "./types";
+import { AccessionInfo } from "./entities";
 
-const ENA_API = `${process.env.NEXT_PUBLIC_ENA_PROXY_DOMAIN}/ena/portal/api/search?result=read_run&query={accessionType}={accession}&fields=${ENA_FIELDS.join(",")}&format=json`;
+const ENA_API = `${process.env.NEXT_PUBLIC_ENA_PROXY_DOMAIN}/ena/portal/api/search?result=read_run&query={query}&fields=${ENA_FIELDS.join(",")}&format=json`;
 
 /**
  * Fetch ENA data for a given accession number.
  * @param options - Options for the ENA data fetch.
- * @param options.accession - The accession number to fetch data for.
- * @param options.accessionType - The type of accession (e.g., experiment, run, sample, study).
+ * @param options.accessionsInfo - The accession numbers to fetch data for, along with types (e.g., experiment, run, sample, study).
  * @param options.submitOptions - Options for the submission.
  * @returns Promise with the ENA data.
  */
 export async function fetchENAData<T>({
-  accession,
-  accessionType,
+  accessionsInfo,
   submitOptions,
 }: {
-  accession: string;
-  accessionType: string;
+  accessionsInfo: AccessionInfo[];
   submitOptions: SubmitOptions;
 }): Promise<T[] | undefined> {
-  const res = await fetch(
-    replaceParameters(ENA_API, { accession, accessionType })
-  );
+  const accessionsByType: Record<string, string[]> = {};
+  for (const { accession, accessionType } of accessionsInfo) {
+    (
+      accessionsByType[accessionType] ?? (accessionsByType[accessionType] = [])
+    ).push(accession);
+  }
+  const query = Object.entries(accessionsByType)
+    .map(([accessionType, accessions]) => {
+      return `${accessionType} IN (${accessions.join(",")})`;
+    })
+    .join(" OR ");
+
+  const res = await fetch(replaceParameters(ENA_API, { query }));
 
   const data = await res.json();
 

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PairedEndStep/components/ENASequencingData/hooks/UseENA/schema.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PairedEndStep/components/ENASequencingData/hooks/UseENA/schema.ts
@@ -1,23 +1,5 @@
 import { object, string } from "yup";
-import { ENA_ACCESSION_REGEX_PATTERN } from "./constants";
 
 export const SCHEMA = object({
-  accession: string()
-    .required("Accession is required")
-    .test(
-      "is-valid-ena-accession",
-      "Accession is an unsupported ENA ID",
-      (value) => {
-        if (!value) return true;
-        return Object.values(ENA_ACCESSION_REGEX_PATTERN).some((regex) =>
-          regex.test(value)
-        );
-      }
-    ),
-  accessionType: string()
-    .required("Accession type is required")
-    .oneOf(
-      Object.keys(ENA_ACCESSION_REGEX_PATTERN),
-      "Accession type is unsupported"
-    ),
+  accession: string().required("Accession is required"),
 });

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PairedEndStep/components/ENASequencingData/hooks/UseENA/utils.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PairedEndStep/components/ENASequencingData/hooks/UseENA/utils.ts
@@ -1,4 +1,9 @@
-import { ENA_ACCESSION_REGEX_PATTERN } from "./constants";
+import { ValidationError } from "yup";
+import {
+  ACCESSION_SEPARATOR_REGEX,
+  ENA_ACCESSION_REGEX_PATTERN,
+} from "./constants";
+import { AccessionInfo } from "./entities";
 
 /**
  * Determine the appropriate accession type based on the accession ID format.
@@ -6,14 +11,37 @@ import { ENA_ACCESSION_REGEX_PATTERN } from "./constants";
  * @param accession - ENA accession number.
  * @returns Accession type.
  */
-export function getAccessionType(
-  accession: FormDataEntryValue | null
-): string | null {
-  if (typeof accession !== "string") return null;
+export function getAccessionType(accession: string): string | null {
   for (const [type, pattern] of Object.entries(ENA_ACCESSION_REGEX_PATTERN)) {
     if (pattern.test(accession)) {
       return type;
     }
   }
   return null;
+}
+
+/**
+ * Parse a string into a list of accessions with types, throwing a ValidationError if any accession is invalid.
+ * @param value - Form input value to parse.
+ * @param fieldName - Field to associate error with if thrown.
+ * @returns array of accession info.
+ */
+export function parseAccessionList(
+  value: string,
+  fieldName: string
+): AccessionInfo[] {
+  const accessions = value.split(ACCESSION_SEPARATOR_REGEX).filter((a) => a);
+  return accessions.map((accession) => {
+    const accessionType = getAccessionType(accession);
+    if (accessionType === null)
+      throw new ValidationError(
+        `Accession ${JSON.stringify(accession)} is not a supported ENA ID`,
+        value,
+        fieldName
+      );
+    return {
+      accession,
+      accessionType,
+    };
+  });
 }


### PR DESCRIPTION
Closes #513

Notes:
- I've made just commas and whitespace the separators for accessions and updated the helper text accordingly
- I've changed the schema to just validate the immediate input data (although validation errors are also thrown manually elsewhere)
- I didn't find any reference to the `IN` operator suggested by ChatGPT in the ENA documentation, but it seems to work so I'm using it for concision