### PR TITLE
feat: include hashes in paired collections sent to galaxy (#470)

### DIFF
--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/GTFStep/gtfStep.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/GTFStep/gtfStep.tsx
@@ -23,6 +23,7 @@ import {
 import { Optional } from "@databiosphere/findable-ui/lib/components/Stepper/components/Step/components/StepLabel/components/Optional/optional";
 import { getGeneModelLabel } from "./utils";
 import { BUTTON_PROPS } from "@databiosphere/findable-ui/lib/components/common/Button/constants";
+import { STEP } from "./step";
 
 export const GTFStep = ({
   active,
@@ -82,7 +83,7 @@ export const GTFStep = ({
                 <FormControlLabel
                   control={<Radio />}
                   key={i}
-                  onChange={() => onConfigure("geneModelUrl", value)}
+                  onChange={() => onConfigure(STEP.key, value)}
                   label={label}
                   value={value}
                 />

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/GTFStep/gtfStep.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/GTFStep/gtfStep.tsx
@@ -28,7 +28,6 @@ export const GTFStep = ({
   active,
   completed,
   description,
-  entryKey,
   entryLabel,
   genome,
   index,
@@ -41,14 +40,8 @@ export const GTFStep = ({
     useRadioGroup(geneModelUrls);
 
   useEffect(() => {
-    configureGTFStep(
-      geneModelUrls,
-      entryKey,
-      entryLabel,
-      onConfigure,
-      onValueChange
-    );
-  }, [geneModelUrls, entryKey, entryLabel, onConfigure, onValueChange]);
+    configureGTFStep(geneModelUrls, onConfigure, onValueChange);
+  }, [geneModelUrls, onConfigure, onValueChange]);
 
   return (
     <Step
@@ -89,11 +82,7 @@ export const GTFStep = ({
                 <FormControlLabel
                   control={<Radio />}
                   key={i}
-                  onChange={() =>
-                    onConfigure(entryKey, entryLabel, [
-                      { key: value, value: label },
-                    ])
-                  }
+                  onChange={() => onConfigure("geneModelUrl", value)}
                   label={label}
                   value={value}
                 />

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/GTFStep/step.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/GTFStep/step.ts
@@ -1,8 +1,13 @@
+import { LABEL } from "@databiosphere/findable-ui/lib/apis/azul/common/entities";
 import { StepConfig } from "../types";
 import { GTFStep } from "./gtfStep";
+import { getGeneModelLabel } from "./utils";
 
 export const STEP: StepConfig = {
   Step: GTFStep,
-  key: "geneModelUrl",
   label: "GTF Files",
+  renderValue({ geneModelUrl }) {
+    if (geneModelUrl === null) return LABEL.NONE;
+    if (geneModelUrl !== undefined) return getGeneModelLabel(geneModelUrl);
+  },
 };

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/GTFStep/step.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/GTFStep/step.ts
@@ -3,11 +3,12 @@ import { StepConfig } from "../types";
 import { GTFStep } from "./gtfStep";
 import { getGeneModelLabel } from "./utils";
 
-export const STEP: StepConfig = {
+export const STEP = {
   Step: GTFStep,
+  key: "geneModelUrl",
   label: "GTF Files",
-  renderValue({ geneModelUrl }) {
+  renderValue({ geneModelUrl }): string | undefined {
     if (geneModelUrl === null) return LABEL.NONE;
     if (geneModelUrl !== undefined) return getGeneModelLabel(geneModelUrl);
   },
-};
+} satisfies StepConfig;

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/GTFStep/utils.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/GTFStep/utils.ts
@@ -1,5 +1,6 @@
 import { UseRadioGroup } from "../hooks/UseRadioGroup/types";
 import { OnConfigure } from "../../../../../../../../../../../views/WorkflowInputsView/hooks/UseConfigureInputs/types";
+import { STEP } from "./step";
 
 /**
  * Configures the GTF step.
@@ -17,7 +18,7 @@ export const configureGTFStep = (
 
   // Gene model URLs are not available for this workflow.
   if (geneModelUrls.length === 0) {
-    onConfigure("geneModelUrl", null);
+    onConfigure(STEP.key, null);
     return;
   }
 
@@ -31,7 +32,7 @@ export const configureGTFStep = (
   if (!value) return;
 
   // Otherwise, use the gene model to configure the step.
-  onConfigure("geneModelUrl", value);
+  onConfigure(STEP.key, value);
 };
 
 /**

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/GTFStep/utils.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/GTFStep/utils.ts
@@ -1,20 +1,14 @@
-import { LABEL } from "@databiosphere/findable-ui/lib/apis/azul/common/entities";
-import { ConfiguredValue } from "../hooks/UseLaunchGalaxy/types";
 import { UseRadioGroup } from "../hooks/UseRadioGroup/types";
 import { OnConfigure } from "../../../../../../../../../../../views/WorkflowInputsView/hooks/UseConfigureInputs/types";
 
 /**
  * Configures the GTF step.
  * @param geneModelUrls - Gene model URLs.
- * @param entryKey - Configured value key.
- * @param entryLabel - Configured value display label.
  * @param onConfigure - Callback function to configure the step.
  * @param onValueChange - Callback function to handle value changes.
  */
 export const configureGTFStep = (
   geneModelUrls: string[] | undefined,
-  entryKey: keyof ConfiguredValue,
-  entryLabel: string,
   onConfigure: OnConfigure,
   onValueChange: UseRadioGroup["onValueChange"]
 ): void => {
@@ -23,7 +17,7 @@ export const configureGTFStep = (
 
   // Gene model URLs are not available for this workflow.
   if (geneModelUrls.length === 0) {
-    onConfigure(entryKey, entryLabel, [{ key: null, value: LABEL.NONE }]);
+    onConfigure("geneModelUrl", null);
     return;
   }
 
@@ -37,9 +31,7 @@ export const configureGTFStep = (
   if (!value) return;
 
   // Otherwise, use the gene model to configure the step.
-  onConfigure(entryKey, entryLabel, [
-    { key: value, value: getGeneModelLabel(value) },
-  ]);
+  onConfigure("geneModelUrl", value);
 };
 
 /**

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PairedEndStep/components/ENASequencingData/components/CollectionSelector/collectionSelector.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PairedEndStep/components/ENASequencingData/components/CollectionSelector/collectionSelector.tsx
@@ -6,10 +6,9 @@ import { BUTTON_PROPS } from "@databiosphere/findable-ui/lib/components/common/B
 import { useState } from "react";
 import { Table } from "./components/Table/table";
 import { RowSelectionState } from "@tanstack/table-core";
+import { EnaPairedReads } from "app/utils/galaxy-api/entities";
 
 export const CollectionSelector = ({
-  entryKey,
-  entryLabel,
   onClose,
   onConfigure,
   open,
@@ -40,13 +39,14 @@ export const CollectionSelector = ({
           {...BUTTON_PROPS.PRIMARY_CONTAINED}
           disabled={selectedCount === 0}
           onClick={() => {
-            const selectedRows = table
-              .getSelectedRowModel()
-              .rows.map((row) => ({
-                key: row.original.fastq_ftp,
-                value: row.original.run_accession,
-              }));
-            onConfigure(entryKey, entryLabel, selectedRows);
+            const selectedRows = table.getSelectedRowModel().rows.map(
+              (row): EnaPairedReads => ({
+                md5Hashes: row.original.fastq_md5,
+                runAccession: row.original.run_accession,
+                urls: row.original.fastq_ftp,
+              })
+            );
+            onConfigure("readRuns", selectedRows);
             onClose();
           }}
         >

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PairedEndStep/components/ENASequencingData/components/CollectionSelector/collectionSelector.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PairedEndStep/components/ENASequencingData/components/CollectionSelector/collectionSelector.tsx
@@ -7,6 +7,7 @@ import { useState } from "react";
 import { Table } from "./components/Table/table";
 import { RowSelectionState } from "@tanstack/table-core";
 import { EnaPairedReads } from "app/utils/galaxy-api/entities";
+import { STEP } from "../../../../step";
 
 export const CollectionSelector = ({
   onClose,
@@ -46,7 +47,7 @@ export const CollectionSelector = ({
                 urls: row.original.fastq_ftp,
               })
             );
-            onConfigure("readRuns", selectedRows);
+            onConfigure(STEP.key, selectedRows);
             onClose();
           }}
         >

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PairedEndStep/components/ENASequencingData/components/CollectionSelector/types.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PairedEndStep/components/ENASequencingData/components/CollectionSelector/types.ts
@@ -1,9 +1,8 @@
 import { ReadRun } from "../../types";
 import { OnConfigure } from "../../../../../../../../../../../../../../../views/WorkflowInputsView/hooks/UseConfigureInputs/types";
-import { StepProps } from "../../../../../types";
 import { Table } from "@tanstack/react-table";
 
-export interface Props extends Pick<StepProps, "entryKey" | "entryLabel"> {
+export interface Props {
   onClose: () => void;
   onConfigure: OnConfigure;
   open: boolean;

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PairedEndStep/components/ENASequencingData/enaSequencingData.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PairedEndStep/components/ENASequencingData/enaSequencingData.tsx
@@ -5,6 +5,7 @@ import { useDialog } from "@databiosphere/findable-ui/lib/components/common/Dial
 import { Props } from "./types";
 import { CollectionSummary } from "./components/CollectionSummary/collectionSummary";
 import { AccessionSelector } from "./components/AccessionSelector/accessionSelector";
+import { STEP } from "../../step";
 
 export const ENASequencingData = ({
   clearErrors,
@@ -39,7 +40,7 @@ export const ENASequencingData = ({
       />
       <CollectionSummary
         onClear={() => {
-          onConfigure("readRuns", null);
+          onConfigure(STEP.key, null);
           table.resetRowSelection();
         }}
         onEdit={collectionDialog.onOpen}

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PairedEndStep/components/ENASequencingData/enaSequencingData.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PairedEndStep/components/ENASequencingData/enaSequencingData.tsx
@@ -8,8 +8,6 @@ import { AccessionSelector } from "./components/AccessionSelector/accessionSelec
 
 export const ENASequencingData = ({
   clearErrors,
-  entryKey,
-  entryLabel,
   onConfigure,
   onRequestData,
   status,
@@ -33,8 +31,6 @@ export const ENASequencingData = ({
         status={status}
       />
       <CollectionSelector
-        entryKey={entryKey}
-        entryLabel={entryLabel}
         onClose={collectionDialog.onClose}
         onConfigure={onConfigure}
         open={collectionDialog.open}
@@ -43,7 +39,7 @@ export const ENASequencingData = ({
       />
       <CollectionSummary
         onClear={() => {
-          onConfigure(entryKey, entryLabel, [{ key: null, value: "None" }]);
+          onConfigure("readRuns", null);
           table.resetRowSelection();
         }}
         onEdit={collectionDialog.onOpen}

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PairedEndStep/components/ENASequencingData/types.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PairedEndStep/components/ENASequencingData/types.ts
@@ -1,6 +1,5 @@
 import { OnConfigure } from "../../../../../../../../../../../../../views/WorkflowInputsView/hooks/UseConfigureInputs/types";
 import { UseENA } from "./hooks/UseENA/types";
-import { StepProps } from "../../../types";
 import { Table } from "@tanstack/react-table";
 
 export interface ReadRun {
@@ -21,9 +20,7 @@ export interface ReadRun {
   tax_id: number;
 }
 
-export interface Props
-  extends UseENA<ReadRun>,
-    Pick<StepProps, "entryKey" | "entryLabel"> {
+export interface Props extends UseENA<ReadRun> {
   onConfigure: OnConfigure;
   table: Table<ReadRun>;
 }

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PairedEndStep/pairedEndStep.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PairedEndStep/pairedEndStep.tsx
@@ -15,7 +15,6 @@ import { useTable } from "./components/ENASequencingData/components/CollectionSe
 export const PairedEndStep = ({
   active,
   completed,
-  entryKey,
   entryLabel,
   index,
   onConfigure,
@@ -33,8 +32,6 @@ export const PairedEndStep = ({
         {value === VIEW.ENA ? (
           <ENASequencingData
             clearErrors={ena.clearErrors}
-            entryKey={entryKey}
-            entryLabel={entryLabel}
             onConfigure={onConfigure}
             onRequestData={ena.onRequestData}
             status={ena.status}

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PairedEndStep/step.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PairedEndStep/step.ts
@@ -2,13 +2,14 @@ import { LABEL } from "@databiosphere/findable-ui/lib/apis/azul/common/entities"
 import { StepConfig } from "../types";
 import { PairedEndStep } from "./pairedEndStep";
 
-export const STEP: StepConfig = {
+export const STEP = {
   Step: PairedEndStep,
   disabled: false,
+  key: "readRuns",
   label: "Paired-End Sequencing Data",
-  renderValue({ readRuns }) {
+  renderValue({ readRuns }): string | undefined {
     if (readRuns === null) return LABEL.NONE;
     if (readRuns !== undefined)
       return readRuns.map(({ runAccession }) => runAccession).join(", ");
   },
-};
+} satisfies StepConfig;

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PairedEndStep/step.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PairedEndStep/step.ts
@@ -1,9 +1,14 @@
+import { LABEL } from "@databiosphere/findable-ui/lib/apis/azul/common/entities";
 import { StepConfig } from "../types";
 import { PairedEndStep } from "./pairedEndStep";
 
 export const STEP: StepConfig = {
   Step: PairedEndStep,
   disabled: false,
-  key: "readRuns",
   label: "Paired-End Sequencing Data",
+  renderValue({ readRuns }) {
+    if (readRuns === null) return LABEL.NONE;
+    if (readRuns !== undefined)
+      return readRuns.map(({ runAccession }) => runAccession).join(", ");
+  },
 };

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/ReferenceAssemblyStep/referenceAssemblyStep.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/ReferenceAssemblyStep/referenceAssemblyStep.tsx
@@ -4,6 +4,7 @@ import { StepLabel } from "@databiosphere/findable-ui/lib/components/Stepper/com
 import { StepProps } from "../types";
 import { Optional } from "@databiosphere/findable-ui/lib/components/Stepper/components/Step/components/StepLabel/components/Optional/optional";
 import { useEffect } from "react";
+import { STEP } from "./step";
 
 export const ReferenceAssemblyStep = ({
   active,
@@ -16,7 +17,7 @@ export const ReferenceAssemblyStep = ({
   const { accession } = genome;
 
   useEffect(() => {
-    onConfigure("referenceAssembly", accession);
+    onConfigure(STEP.key, accession);
   }, [accession, entryLabel, onConfigure]);
 
   return (

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/ReferenceAssemblyStep/referenceAssemblyStep.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/ReferenceAssemblyStep/referenceAssemblyStep.tsx
@@ -8,7 +8,6 @@ import { useEffect } from "react";
 export const ReferenceAssemblyStep = ({
   active,
   completed,
-  entryKey,
   entryLabel,
   genome,
   index,
@@ -17,8 +16,8 @@ export const ReferenceAssemblyStep = ({
   const { accession } = genome;
 
   useEffect(() => {
-    onConfigure(entryKey, entryLabel, [{ key: accession, value: accession }]);
-  }, [accession, entryKey, entryLabel, onConfigure]);
+    onConfigure("referenceAssembly", accession);
+  }, [accession, entryLabel, onConfigure]);
 
   return (
     <Step active={active} completed={completed} index={index}>

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/ReferenceAssemblyStep/step.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/ReferenceAssemblyStep/step.ts
@@ -4,6 +4,8 @@ import { ReferenceAssemblyStep } from "./referenceAssemblyStep";
 export const STEP: StepConfig = {
   Step: ReferenceAssemblyStep,
   disabled: true,
-  key: "referenceAssembly",
   label: "Reference Assembly",
+  renderValue({ referenceAssembly }) {
+    return referenceAssembly;
+  },
 };

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/ReferenceAssemblyStep/step.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/ReferenceAssemblyStep/step.ts
@@ -1,11 +1,12 @@
 import { StepConfig } from "../types";
 import { ReferenceAssemblyStep } from "./referenceAssemblyStep";
 
-export const STEP: StepConfig = {
+export const STEP = {
   Step: ReferenceAssemblyStep,
   disabled: true,
+  key: "referenceAssembly",
   label: "Reference Assembly",
-  renderValue({ referenceAssembly }) {
+  renderValue({ referenceAssembly }): string | undefined {
     return referenceAssembly;
   },
-};
+} satisfies StepConfig;

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/hooks/UseLaunchGalaxy/constants.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/hooks/UseLaunchGalaxy/constants.ts
@@ -1,7 +1,0 @@
-import { ConfiguredValue } from "./types";
-
-export const CONFIGURED_VALUE_KEYS: (keyof ConfiguredValue)[] = [
-  "geneModelUrl",
-  "readRuns",
-  "referenceAssembly",
-];

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/hooks/UseLaunchGalaxy/types.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/hooks/UseLaunchGalaxy/types.ts
@@ -1,9 +1,10 @@
+import { EnaPairedReads } from "app/utils/galaxy-api/entities";
 import { Workflow } from "../../../../../../../../../../../../apis/catalog/brc-analytics-catalog/common/entities";
 import { ConfiguredInput } from "../../../../../../../../../../../../views/WorkflowInputsView/hooks/UseConfigureInputs/types";
 
 export interface ConfiguredValue {
   geneModelUrl: string | null;
-  readRuns: string[] | null;
+  readRuns: EnaPairedReads[] | null;
   referenceAssembly: string;
 }
 

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/hooks/UseLaunchGalaxy/utils.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/hooks/UseLaunchGalaxy/utils.ts
@@ -1,20 +1,5 @@
 import { ConfiguredInput } from "../../../../../../../../../../../../views/WorkflowInputsView/hooks/UseConfigureInputs/types";
-import { CONFIGURED_VALUE_KEYS } from "./constants";
 import { ConfiguredValue } from "./types";
-import { isStringArray } from "./typeGuards";
-
-/**
- * Returns the configured values for a given entry key.
- * @param key - Entry key.
- * @param configuredInput - Configured input.
- * @returns Configured values, or undefined.
- */
-export function getConfiguredValue(
-  key: keyof ConfiguredValue,
-  configuredInput: ConfiguredInput
-): (string | null)[] | undefined {
-  return configuredInput[key]?.values?.map((value) => value.key);
-}
 
 /**
  * Returns the configured values from the configured input.
@@ -24,48 +9,11 @@ export function getConfiguredValue(
 export function getConfiguredValues(
   configuredInput: ConfiguredInput
 ): ConfiguredValue | undefined {
-  const configuredValue = {} as ConfiguredValue;
-  for (const key of CONFIGURED_VALUE_KEYS) {
-    const values = getConfiguredValue(key, configuredInput);
-    if (key === "geneModelUrl" || key === "referenceAssembly") {
-      const value = parseValue(key, values);
-      if (!value) return;
-      configuredValue[key] = value;
-      continue;
-    }
-    if (key === "readRuns") {
-      const value = parseValue(key, values);
-      if (!value) return;
-      configuredValue[key] = value;
-    }
-  }
-  return configuredValue;
-}
-
-/**
- * Returns the value for the given key.
- * @param key - Key of the configured value.
- * @param values - Values for the configured value.
- * @returns Value for the given key, or undefined.
- */
-function parseValue<K extends keyof ConfiguredValue>(
-  key: K,
-  values: (string | null)[] | undefined
-): ConfiguredValue[K] | undefined {
-  switch (key) {
-    case "geneModelUrl":
-    case "referenceAssembly": {
-      // Expecting gene model URL and reference assembly to be a string.
-      const value = values?.[0];
-      if (typeof value !== "string") return;
-      return value as ConfiguredValue[K]; // Type assertion is safe here because we know these keys expect a string.
-    }
-    case "readRuns": {
-      // Expecting read runs to be string array.
-      if (!isStringArray(values)) return;
-      return values as ConfiguredValue[K]; // Type assertion is safe here because we know this key expects a string array.
-    }
-    default:
-      return undefined;
-  }
+  const { geneModelUrl, readRuns, referenceAssembly } = configuredInput;
+  if (!geneModelUrl || !readRuns || !referenceAssembly) return;
+  return {
+    geneModelUrl,
+    readRuns,
+    referenceAssembly,
+  };
 }

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/types.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/types.ts
@@ -14,13 +14,14 @@ import { OnContinue, OnEdit } from "../../hooks/UseStepper/types";
 export interface StepConfig {
   description?: ReactNode;
   disabled?: boolean;
+  key: keyof ConfiguredInput;
   label: string;
   renderValue: (ci: ConfiguredInput) => string | undefined;
   Step: ComponentType<StepProps>;
 }
 
 export interface StepProps
-  extends Omit<StepConfig, "Step" | "key" | "label">,
+  extends Pick<StepConfig, "description" | "disabled">,
     Pick<MStepProps, "active" | "completed" | "last">,
     Required<Pick<MStepProps, "index">> {
   entryLabel: string;

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/types.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/types.ts
@@ -4,19 +4,18 @@ import {
   BRCDataCatalogGenome,
   Workflow,
 } from "../../../../../../../../../../apis/catalog/brc-analytics-catalog/common/entities";
-import { OnConfigure } from "../../../../../../../../../../views/WorkflowInputsView/hooks/UseConfigureInputs/types";
 import {
-  ConfiguredValue,
-  Status,
-  OnLaunchGalaxy,
-} from "./hooks/UseLaunchGalaxy/types";
+  ConfiguredInput,
+  OnConfigure,
+} from "../../../../../../../../../../views/WorkflowInputsView/hooks/UseConfigureInputs/types";
+import { Status, OnLaunchGalaxy } from "./hooks/UseLaunchGalaxy/types";
 import { OnContinue, OnEdit } from "../../hooks/UseStepper/types";
 
 export interface StepConfig {
   description?: ReactNode;
   disabled?: boolean;
-  key: keyof ConfiguredValue;
   label: string;
+  renderValue: (ci: ConfiguredInput) => string | undefined;
   Step: ComponentType<StepProps>;
 }
 
@@ -24,7 +23,6 @@ export interface StepProps
   extends Omit<StepConfig, "Step" | "key" | "label">,
     Pick<MStepProps, "active" | "completed" | "last">,
     Required<Pick<MStepProps, "index">> {
-  entryKey: keyof ConfiguredValue;
   entryLabel: string;
   genome: BRCDataCatalogGenome;
   onConfigure: OnConfigure;

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/stepper.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/stepper.tsx
@@ -9,15 +9,14 @@ export const Stepper = ({ workflow, ...props }: Props): JSX.Element => {
   const { activeStep, onContinue, onEdit } = useStepper(steps);
   return (
     <StyledStepper activeStep={activeStep} {...STEPPER_PROPS}>
-      {steps.map(({ key, label, Step, ...stepProps }, i) => {
+      {steps.map(({ label, Step, ...stepProps }, i) => {
         const active = activeStep === i;
         const completed = activeStep > i;
         return (
           <Step
-            key={key}
+            key={i}
             active={active}
             completed={completed}
-            entryKey={key}
             entryLabel={label}
             index={i}
             onContinue={onContinue}

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/stepper.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/stepper.tsx
@@ -9,7 +9,7 @@ export const Stepper = ({ workflow, ...props }: Props): JSX.Element => {
   const { activeStep, onContinue, onEdit } = useStepper(steps);
   return (
     <StyledStepper activeStep={activeStep} {...STEPPER_PROPS}>
-      {steps.map(({ label, Step, ...stepProps }, i) => {
+      {steps.map(({ description, disabled, label, Step }, i) => {
         const active = activeStep === i;
         const completed = activeStep > i;
         return (
@@ -17,12 +17,13 @@ export const Stepper = ({ workflow, ...props }: Props): JSX.Element => {
             key={i}
             active={active}
             completed={completed}
+            description={description}
+            disabled={disabled}
             entryLabel={label}
             index={i}
             onContinue={onContinue}
             onEdit={onEdit}
             workflow={workflow}
-            {...stepProps}
             {...props}
           />
         );

--- a/app/utils/galaxy-api/entities.ts
+++ b/app/utils/galaxy-api/entities.ts
@@ -1,3 +1,9 @@
+export interface EnaPairedReads {
+  md5Hashes: string;
+  runAccession: string;
+  urls: string;
+}
+
 export interface WorkflowLandingsBody {
   public: true;
   request_state: WorkflowLandingsBodyRequestState;

--- a/app/utils/galaxy-api/entities.ts
+++ b/app/utils/galaxy-api/entities.ts
@@ -4,6 +4,11 @@ export interface EnaPairedReads {
   urls: string;
 }
 
+export interface EnaFileInfo {
+  md5: string;
+  url: string;
+}
+
 export interface WorkflowLandingsBody {
   public: true;
   request_state: WorkflowLandingsBodyRequestState;
@@ -36,12 +41,14 @@ interface WorkflowPairedCollectionParameter {
       {
         class: "File";
         filetype: string;
+        hashes: WorkflowDatasetHash[];
         identifier: "forward";
         location: string;
       },
       {
         class: "File";
         filetype: string;
+        hashes: WorkflowDatasetHash[];
         identifier: "reverse";
         location: string;
       },
@@ -49,6 +56,11 @@ interface WorkflowPairedCollectionParameter {
     identifier: string;
     type: "paired";
   }>;
+}
+
+interface WorkflowDatasetHash {
+  hash_function: "MD5" | "SHA-1" | "SHA-256" | "SHA-512";
+  hash_value: string;
 }
 
 export interface WorkflowLanding {

--- a/app/utils/galaxy-api/galaxy-api.ts
+++ b/app/utils/galaxy-api/galaxy-api.ts
@@ -3,6 +3,7 @@ import { WorkflowParameter } from "../../apis/catalog/brc-analytics-catalog/comm
 import ky from "ky";
 import { GALAXY_ENVIRONMENT } from "site-config/common/galaxy";
 import {
+  EnaPairedReads,
   WorkflowLanding,
   WorkflowLandingsBody,
   WorkflowLandingsBodyRequestState,
@@ -28,7 +29,7 @@ export async function getWorkflowLandingUrl(
   workflowId: string,
   referenceGenome: string,
   geneModelUrl: string | null,
-  readRuns: string[] | null,
+  readRuns: EnaPairedReads[] | null,
   parameters: WorkflowParameter[]
 ): Promise<string> {
   const body: WorkflowLandingsBody = {
@@ -65,7 +66,7 @@ function buildFastaUrl(identifier: string): string {
 function paramVariableToRequestValue(
   variable: WORKFLOW_PARAMETER_VARIABLE,
   geneModelUrl: string | null,
-  readRuns: string[] | null,
+  readRuns: EnaPairedReads[] | null,
   referenceGenome: string
 ): WorkflowParameterValue | null {
   // Because this `switch` has no default case, and the function doesn't allow `undefined` as a return type,
@@ -92,7 +93,7 @@ function paramVariableToRequestValue(
       return {
         class: "Collection",
         collection_type: "list:paired",
-        elements: readRuns.map((readRunsPair) => {
+        elements: readRuns.map(({ urls: readRunsPair }) => {
           // TODO get this info earlier? In particular, it might be better to explicitly get the run accession from ENA rather than getting it from the filenames.
           const { forwardUrl, reverseUrl, runAccession } =
             getPairedRunUrlsInfo(readRunsPair);
@@ -166,7 +167,7 @@ function getPairedRunUrlsInfo(enaUrls: string): {
 function getWorkflowLandingsRequestState(
   referenceGenome: string,
   geneModelUrl: string | null,
-  readRuns: string[] | null,
+  readRuns: EnaPairedReads[] | null,
   parameters: WorkflowParameter[]
 ): WorkflowLandingsBodyRequestState {
   const result: WorkflowLandingsBodyRequestState = {};

--- a/app/utils/galaxy-api/galaxy-api.ts
+++ b/app/utils/galaxy-api/galaxy-api.ts
@@ -3,6 +3,7 @@ import { WorkflowParameter } from "../../apis/catalog/brc-analytics-catalog/comm
 import ky from "ky";
 import { GALAXY_ENVIRONMENT } from "site-config/common/galaxy";
 import {
+  EnaFileInfo,
   EnaPairedReads,
   WorkflowLanding,
   WorkflowLandingsBody,
@@ -93,24 +94,28 @@ function paramVariableToRequestValue(
       return {
         class: "Collection",
         collection_type: "list:paired",
-        elements: readRuns.map(({ urls: readRunsPair }) => {
+        elements: readRuns.map((pairInfo) => {
           // TODO get this info earlier? In particular, it might be better to explicitly get the run accession from ENA rather than getting it from the filenames.
-          const { forwardUrl, reverseUrl, runAccession } =
-            getPairedRunUrlsInfo(readRunsPair);
+          const { forward, reverse, runAccession } = getPairedRunUrlsInfo(
+            pairInfo.urls,
+            pairInfo.md5Hashes
+          );
           return {
             class: "Collection",
             elements: [
               {
                 class: "File",
                 filetype: "fastqsanger.gz",
+                hashes: [{ hash_function: "MD5", hash_value: forward.md5 }],
                 identifier: "forward",
-                location: forwardUrl,
+                location: forward.url,
               },
               {
                 class: "File",
                 filetype: "fastqsanger.gz",
+                hashes: [{ hash_function: "MD5", hash_value: reverse.md5 }],
                 identifier: "reverse",
-                location: reverseUrl,
+                location: reverse.url,
               },
             ],
             identifier: runAccession,
@@ -125,17 +130,25 @@ function paramVariableToRequestValue(
 /**
  * Get run accession and full URLs for the given paired run URLs from ENA.
  * @param enaUrls - Concatenated paired run URLs, as provided by ENA.
- * @returns accession and URLs for forward and reverse runs.
+ * @param enaMd5Hashes - Concatenated MD5 hashes of the files referenced by the URLs, as provided by ENA.
+ * @returns accession, URLs, and hashes for forward and reverse runs.
  */
-function getPairedRunUrlsInfo(enaUrls: string): {
-  forwardUrl: string;
-  reverseUrl: string;
+function getPairedRunUrlsInfo(
+  enaUrls: string,
+  enaMd5Hashes: string
+): {
+  forward: EnaFileInfo;
+  reverse: EnaFileInfo;
   runAccession: string;
 } {
-  let forwardUrl: string | null = null;
-  let reverseUrl: string | null = null;
+  const splitUrls = enaUrls.split(";");
+  const splitMd5Hashes = enaMd5Hashes.split(";");
+  if (splitMd5Hashes.length !== splitUrls.length)
+    throw new Error("Hash list has different length than URL list");
+  let forward: EnaFileInfo | null = null;
+  let reverse: EnaFileInfo | null = null;
   let runAccession: string | null = null;
-  for (const url of enaUrls.split(";")) {
+  for (const [i, url] of splitUrls.entries()) {
     // Regarding file name format, see https://ena-docs.readthedocs.io/en/latest/faq/archive-generated-files.html#generated-fastq-files and https://ena-docs.readthedocs.io/en/latest/submit/general-guide/accessions.html#accession-numbers
     const urlMatch = /\/([EDS]RR\d{6,})_([12])\.fastq\.gz$/.exec(url);
     if (!urlMatch) continue;
@@ -145,15 +158,18 @@ function getPairedRunUrlsInfo(enaUrls: string): {
       throw new Error(
         `Inconsistent run accessions: ${JSON.stringify(runAccession)} and ${JSON.stringify(accession)}`
       );
-    const fullUrl = `ftp://${url}`;
-    if (readIndex === "1") forwardUrl = fullUrl;
-    else reverseUrl = fullUrl;
+    const fileInfo: EnaFileInfo = {
+      md5: splitMd5Hashes[i],
+      url: `ftp://${url}`,
+    };
+    if (readIndex === "1") forward = fileInfo;
+    else reverse = fileInfo;
   }
   if (runAccession === null)
     throw new Error("No URLs with expected format found");
-  if (forwardUrl === null) throw new Error("No URL for forward read found");
-  if (reverseUrl === null) throw new Error("No URL for reverse read found");
-  return { forwardUrl, reverseUrl, runAccession };
+  if (forward === null) throw new Error("No URL for forward read found");
+  if (reverse === null) throw new Error("No URL for reverse read found");
+  return { forward, reverse, runAccession };
 }
 
 /**

--- a/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
@@ -11,6 +11,7 @@ import {
   Workflow,
 } from "../../../../apis/catalog/brc-analytics-catalog/common/entities";
 import * as C from "../../../../components";
+import { STEPS as WORKFLOW_STEPS } from "../../../../components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/constants";
 import {
   GENOME_BROWSER,
   NCBI_ASSEMBLY,
@@ -669,13 +670,10 @@ export const buildWorkflowConfiguration = (
   configuredInput: ConfiguredInput
 ): ComponentProps<typeof C.KeyValuePairs> => {
   const keyValuePairs = new Map<Key, Value>();
-  for (const { entryLabel, values } of Object.values(configuredInput)) {
-    if (values.length > 0) {
-      keyValuePairs.set(
-        entryLabel,
-        values.map(({ value }) => value).join(", ")
-      );
-    }
+  for (const stepConfig of WORKFLOW_STEPS) {
+    const value = stepConfig.renderValue(configuredInput);
+    if (value === undefined) continue;
+    keyValuePairs.set(stepConfig.label, value);
   }
   return {
     KeyElType: C.KeyElType,

--- a/app/views/WorkflowInputsView/hooks/UseConfigureInputs/types.ts
+++ b/app/views/WorkflowInputsView/hooks/UseConfigureInputs/types.ts
@@ -2,6 +2,9 @@ import { EnaPairedReads } from "app/utils/galaxy-api/entities";
 
 export type OnConfigure = (...p: OnConfigureParams) => void;
 
+/**
+ * Possible tuples containing a key and its associated value type.
+ */
 export type OnConfigureParams = {
   [K in keyof Required<ConfiguredInput>]: [K, ConfiguredInput[K]];
 }[keyof ConfiguredInput];

--- a/app/views/WorkflowInputsView/hooks/UseConfigureInputs/types.ts
+++ b/app/views/WorkflowInputsView/hooks/UseConfigureInputs/types.ts
@@ -1,21 +1,15 @@
-export type OnConfigure = (
-  entryKey: string,
-  entryLabel: string,
-  values: ConfiguredValue[]
-) => void;
+import { EnaPairedReads } from "app/utils/galaxy-api/entities";
 
-export interface ConfigurationEntry {
-  entryLabel: string;
-  values: ConfiguredValue[];
-}
+export type OnConfigure = (...p: OnConfigureParams) => void;
+
+export type OnConfigureParams = {
+  [K in keyof Required<ConfiguredInput>]: [K, ConfiguredInput[K]];
+}[keyof ConfiguredInput];
 
 export interface ConfiguredInput {
-  [key: string]: ConfigurationEntry;
-}
-
-export interface ConfiguredValue {
-  key: string | null;
-  value: string | null;
+  geneModelUrl?: string | null;
+  readRuns?: EnaPairedReads[] | null;
+  referenceAssembly?: string;
 }
 
 export interface UseConfigureInputs {

--- a/app/views/WorkflowInputsView/hooks/UseConfigureInputs/useConfigureInputs.ts
+++ b/app/views/WorkflowInputsView/hooks/UseConfigureInputs/useConfigureInputs.ts
@@ -1,18 +1,27 @@
 import { useCallback, useState } from "react";
-import { ConfiguredInput, ConfiguredValue, UseConfigureInputs } from "./types";
+import {
+  ConfiguredInput,
+  OnConfigureParams,
+  UseConfigureInputs,
+} from "./types";
 
 export const useConfigureInputs = (): UseConfigureInputs => {
   const [configuredInput, setConfiguredInput] = useState<ConfiguredInput>({});
 
-  const onConfigure = useCallback(
-    (entryKey: string, entryLabel: string, values: ConfiguredValue[]): void => {
-      setConfiguredInput((prev) => ({
-        ...prev,
-        [entryKey]: { entryLabel, values },
-      }));
-    },
-    []
-  );
+  const onConfigure = useCallback((...params: OnConfigureParams): void => {
+    setConfiguredInput((prev) => configureInput(prev, params[0], params[1]));
+  }, []);
 
   return { configuredInput, onConfigure };
 };
+
+function configureInput<K extends keyof ConfiguredInput>(
+  configuredInput: ConfiguredInput,
+  key: K,
+  value: ConfiguredInput[K]
+): ConfiguredInput {
+  return {
+    ...configuredInput,
+    [key]: value,
+  };
+}


### PR DESCRIPTION
Closes #470

Passing the hashes through from the stepper to the Galaxy API requires some changes to how the steps work:
- `ConfiguredInput` now contains a specific set of fields which may have different types, rather than containing arbitrary entries all of the same type.
- Labels are no longer stored in `ConfiguredInput` -- instead, the view model builder for the side panel maps over the `STEPS` array, and for each step uses the `label` field to determine the entry label, and the function in the `renderValue` field to determine how the value is displayed. (Note: I believe this is the one place where the new system is less powerful than the old one -- with the new system, there's a one-to-one correspondence between steps and side panel entries.)
- Due to the change in how labels are used, `onConfigure` just takes a key and a value. Since the values may be different types, this requires the type system to know what the key is, so keys are referenced via the step config constant rather than being passed to the step component as a prop.