### PR TITLE
fix: remove count from sunburst tooltip/link for clarity #481 #545 #522

### DIFF
--- a/app/components/Home/components/Section/components/SectionViz/NodeDetails.tsx
+++ b/app/components/Home/components/Section/components/SectionViz/NodeDetails.tsx
@@ -121,9 +121,7 @@ export const NodeDetails: React.FC<NodeDetailsProps> = ({
   // Create the appropriate display text based on node type
   let filterLinkText = "Browse All Assemblies";
   if (!isRoot) {
-    const assemblyCount = countLeafNodes(node);
-    const assemblySuffix = assemblyCount > 1 ? "ies" : "y";
-    filterLinkText = `View ${assemblyCount} Assembl${assemblySuffix} for ${nodeName}`;
+    filterLinkText = `View assemblies for ${nodeName}`;
   }
 
   return (

--- a/app/components/Home/components/Section/components/SectionViz/sunburst.tsx
+++ b/app/components/Home/components/Section/components/SectionViz/sunburst.tsx
@@ -205,7 +205,7 @@ export const SectionViz = (): JSX.Element => {
         d3.select(this).style("stroke-width", "2px");
         tooltip.transition().duration(200).style("opacity", 0.9);
         tooltip
-          .html(`<strong>${d.data.name}</strong><br/>Assemblies: ${d.value}`)
+          .html(`<strong>${d.data.name}</strong>`)
           .style("left", event.pageX + 10 + "px")
           .style("top", event.pageY - 28 + "px");
       })


### PR DESCRIPTION
This pull request simplifies the user interface in the `SectionViz` component by removing redundant information and streamlining the display text for better readability. The most important changes are:

### User Interface Simplifications:

* [`NodeDetails.tsx`](diffhunk://#diff-2e793d58df5d8af3f0190b86a6d41864fa1d86510b38a3cab72bc60f344ceb98L124-R124): Simplified the filter link text by removing the dynamic assembly count and suffix, replacing it with a static message: "View assemblies for {nodeName}". This makes the text more concise and easier to understand.

* [`sunburst.tsx`](diffhunk://#diff-6c361bc88cd5bffde4a68a0f78ab95386a9c2f60002d1007728c1c856cf89cd2L208-R208): Updated the tooltip content to exclude the assembly count, leaving only the node name (`<strong>${d.data.name}</strong>`). This reduces clutter and focuses on the most relevant information.We'll iterate on the 'what' is actually represnted in the sunburst (whether we prune at species/organism, or go all the way to strain taxa, etc).  As it is, this prevents any confusion about what the count is.  By removing it.

Closes #545 