### PR TITLE
fix: sunburst display issues in firefox

### DIFF
--- a/app/components/Home/components/Section/components/SectionHero/components/Hero/hero.tsx
+++ b/app/components/Home/components/Section/components/SectionHero/components/Hero/hero.tsx
@@ -31,7 +31,7 @@ export const Hero = ({
       height={height}
       preserveAspectRatio="xMinYMin meet"
       viewBox={getViewBox(gridSize, height)}
-      width="100vw"
+      width="100%"
       xmlns="http://www.w3.org/2000/svg"
     >
       <SmokeRect gridSize={gridSize} />
@@ -46,7 +46,7 @@ export const Hero = ({
             <rect
               fill={getFillUrl(elementId)}
               height={height}
-              width="100vw"
+              width="100%"
               x={0}
               y={0}
             />

--- a/app/components/Home/components/Section/components/SectionViz/sunburst.tsx
+++ b/app/components/Home/components/Section/components/SectionViz/sunburst.tsx
@@ -310,21 +310,16 @@ export const SectionViz = (): JSX.Element => {
     const LOGO_WIDTH = 140;
     const LOGO_HEIGHT = 140;
 
-    // Add foreignObject for logo
-    const logoObject = centerGroup
-      .append("foreignObject")
+    // Add image element for logo (Safari-compatible)
+    const logoImage = centerGroup
+      .append("image")
       .attr("x", -LOGO_WIDTH / 2)
       .attr("y", -LOGO_HEIGHT / 2)
       .attr("width", LOGO_WIDTH)
       .attr("height", LOGO_HEIGHT)
+      .attr("href", "/logo/brc.svg")
+      .attr("preserveAspectRatio", "xMidYMid meet")
       .style("opacity", 1);
-
-    logoObject
-      .append("xhtml:img")
-      .attr("src", "/logo/brc.svg")
-      .attr("width", LOGO_WIDTH)
-      .attr("height", LOGO_HEIGHT)
-      .style("object-fit", "contain");
 
     // Add text element for non-root nodes
     const centerText = centerGroup
@@ -337,7 +332,7 @@ export const SectionViz = (): JSX.Element => {
 
     function updateCenter(p: TreeNode): void {
       const isRoot = p.depth === 0;
-      logoObject.style("opacity", isRoot ? 1 : 0);
+      logoImage.style("opacity", isRoot ? 1 : 0);
       centerText
         .style("opacity", isRoot ? 0 : 1)
         .text(isRoot ? "" : p.data.name);

--- a/app/components/Home/components/Section/components/SectionViz/sunburst.tsx
+++ b/app/components/Home/components/Section/components/SectionViz/sunburst.tsx
@@ -472,7 +472,7 @@ export const SectionViz = (): JSX.Element => {
       }}
     >
       <div style={{ display: "flex", justifyContent: "center", width: "70%" }}>
-        <svg ref={svgRef}></svg>
+        <svg ref={svgRef} style={{ maxWidth: "800px", width: "100%" }}></svg>
       </div>
       <div style={{ marginLeft: "3rem", padding: "1rem", width: "30%" }}>
         {selectedNode ? (

--- a/app/components/Layout/components/AppLayout/components/Section/components/SectionHero/components/Hero/hero.tsx
+++ b/app/components/Layout/components/AppLayout/components/Section/components/SectionHero/components/Hero/hero.tsx
@@ -23,7 +23,7 @@ export const Hero = ({
       height={height}
       preserveAspectRatio="xMinYMin meet"
       viewBox={getViewBox(gridSize, height)}
-      width="100vw"
+      width="100%"
       xmlns="http://www.w3.org/2000/svg"
     >
       <SmokeRect gridSize={gridSize} />
@@ -36,7 +36,7 @@ export const Hero = ({
             <rect
               fill={getFillUrl(elementId)}
               height={height}
-              width="100vw"
+              width="100%"
               x={0}
               y={0}
             />


### PR DESCRIPTION
## Description

This fixes the sunburst in safari. 

Three separate changes address different Safari-specific issues:
  - The SVG width specification fix prevents Safari warnings
  - The foreignObject replacement fixes Safari's known compatibility issues with HTML content in SVG
  - The explicit dimensions fix ensures Safari can properly size the SVG within the flex container

## Related Issue

Closes #590 