### PR TITLE
chore: remove required GitHub issue linking from PR title validation

### DIFF
--- a/.github/actions/check-input-commit-message/index.js
+++ b/.github/actions/check-input-commit-message/index.js
@@ -19,23 +19,9 @@ async function runCommitlint(message) {
   return report.valid;
 }
 
-function checkIssueNumber(message) {
-  console.log(
-    "Checking for a '#xxx' reference to a corresponding GitHub issue"
-  );
-  if (/#[0-9]/.test(message)) {
-    console.log("Successfully found issue number\n");
-    return true;
-  } else {
-    console.error("Issue number missing\n");
-    return false;
-  }
-}
-
 async function checkMessage() {
   const message = core.getInput("message");
   const failedChecks = [];
-  if (!checkIssueNumber(message)) failedChecks.push("issue number");
   if (!(await runCommitlint(message)))
     failedChecks.push("Conventional Commits");
   if (failedChecks.length > 0)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+## Description
+
+Brief description of the changes made in this PR.
+
+## Related Issue
+
+If this addresses an existing GitHub issue, link it here (e.g., "Closes #123"). If no existing issue exists, consider creating one first to discuss the changes.


### PR DESCRIPTION
Removes the mandatory #xxx issue reference requirement from PR titles while adding a PR template that encourages linking to existing issues when relevant.

One option to close #586; draft pending discussion.