### PR TITLE
feat: add IWC linkage from workflows

### DIFF
--- a/app/apis/catalog/brc-analytics-catalog/common/entities.ts
+++ b/app/apis/catalog/brc-analytics-catalog/common/entities.ts
@@ -114,6 +114,7 @@ export interface WorkflowCategory {
 }
 
 export interface Workflow {
+  iwcId: string;
   parameters: WorkflowParameter[];
   ploidy: WORKFLOW_PLOIDY;
   taxonomyId: string | null;

--- a/app/components/Entity/components/AnalysisMethod/components/Workflow/constants.ts
+++ b/app/components/Entity/components/AnalysisMethod/components/Workflow/constants.ts
@@ -12,3 +12,11 @@ export const BUTTON_PROPS = {
   color: MUI_BUTTON_PROPS.COLOR.PRIMARY,
   variant: MUI_BUTTON_PROPS.VARIANT.CONTAINED,
 } satisfies ButtonProps;
+
+export const OUTLINED_BUTTON_PROPS = {
+  color: MUI_BUTTON_PROPS.COLOR.PRIMARY,
+  sx: {
+    padding: "7px 15px", // Reduced by 1px on each side to compensate for border
+  },
+  variant: MUI_BUTTON_PROPS.VARIANT.OUTLINED,
+} satisfies ButtonProps;

--- a/app/components/Entity/components/AnalysisMethod/components/Workflow/workflow.tsx
+++ b/app/components/Entity/components/AnalysisMethod/components/Workflow/workflow.tsx
@@ -90,7 +90,7 @@ export const Workflow = ({
                 );
               }}
             >
-              View on IWC
+              View Workflow Details
             </Button>
           </Grid>
         )}

--- a/app/components/Entity/components/AnalysisMethod/components/Workflow/workflow.tsx
+++ b/app/components/Entity/components/AnalysisMethod/components/Workflow/workflow.tsx
@@ -5,7 +5,7 @@ import { Props } from "./types";
 import { TEXT_BODY_500 } from "@databiosphere/findable-ui/lib/theme/common/typography";
 import { StyledGrid } from "./workflow.styles";
 import { TYPOGRAPHY_PROPS } from "../../constants";
-import { BUTTON_PROPS, GRID_PROPS } from "./constants";
+import { BUTTON_PROPS, GRID_PROPS, OUTLINED_BUTTON_PROPS } from "./constants";
 import { getWorkflowLandingUrl } from "../../../../../../utils/galaxy-api/galaxy-api";
 import {
   ANCHOR_TARGET,
@@ -80,8 +80,7 @@ export const Workflow = ({
         {iwcId && (
           <Grid>
             <Button
-              {...BUTTON_PROPS}
-              variant="outlined"
+              {...OUTLINED_BUTTON_PROPS}
               onClick={(): void => {
                 window.open(
                   `https://iwc.galaxyproject.org/workflow/${iwcId}`,

--- a/app/components/Entity/components/AnalysisMethod/components/Workflow/workflow.tsx
+++ b/app/components/Entity/components/AnalysisMethod/components/Workflow/workflow.tsx
@@ -24,7 +24,7 @@ export const Workflow = ({
   isFeatureEnabled,
   workflow,
 }: Props): JSX.Element => {
-  const { parameters, workflowDescription, workflowName } = workflow;
+  const { iwcId, parameters, workflowDescription, workflowName } = workflow;
   const { data: landingUrl, isLoading, run } = useAsync<string>();
   return (
     <StyledGrid {...GRID_PROPS}>
@@ -33,45 +33,68 @@ export const Workflow = ({
         <Typography variant={TEXT_BODY_500}>{workflowName}</Typography>
         <Typography {...TYPOGRAPHY_PROPS}>{workflowDescription}</Typography>
       </Grid>
-      {isFeatureEnabled ? (
-        <Button
-          {...BUTTON_PROPS}
-          component={Link}
-          disabled={!workflow.trsId}
-          href={replaceParameters(ROUTES.CONFIGURE_WORKFLOW, {
-            entityId,
-            trsId: formatTrsId(workflow.trsId),
-          })}
-          rel={REL_ATTRIBUTE.NO_OPENER}
-        >
-          Configure Inputs
-        </Button>
-      ) : (
-        <Button
-          {...BUTTON_PROPS}
-          disabled={!workflow.trsId}
-          onClick={async (): Promise<void> => {
-            const url =
-              landingUrl ??
-              (await run(
-                getWorkflowLandingUrl(
-                  workflow.trsId,
-                  genomeVersionAssemblyId,
-                  geneModelUrl,
-                  null, // Read runs.
-                  parameters
-                )
-              ));
-            window.open(
-              url,
-              ANCHOR_TARGET.BLANK,
-              REL_ATTRIBUTE.NO_OPENER_NO_REFERRER
-            );
-          }}
-        >
-          Launch in Galaxy
-        </Button>
-      )}
+      <Grid container spacing={1}>
+        {isFeatureEnabled ? (
+          <Grid>
+            <Button
+              {...BUTTON_PROPS}
+              component={Link}
+              disabled={!workflow.trsId}
+              href={replaceParameters(ROUTES.CONFIGURE_WORKFLOW, {
+                entityId,
+                trsId: formatTrsId(workflow.trsId),
+              })}
+              rel={REL_ATTRIBUTE.NO_OPENER}
+            >
+              Configure Inputs
+            </Button>
+          </Grid>
+        ) : (
+          <Grid>
+            <Button
+              {...BUTTON_PROPS}
+              disabled={!workflow.trsId}
+              onClick={async (): Promise<void> => {
+                const url =
+                  landingUrl ??
+                  (await run(
+                    getWorkflowLandingUrl(
+                      workflow.trsId,
+                      genomeVersionAssemblyId,
+                      geneModelUrl,
+                      null, // Read runs.
+                      parameters
+                    )
+                  ));
+                window.open(
+                  url,
+                  ANCHOR_TARGET.BLANK,
+                  REL_ATTRIBUTE.NO_OPENER_NO_REFERRER
+                );
+              }}
+            >
+              Launch in Galaxy
+            </Button>
+          </Grid>
+        )}
+        {iwcId && (
+          <Grid>
+            <Button
+              {...BUTTON_PROPS}
+              variant="outlined"
+              onClick={(): void => {
+                window.open(
+                  `https://iwc.galaxyproject.org/workflow/${iwcId}`,
+                  ANCHOR_TARGET.BLANK,
+                  REL_ATTRIBUTE.NO_OPENER_NO_REFERRER
+                );
+              }}
+            >
+              View on IWC
+            </Button>
+          </Grid>
+        )}
+      </Grid>
     </StyledGrid>
   );
 };

--- a/catalog/build/ts/build-catalog.ts
+++ b/catalog/build/ts/build-catalog.ts
@@ -4,29 +4,32 @@ import { buildOutbreaks } from "./build-outbreaks";
 import { buildWorkflows } from "./build-workflows";
 import { saveJson } from "./utils";
 
-buildCatalog();
+buildCatalog().catch(console.error);
 
 async function buildCatalog(): Promise<void> {
-  const outbreaks = await buildOutbreaks();
-  const outbreaksByTaxonomyId = new Map(
-    outbreaks.map((outbreak) => [outbreak.taxonomy_id, outbreak])
-  );
+  try {
+    const outbreaks = await buildOutbreaks();
+    const outbreaksByTaxonomyId = new Map(
+      outbreaks.map((outbreak) => [outbreak.taxonomy_id, outbreak])
+    );
 
-  const genomes = await buildAssemblies(outbreaksByTaxonomyId);
-  const organisms = buildOrganisms(genomes);
-  const workflows = await buildWorkflows();
+    const genomes = await buildAssemblies(outbreaksByTaxonomyId);
+    const organisms = buildOrganisms(genomes);
+    const workflows = await buildWorkflows();
 
-  console.log("Assemblies:", genomes.length);
-  await saveJson("catalog/output/assemblies.json", genomes);
+    console.log("Assemblies:", genomes.length);
+    await saveJson("catalog/output/assemblies.json", genomes);
 
-  console.log("Organisms:", organisms.length);
-  await saveJson("catalog/output/organisms.json", organisms);
+    console.log("Organisms:", organisms.length);
+    await saveJson("catalog/output/organisms.json", organisms);
 
-  console.log("Outbreaks:", outbreaks.length);
-  await saveJson("catalog/output/outbreaks.json", outbreaks);
+    console.log("Outbreaks:", outbreaks.length);
+    await saveJson("catalog/output/outbreaks.json", outbreaks);
 
-  console.log("Workflows:", workflows.length);
-  await saveJson("catalog/output/workflows.json", workflows);
-
-  console.log("Done");
+    console.log("Workflows:", workflows.length);
+    await saveJson("catalog/output/workflows.json", workflows);
+  } catch (error) {
+    console.error("Build failed:", error);
+    process.exit(1);
+  }
 }

--- a/catalog/build/ts/build-workflows.ts
+++ b/catalog/build/ts/build-workflows.ts
@@ -62,7 +62,7 @@ function buildWorkflow(
     else if (url_spec) parameters.push({ key, url_spec });
   }
   const workflow: Workflow = {
-    iwcId: iwcId || undefined,
+    iwcId,
     parameters,
     ploidy,
     taxonomyId: typeof taxonomyId === "number" ? String(taxonomyId) : null,

--- a/catalog/build/ts/build-workflows.ts
+++ b/catalog/build/ts/build-workflows.ts
@@ -43,16 +43,18 @@ export async function buildWorkflows(): Promise<WorkflowCategory[]> {
 
 function buildWorkflow(
   workflowCategories: WorkflowCategory[],
-  {
+  sourceWorkflow: SourceWorkflow
+): void {
+  const {
     categories,
+    iwc_id: iwcId,
     parameters: sourceParameters,
     ploidy,
     taxonomy_id: taxonomyId,
     trs_id: trsId,
     workflow_description: workflowDescription,
     workflow_name: workflowName,
-  }: SourceWorkflow
-): void {
+  } = sourceWorkflow;
   const parameters = [];
   for (const { key, url_spec, variable } of sourceParameters) {
     // Add parameter if either variable or url_spec is defined
@@ -60,6 +62,7 @@ function buildWorkflow(
     else if (url_spec) parameters.push({ key, url_spec });
   }
   const workflow: Workflow = {
+    iwcId: iwcId || undefined,
     parameters,
     ploidy,
     taxonomyId: typeof taxonomyId === "number" ? String(taxonomyId) : null,

--- a/catalog/output/workflows.json
+++ b/catalog/output/workflows.json
@@ -6,6 +6,7 @@
     "showComingSoon": true,
     "workflows": [
       {
+        "iwcId": "haploid-variant-calling-wgs-pe-main",
         "parameters": [
           {
             "key": "Paired Collection",
@@ -27,6 +28,7 @@
         "workflowName": "Paired end variant calling in haploid system"
       },
       {
+        "iwcId": "sars-cov-2-pe-illumina-artic-variant-calling-covid-19-pe-artic-illumina",
         "parameters": [
           {
             "key": "NC_045512.2 FASTA sequence of SARS-CoV-2",
@@ -56,6 +58,7 @@
         "workflowName": "COVID-19: variation analysis on ARTIC PE data"
       },
       {
+        "iwcId": "sars-cov-2-pe-illumina-wgs-variant-calling-covid-19-pe-wgs-illumina",
         "parameters": [
           {
             "key": "NC_045512.2 FASTA sequence of SARS-CoV-2",
@@ -69,6 +72,7 @@
         "workflowName": "COVID-19: variation analysis on WGS PE data"
       },
       {
+        "iwcId": "sars-cov-2-se-illumina-wgs-variant-calling-covid-19-se-wgs-illumina",
         "parameters": [
           {
             "key": "NC_045512.2 FASTA sequence of SARS-CoV-2",
@@ -90,6 +94,7 @@
     "showComingSoon": true,
     "workflows": [
       {
+        "iwcId": "fastq-to-matrix-10x-scrna-seq-fastq-to-matrix-10x-cellplex",
         "parameters": [
           {
             "key": "reference genome",
@@ -107,6 +112,7 @@
         "workflowName": "Single-Cell RNA-seq Preprocessing: 10X Genomics CellPlex Multiplexed Samples"
       },
       {
+        "iwcId": "fastq-to-matrix-10x-scrna-seq-fastq-to-matrix-10x-v3",
         "parameters": [
           {
             "key": "reference genome",
@@ -124,6 +130,7 @@
         "workflowName": "Single-Cell RNA-seq Preprocessing: 10X Genomics v3 to Seurat and Scanpy Compatible Format"
       },
       {
+        "iwcId": "rnaseq-pe-main",
         "parameters": [
           {
             "key": "Reference genome",
@@ -141,6 +148,7 @@
         "workflowName": "RNA-Seq Analysis: Paired-End Read Processing and Quantification"
       },
       {
+        "iwcId": "rnaseq-sr-main",
         "parameters": [
           {
             "key": "Reference genome",
@@ -166,6 +174,7 @@
     "showComingSoon": true,
     "workflows": [
       {
+        "iwcId": "atacseq-main",
         "parameters": [
           {
             "key": "reference_genome",
@@ -179,6 +188,7 @@
         "workflowName": "ATAC-seq Analysis: Chromatin Accessibility Profiling"
       },
       {
+        "iwcId": "chipseq-pe-main",
         "parameters": [
           {
             "key": "reference_genome",
@@ -192,6 +202,7 @@
         "workflowName": "ChIP-seq Analysis: Paired-End Read Processing"
       },
       {
+        "iwcId": "chipseq-sr-main",
         "parameters": [
           {
             "key": "reference_genome",
@@ -205,6 +216,7 @@
         "workflowName": "ChIP-seq Analysis: Single-End Read Processing"
       },
       {
+        "iwcId": "consensus-peaks-consensus-peaks-atac-cutandrun",
         "parameters": [],
         "ploidy": "ANY",
         "taxonomyId": null,
@@ -213,6 +225,7 @@
         "workflowName": "Consensus Peak Calling for ATAC-seq and CUT&RUN Replicates"
       },
       {
+        "iwcId": "cutandrun-main",
         "parameters": [
           {
             "key": "reference_genome",
@@ -234,6 +247,7 @@
     "showComingSoon": false,
     "workflows": [
       {
+        "iwcId": "pox-virus-amplicon-main",
         "parameters": [
           {
             "key": "Reference FASTA",

--- a/catalog/py_package/catalog_build/generated_schema/schema.py
+++ b/catalog/py_package/catalog_build/generated_schema/schema.py
@@ -1,32 +1,13 @@
-from __future__ import annotations 
+from __future__ import annotations
 
 import re
 import sys
-from datetime import (
-    date,
-    datetime,
-    time
-)
-from decimal import Decimal 
-from enum import Enum 
-from typing import (
-    Any,
-    ClassVar,
-    Dict,
-    List,
-    Literal,
-    Optional,
-    Union
-)
+from datetime import date, datetime, time
+from decimal import Decimal
+from enum import Enum
+from typing import Any, ClassVar, Dict, List, Literal, Optional, Union
 
-from pydantic import (
-    BaseModel,
-    ConfigDict,
-    Field,
-    RootModel,
-    field_validator
-)
-
+from pydantic import BaseModel, ConfigDict, Field, RootModel, field_validator
 
 metamodel_version = "None"
 version = "None"
@@ -34,52 +15,62 @@ version = "None"
 
 class ConfiguredBaseModel(BaseModel):
     model_config = ConfigDict(
-        validate_assignment = True,
-        validate_default = True,
-        extra = "forbid",
-        arbitrary_types_allowed = True,
-        use_enum_values = True,
-        strict = False,
+        validate_assignment=True,
+        validate_default=True,
+        extra="forbid",
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        strict=False,
     )
     pass
-
-
 
 
 class LinkMLMeta(RootModel):
     root: Dict[str, Any] = {}
     model_config = ConfigDict(frozen=True)
 
-    def __getattr__(self, key:str):
+    def __getattr__(self, key: str):
         return getattr(self.root, key)
 
-    def __getitem__(self, key:str):
+    def __getitem__(self, key: str):
         return self.root[key]
 
-    def __setitem__(self, key:str, value):
+    def __setitem__(self, key: str, value):
         self.root[key] = value
 
-    def __contains__(self, key:str) -> bool:
+    def __contains__(self, key: str) -> bool:
         return key in self.root
 
 
-linkml_meta = LinkMLMeta({'default_prefix': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/schema.yaml#',
-     'description': 'Combined source data schemas.',
-     'id': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/schema.yaml#',
-     'imports': ['./assemblies',
-                 './organisms',
-                 './outbreaks',
-                 './workflow_categories',
-                 './workflows'],
-     'name': 'schema',
-     'prefixes': {'linkml': {'prefix_prefix': 'linkml',
-                             'prefix_reference': 'https://w3id.org/linkml/'}},
-     'source_file': '/Users/dannon/work/brc-analytics/catalog/py_package/catalog_build/schema_utils/../schema/schema.yaml'} )
+linkml_meta = LinkMLMeta(
+    {
+        "default_prefix": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/schema.yaml#",
+        "description": "Combined source data schemas.",
+        "id": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/schema.yaml#",
+        "imports": [
+            "./assemblies",
+            "./organisms",
+            "./outbreaks",
+            "./workflow_categories",
+            "./workflows",
+        ],
+        "name": "schema",
+        "prefixes": {
+            "linkml": {
+                "prefix_prefix": "linkml",
+                "prefix_reference": "https://w3id.org/linkml/",
+            }
+        },
+        "source_file": "/Users/dannon/work/brc-analytics/catalog/py_package/catalog_build/schema_utils/../schema/schema.yaml",
+    }
+)
+
 
 class OrganismPloidy(str, Enum):
     """
     Possible ploidies of an organism.
     """
+
     DIPLOID = "DIPLOID"
     HAPLOID = "HAPLOID"
     POLYPLOID = "POLYPLOID"
@@ -89,6 +80,7 @@ class OutbreakPriority(str, Enum):
     """
     Possible priorities of an outbreak.
     """
+
     HIGHEST = "HIGHEST"
     CRITICAL = "CRITICAL"
     HIGH = "HIGH"
@@ -100,6 +92,7 @@ class OutbreakResourceType(str, Enum):
     """
     Possible types of an outbreak resource.
     """
+
     PUBLICATION = "PUBLICATION"
     REFERENCE = "REFERENCE"
     NEWS = "NEWS"
@@ -113,6 +106,7 @@ class WorkflowCategoryId(str, Enum):
     """
     Set of IDs of workflow categories.
     """
+
     VARIANT_CALLING = "VARIANT_CALLING"
     TRANSCRIPTOMICS = "TRANSCRIPTOMICS"
     REGULATION = "REGULATION"
@@ -127,6 +121,7 @@ class WorkflowParameterVariable(str, Enum):
     """
     Possible variables that can be inserted into workflow parameters.
     """
+
     ASSEMBLY_ID = "ASSEMBLY_ID"
     ASSEMBLY_FASTA_URL = "ASSEMBLY_FASTA_URL"
     GENE_MODEL_URL = "GENE_MODEL_URL"
@@ -137,104 +132,264 @@ class WorkflowPloidy(str, Enum):
     """
     Possible ploidies supported by workflows.
     """
+
     ANY = "ANY"
     DIPLOID = "DIPLOID"
     HAPLOID = "HAPLOID"
     POLYPLOID = "POLYPLOID"
 
 
-
 class Assemblies(ConfiguredBaseModel):
     """
     Root object containing a collection of genomic assembly definitions for the BRC Analytics platform.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/assemblies.yaml#',
-         'tree_root': True})
 
-    assemblies: List[Assembly] = Field(default=..., description="""Collection of genomic assembly entries that will be available for analysis in the BRC Analytics platform.""", json_schema_extra = { "linkml_meta": {'alias': 'assemblies', 'domain_of': ['Assemblies']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/assemblies.yaml#",
+            "tree_root": True,
+        }
+    )
+
+    assemblies: List[Assembly] = Field(
+        default=...,
+        description="""Collection of genomic assembly entries that will be available for analysis in the BRC Analytics platform.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "assemblies", "domain_of": ["Assemblies"]}
+        },
+    )
 
 
 class Assembly(ConfiguredBaseModel):
     """
     Definition of a genomic assembly with its unique identifier.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/assemblies.yaml#'})
 
-    accession: str = Field(default=..., description="""The unique accession identifier for the assembly (e.g., GCA_000001405.28 for GRCh38), used to retrieve the assembly data from public repositories.""", json_schema_extra = { "linkml_meta": {'alias': 'accession', 'domain_of': ['Assembly']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/assemblies.yaml#"
+        }
+    )
+
+    accession: str = Field(
+        default=...,
+        description="""The unique accession identifier for the assembly (e.g., GCA_000001405.28 for GRCh38), used to retrieve the assembly data from public repositories.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "accession", "domain_of": ["Assembly"]}
+        },
+    )
 
 
 class Organisms(ConfiguredBaseModel):
     """
     Root object containing a collection of organism definitions for the BRC Analytics platform.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/organisms.yaml#',
-         'tree_root': True})
 
-    organisms: List[Organism] = Field(default=..., description="""Collection of organism entries that will be available in the BRC Analytics platform.""", json_schema_extra = { "linkml_meta": {'alias': 'organisms', 'domain_of': ['Organisms']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/organisms.yaml#",
+            "tree_root": True,
+        }
+    )
+
+    organisms: List[Organism] = Field(
+        default=...,
+        description="""Collection of organism entries that will be available in the BRC Analytics platform.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "organisms", "domain_of": ["Organisms"]}
+        },
+    )
 
 
 class Organism(ConfiguredBaseModel):
     """
     Definition of an organism with its taxonomic and genetic characteristics.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/organisms.yaml#'})
 
-    taxonomy_id: int = Field(default=..., description="""An NCBI Taxonomy ID at rank 'species'.""", json_schema_extra = { "linkml_meta": {'alias': 'taxonomy_id', 'domain_of': ['Organism', 'Outbreak', 'Workflow']} })
-    ploidy: List[OrganismPloidy] = Field(default=..., description="""The possible ploidy states (number of chromosome sets) that the organism may have, which determines compatible workflows.""", json_schema_extra = { "linkml_meta": {'alias': 'ploidy', 'domain_of': ['Organism', 'Workflow']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/organisms.yaml#"
+        }
+    )
+
+    taxonomy_id: int = Field(
+        default=...,
+        description="""An NCBI Taxonomy ID at rank 'species'.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "taxonomy_id",
+                "domain_of": ["Organism", "Outbreak", "Workflow"],
+            }
+        },
+    )
+    ploidy: List[OrganismPloidy] = Field(
+        default=...,
+        description="""The possible ploidy states (number of chromosome sets) that the organism may have, which determines compatible workflows.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "ploidy", "domain_of": ["Organism", "Workflow"]}
+        },
+    )
 
 
 class Outbreaks(ConfiguredBaseModel):
     """
     Root object containing a collection of pathogen definitions for the BRC Analytics platform to highlight as outbreaks/priority pathogens.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/outbreaks.yaml#',
-         'tree_root': True})
 
-    outbreaks: List[Outbreak] = Field(default=..., description="""Collection of pathogen entries that will be displayed in the BRC Analytics platform as outbreaks/priority pathogens.""", json_schema_extra = { "linkml_meta": {'alias': 'outbreaks', 'domain_of': ['Outbreaks']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/outbreaks.yaml#",
+            "tree_root": True,
+        }
+    )
+
+    outbreaks: List[Outbreak] = Field(
+        default=...,
+        description="""Collection of pathogen entries that will be displayed in the BRC Analytics platform as outbreaks/priority pathogens.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "outbreaks", "domain_of": ["Outbreaks"]}
+        },
+    )
 
 
 class Outbreak(ConfiguredBaseModel):
     """
     Definition of a priority pathogen with its taxonomic classification, priority level, and associated resources.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/outbreaks.yaml#'})
 
-    name: str = Field(default=..., description="""The display name of the pathogen as it will appear in the BRC Analytics interface.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Outbreak', 'WorkflowCategory']} })
-    taxonomy_id: int = Field(default=..., description="""The NCBI Taxonomy ID for the pathogen. Used to link to relevant genomic data and workflows.""", json_schema_extra = { "linkml_meta": {'alias': 'taxonomy_id', 'domain_of': ['Organism', 'Outbreak', 'Workflow']} })
-    priority: OutbreakPriority = Field(default=..., description="""The priority level of the pathogen, which determines its visibility and prominence in the BRC Analytics interface.""", json_schema_extra = { "linkml_meta": {'alias': 'priority', 'domain_of': ['Outbreak']} })
-    resources: List[OutbreakResource] = Field(default=..., description="""Collection of external resources (references, tools, databases) related to the pathogen.""", json_schema_extra = { "linkml_meta": {'alias': 'resources', 'domain_of': ['Outbreak']} })
-    description: MarkdownFileReference = Field(default=..., description="""Reference to a markdown file containing detailed information about the pathogen.""", json_schema_extra = { "linkml_meta": {'alias': 'description', 'domain_of': ['Outbreak', 'WorkflowCategory']} })
-    active: bool = Field(default=..., description="""Boolean flag that determines if the pathogen should be included in the BRC Analytics interface. Used to manage visibility as pathogen relevance changes over time.""", json_schema_extra = { "linkml_meta": {'alias': 'active', 'domain_of': ['Outbreak', 'Workflow']} })
-    highlight_descendant_taxonomy_ids: Optional[List[int]] = Field(default=None, description="""List of NCBI Taxonomy IDs for descendant taxa (e.g., specific strains or serotypes) that should be highlighted within the outbreak category.""", json_schema_extra = { "linkml_meta": {'alias': 'highlight_descendant_taxonomy_ids', 'domain_of': ['Outbreak']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/outbreaks.yaml#"
+        }
+    )
+
+    name: str = Field(
+        default=...,
+        description="""The display name of the pathogen as it will appear in the BRC Analytics interface.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Outbreak", "WorkflowCategory"],
+            }
+        },
+    )
+    taxonomy_id: int = Field(
+        default=...,
+        description="""The NCBI Taxonomy ID for the pathogen. Used to link to relevant genomic data and workflows.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "taxonomy_id",
+                "domain_of": ["Organism", "Outbreak", "Workflow"],
+            }
+        },
+    )
+    priority: OutbreakPriority = Field(
+        default=...,
+        description="""The priority level of the pathogen, which determines its visibility and prominence in the BRC Analytics interface.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "priority", "domain_of": ["Outbreak"]}
+        },
+    )
+    resources: List[OutbreakResource] = Field(
+        default=...,
+        description="""Collection of external resources (references, tools, databases) related to the pathogen.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "resources", "domain_of": ["Outbreak"]}
+        },
+    )
+    description: MarkdownFileReference = Field(
+        default=...,
+        description="""Reference to a markdown file containing detailed information about the pathogen.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Outbreak", "WorkflowCategory"],
+            }
+        },
+    )
+    active: bool = Field(
+        default=...,
+        description="""Boolean flag that determines if the pathogen should be included in the BRC Analytics interface. Used to manage visibility as pathogen relevance changes over time.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "active", "domain_of": ["Outbreak", "Workflow"]}
+        },
+    )
+    highlight_descendant_taxonomy_ids: Optional[List[int]] = Field(
+        default=None,
+        description="""List of NCBI Taxonomy IDs for descendant taxa (e.g., specific strains or serotypes) that should be highlighted within the outbreak category.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "highlight_descendant_taxonomy_ids",
+                "domain_of": ["Outbreak"],
+            }
+        },
+    )
 
 
 class OutbreakResource(ConfiguredBaseModel):
     """
     Definition of an external resource (reference, tool, database) associated with a priority pathogen.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/outbreaks.yaml#'})
 
-    url: str = Field(default=..., description="""The complete URL (including http/https protocol) to the external resource.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['OutbreakResource', 'WorkflowUrlSpec']} })
-    title: str = Field(default=..., description="""The display title for the resource link as it will appear in the BRC Analytics interface.""", json_schema_extra = { "linkml_meta": {'alias': 'title', 'domain_of': ['OutbreakResource']} })
-    type: OutbreakResourceType = Field(default=..., description="""The category or type of the resource (e.g., REFERENCE, TOOL, DATABASE), which determines how it is displayed and organized.""", json_schema_extra = { "linkml_meta": {'alias': 'type', 'domain_of': ['OutbreakResource']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/outbreaks.yaml#"
+        }
+    )
+
+    url: str = Field(
+        default=...,
+        description="""The complete URL (including http/https protocol) to the external resource.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["OutbreakResource", "WorkflowUrlSpec"],
+            }
+        },
+    )
+    title: str = Field(
+        default=...,
+        description="""The display title for the resource link as it will appear in the BRC Analytics interface.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "title", "domain_of": ["OutbreakResource"]}
+        },
+    )
+    type: OutbreakResourceType = Field(
+        default=...,
+        description="""The category or type of the resource (e.g., REFERENCE, TOOL, DATABASE), which determines how it is displayed and organized.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "type", "domain_of": ["OutbreakResource"]}
+        },
+    )
 
 
 class MarkdownFileReference(ConfiguredBaseModel):
     """
     A reference to a markdown file containing detailed content about a priority pathogen.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/outbreaks.yaml#'})
 
-    path: str = Field(default=..., description="""Relative path to the markdown file from the project root. Must end with .md extension.""", json_schema_extra = { "linkml_meta": {'alias': 'path', 'domain_of': ['MarkdownFileReference']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/outbreaks.yaml#"
+        }
+    )
 
-    @field_validator('path')
+    path: str = Field(
+        default=...,
+        description="""Relative path to the markdown file from the project root. Must end with .md extension.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "path", "domain_of": ["MarkdownFileReference"]}
+        },
+    )
+
+    @field_validator("path")
     def pattern_path(cls, v):
-        pattern=re.compile(r".*\.md$")
-        if isinstance(v,list):
+        pattern = re.compile(r".*\.md$")
+        if isinstance(v, list):
             for element in v:
                 if isinstance(v, str) and not pattern.match(element):
                     raise ValueError(f"Invalid path format: {element}")
-        elif isinstance(v,str):
+        elif isinstance(v, str):
             if not pattern.match(v):
                 raise ValueError(f"Invalid path format: {v}")
         return v
@@ -244,72 +399,252 @@ class WorkflowCategories(ConfiguredBaseModel):
     """
     Root object containing a collection of workflow category definitions used to organize workflows in the BRC Analytics platform.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflow_categories.yaml#',
-         'tree_root': True})
 
-    workflow_categories: List[WorkflowCategory] = Field(default=..., description="""Collection of workflow category entries that will be used to group and organize workflows in the BRC Analytics interface.""", json_schema_extra = { "linkml_meta": {'alias': 'workflow_categories', 'domain_of': ['WorkflowCategories']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflow_categories.yaml#",
+            "tree_root": True,
+        }
+    )
+
+    workflow_categories: List[WorkflowCategory] = Field(
+        default=...,
+        description="""Collection of workflow category entries that will be used to group and organize workflows in the BRC Analytics interface.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "workflow_categories",
+                "domain_of": ["WorkflowCategories"],
+            }
+        },
+    )
 
 
 class WorkflowCategory(ConfiguredBaseModel):
     """
     Definition of a workflow category used to group related workflows for organization and display purposes.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflow_categories.yaml#'})
 
-    category: WorkflowCategoryId = Field(default=..., description="""The unique identifier for the workflow category, used to link workflows to their respective categories.""", json_schema_extra = { "linkml_meta": {'alias': 'category', 'domain_of': ['WorkflowCategory']} })
-    name: str = Field(default=..., description="""The human-readable display name of the workflow category as it will appear in the BRC Analytics interface.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Outbreak', 'WorkflowCategory']} })
-    description: str = Field(default=..., description="""A detailed description of the workflow category explaining its purpose and the types of workflows it contains.""", json_schema_extra = { "linkml_meta": {'alias': 'description', 'domain_of': ['Outbreak', 'WorkflowCategory']} })
-    show_coming_soon: bool = Field(default=..., description="""Boolean flag that determines whether to display a 'Coming Soon' indicator for this category in the BRC Analytics interface when workflows in this category are not yet available.""", json_schema_extra = { "linkml_meta": {'alias': 'show_coming_soon', 'domain_of': ['WorkflowCategory']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflow_categories.yaml#"
+        }
+    )
+
+    category: WorkflowCategoryId = Field(
+        default=...,
+        description="""The unique identifier for the workflow category, used to link workflows to their respective categories.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "category", "domain_of": ["WorkflowCategory"]}
+        },
+    )
+    name: str = Field(
+        default=...,
+        description="""The human-readable display name of the workflow category as it will appear in the BRC Analytics interface.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Outbreak", "WorkflowCategory"],
+            }
+        },
+    )
+    description: str = Field(
+        default=...,
+        description="""A detailed description of the workflow category explaining its purpose and the types of workflows it contains.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": ["Outbreak", "WorkflowCategory"],
+            }
+        },
+    )
+    show_coming_soon: bool = Field(
+        default=...,
+        description="""Boolean flag that determines whether to display a 'Coming Soon' indicator for this category in the BRC Analytics interface when workflows in this category are not yet available.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "show_coming_soon",
+                "domain_of": ["WorkflowCategory"],
+            }
+        },
+    )
 
 
 class Workflows(ConfiguredBaseModel):
     """
     Root object containing a collection of Galaxy workflow definitions for the BRC Analytics platform.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#',
-         'tree_root': True})
 
-    workflows: List[Workflow] = Field(default=..., description="""Collection of workflow entries that will be available to users in the BRC Analytics platform.""", json_schema_extra = { "linkml_meta": {'alias': 'workflows', 'domain_of': ['Workflows']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#",
+            "tree_root": True,
+        }
+    )
+
+    workflows: List[Workflow] = Field(
+        default=...,
+        description="""Collection of workflow entries that will be available to users in the BRC Analytics platform.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "workflows", "domain_of": ["Workflows"]}
+        },
+    )
 
 
 class Workflow(ConfiguredBaseModel):
     """
     Definition of a Galaxy workflow with its metadata, parameters, and organism compatibility information.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#'})
 
-    trs_id: str = Field(default=..., description="""The Tool Repository Service (TRS) identifier for the workflow, used to locate and retrieve the workflow from a Galaxy server.""", json_schema_extra = { "linkml_meta": {'alias': 'trs_id', 'domain_of': ['Workflow']} })
-    categories: List[WorkflowCategoryId] = Field(default=..., description="""List of category identifiers that this workflow belongs to, determining how it is organized and displayed in the BRC Analytics interface.""", json_schema_extra = { "linkml_meta": {'alias': 'categories', 'domain_of': ['Workflow']} })
-    workflow_name: str = Field(default=..., description="""The human-readable display name of the workflow as it will appear in the BRC Analytics interface.""", json_schema_extra = { "linkml_meta": {'alias': 'workflow_name', 'domain_of': ['Workflow']} })
-    workflow_description: str = Field(default=..., description="""A detailed description of the workflow's purpose, functionality, and expected outputs for users.""", json_schema_extra = { "linkml_meta": {'alias': 'workflow_description', 'domain_of': ['Workflow']} })
-    ploidy: WorkflowPloidy = Field(default=..., description="""The ploidy state (number of chromosome sets) that this workflow is designed to work with, ensuring compatibility with organism data.""", json_schema_extra = { "linkml_meta": {'alias': 'ploidy', 'domain_of': ['Organism', 'Workflow']} })
-    taxonomy_id: Optional[int] = Field(default=None, description="""The NCBI Taxonomy ID of the organism this workflow is designed for. If specified, the workflow will be available for all assemblies with this ID in their taxonomic lineage.""", json_schema_extra = { "linkml_meta": {'alias': 'taxonomy_id', 'domain_of': ['Organism', 'Outbreak', 'Workflow']} })
-    parameters: List[WorkflowParameter] = Field(default=..., description="""Collection of input parameters that will be passed to the workflow when it is executed, including data sources and configuration options.""", json_schema_extra = { "linkml_meta": {'alias': 'parameters', 'domain_of': ['Workflow']} })
-    active: bool = Field(default=..., description="""Boolean flag that determines if the workflow should be included in the BRC Analytics interface. Used to manage visibility of workflows that may be under development or deprecated.""", json_schema_extra = { "linkml_meta": {'alias': 'active', 'domain_of': ['Outbreak', 'Workflow']} })
-    iwc_id: Optional[str] = Field(default=None, description="""The Intergalactic Workflow Commission (IWC) identifier for the workflow, used to link to the workflow's page on the IWC website.""", json_schema_extra = { "linkml_meta": {'alias': 'iwc_id', 'domain_of': ['Workflow']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#"
+        }
+    )
+
+    trs_id: str = Field(
+        default=...,
+        description="""The Tool Repository Service (TRS) identifier for the workflow, used to locate and retrieve the workflow from a Galaxy server.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "trs_id", "domain_of": ["Workflow"]}
+        },
+    )
+    categories: List[WorkflowCategoryId] = Field(
+        default=...,
+        description="""List of category identifiers that this workflow belongs to, determining how it is organized and displayed in the BRC Analytics interface.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "categories", "domain_of": ["Workflow"]}
+        },
+    )
+    workflow_name: str = Field(
+        default=...,
+        description="""The human-readable display name of the workflow as it will appear in the BRC Analytics interface.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "workflow_name", "domain_of": ["Workflow"]}
+        },
+    )
+    workflow_description: str = Field(
+        default=...,
+        description="""A detailed description of the workflow's purpose, functionality, and expected outputs for users.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "workflow_description", "domain_of": ["Workflow"]}
+        },
+    )
+    ploidy: WorkflowPloidy = Field(
+        default=...,
+        description="""The ploidy state (number of chromosome sets) that this workflow is designed to work with, ensuring compatibility with organism data.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "ploidy", "domain_of": ["Organism", "Workflow"]}
+        },
+    )
+    taxonomy_id: Optional[int] = Field(
+        default=None,
+        description="""The NCBI Taxonomy ID of the organism this workflow is designed for. If specified, the workflow will be available for all assemblies with this ID in their taxonomic lineage.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "taxonomy_id",
+                "domain_of": ["Organism", "Outbreak", "Workflow"],
+            }
+        },
+    )
+    parameters: List[WorkflowParameter] = Field(
+        default=...,
+        description="""Collection of input parameters that will be passed to the workflow when it is executed, including data sources and configuration options.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "parameters", "domain_of": ["Workflow"]}
+        },
+    )
+    active: bool = Field(
+        default=...,
+        description="""Boolean flag that determines if the workflow should be included in the BRC Analytics interface. Used to manage visibility of workflows that may be under development or deprecated.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "active", "domain_of": ["Outbreak", "Workflow"]}
+        },
+    )
+    iwc_id: str = Field(
+        default=...,
+        description="""The Intergalactic Workflow Commission (IWC) identifier for the workflow, used to link to the workflow's page on the IWC website.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "iwc_id", "domain_of": ["Workflow"]}
+        },
+    )
 
 
 class WorkflowParameter(ConfiguredBaseModel):
     """
     Definition of an input parameter for a Galaxy workflow, specifying how the parameter value should be determined when the workflow is executed.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#'})
 
-    key: str = Field(default=..., description="""The identifier for the parameter as expected by the Galaxy workflow, used to map the parameter value to the correct input.""", json_schema_extra = { "linkml_meta": {'alias': 'key', 'domain_of': ['WorkflowParameter']} })
-    variable: Optional[WorkflowParameterVariable] = Field(default=None, description="""A predefined variable that will be substituted as the value of the parameter at runtime, such as assembly information.""", json_schema_extra = { "linkml_meta": {'alias': 'variable', 'domain_of': ['WorkflowParameter']} })
-    url_spec: Optional[WorkflowUrlSpec] = Field(default=None, description="""A direct URL specification for the parameter, allowing for external data sources to be provided to the workflow.""", json_schema_extra = { "linkml_meta": {'alias': 'url_spec', 'domain_of': ['WorkflowParameter']} })
-    type_guide: Optional[Any] = Field(default=None, description="""Arbitrary data describing the expected type and format of the parameter, intended as a reference for catalog maintainers and not used in workflow execution.""", json_schema_extra = { "linkml_meta": {'alias': 'type_guide', 'domain_of': ['WorkflowParameter']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#"
+        }
+    )
+
+    key: str = Field(
+        default=...,
+        description="""The identifier for the parameter as expected by the Galaxy workflow, used to map the parameter value to the correct input.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "key", "domain_of": ["WorkflowParameter"]}
+        },
+    )
+    variable: Optional[WorkflowParameterVariable] = Field(
+        default=None,
+        description="""A predefined variable that will be substituted as the value of the parameter at runtime, such as assembly information.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "variable", "domain_of": ["WorkflowParameter"]}
+        },
+    )
+    url_spec: Optional[WorkflowUrlSpec] = Field(
+        default=None,
+        description="""A direct URL specification for the parameter, allowing for external data sources to be provided to the workflow.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "url_spec", "domain_of": ["WorkflowParameter"]}
+        },
+    )
+    type_guide: Optional[Any] = Field(
+        default=None,
+        description="""Arbitrary data describing the expected type and format of the parameter, intended as a reference for catalog maintainers and not used in workflow execution.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "type_guide", "domain_of": ["WorkflowParameter"]}
+        },
+    )
 
 
 class WorkflowUrlSpec(ConfiguredBaseModel):
     """
     Definition of a URL-based data source for a workflow parameter, typically used for reference data or external resources.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#'})
 
-    ext: str = Field(default=..., description="""The file extension of the resource at the URL, which determines how Galaxy will interpret the data (e.g., 'fasta', 'gff', 'tabular').""", json_schema_extra = { "linkml_meta": {'alias': 'ext', 'domain_of': ['WorkflowUrlSpec']} })
-    src: str = Field(default=..., description="""The source type for the parameter, typically 'url' to indicate an external URL source rather than a Galaxy dataset or other source type.""", json_schema_extra = { "linkml_meta": {'alias': 'src', 'domain_of': ['WorkflowUrlSpec']} })
-    url: str = Field(default=..., description="""The complete URL (including http/https protocol) to the external resource that will be used as input to the workflow.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['OutbreakResource', 'WorkflowUrlSpec']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#"
+        }
+    )
+
+    ext: str = Field(
+        default=...,
+        description="""The file extension of the resource at the URL, which determines how Galaxy will interpret the data (e.g., 'fasta', 'gff', 'tabular').""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "ext", "domain_of": ["WorkflowUrlSpec"]}
+        },
+    )
+    src: str = Field(
+        default=...,
+        description="""The source type for the parameter, typically 'url' to indicate an external URL source rather than a Galaxy dataset or other source type.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "src", "domain_of": ["WorkflowUrlSpec"]}
+        },
+    )
+    url: str = Field(
+        default=...,
+        description="""The complete URL (including http/https protocol) to the external resource that will be used as input to the workflow.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["OutbreakResource", "WorkflowUrlSpec"],
+            }
+        },
+    )
 
 
 # Model rebuild
@@ -328,4 +663,3 @@ Workflows.model_rebuild()
 Workflow.model_rebuild()
 WorkflowParameter.model_rebuild()
 WorkflowUrlSpec.model_rebuild()
-

--- a/catalog/py_package/catalog_build/generated_schema/schema.py
+++ b/catalog/py_package/catalog_build/generated_schema/schema.py
@@ -1,13 +1,31 @@
-from __future__ import annotations
+from __future__ import annotations 
 
 import re
 import sys
-from datetime import date, datetime, time
-from decimal import Decimal
-from enum import Enum
-from typing import Any, ClassVar, Dict, List, Literal, Optional, Union
+from datetime import (
+    date,
+    datetime,
+    time
+)
+from decimal import Decimal 
+from enum import Enum 
+from typing import (
+    Any,
+    ClassVar,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Union
+)
 
-from pydantic import BaseModel, ConfigDict, Field, RootModel, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    RootModel,
+    field_validator
+)
 
 
 metamodel_version = "None"
@@ -16,62 +34,52 @@ version = "None"
 
 class ConfiguredBaseModel(BaseModel):
     model_config = ConfigDict(
-        validate_assignment=True,
-        validate_default=True,
-        extra="forbid",
-        arbitrary_types_allowed=True,
-        use_enum_values=True,
-        strict=False,
+        validate_assignment = True,
+        validate_default = True,
+        extra = "forbid",
+        arbitrary_types_allowed = True,
+        use_enum_values = True,
+        strict = False,
     )
     pass
+
+
 
 
 class LinkMLMeta(RootModel):
     root: Dict[str, Any] = {}
     model_config = ConfigDict(frozen=True)
 
-    def __getattr__(self, key: str):
+    def __getattr__(self, key:str):
         return getattr(self.root, key)
 
-    def __getitem__(self, key: str):
+    def __getitem__(self, key:str):
         return self.root[key]
 
-    def __setitem__(self, key: str, value):
+    def __setitem__(self, key:str, value):
         self.root[key] = value
 
-    def __contains__(self, key: str) -> bool:
+    def __contains__(self, key:str) -> bool:
         return key in self.root
 
 
-linkml_meta = LinkMLMeta(
-    {
-        "default_prefix": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/schema.yaml#",
-        "description": "Combined source data schemas.",
-        "id": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/schema.yaml#",
-        "imports": [
-            "./assemblies",
-            "./organisms",
-            "./outbreaks",
-            "./workflow_categories",
-            "./workflows",
-        ],
-        "name": "schema",
-        "prefixes": {
-            "linkml": {
-                "prefix_prefix": "linkml",
-                "prefix_reference": "https://w3id.org/linkml/",
-            }
-        },
-        "source_file": "/Users/dannon/work/brc-analytics/catalog/py_package/catalog_build/schema_utils/../schema/schema.yaml",
-    }
-)
-
+linkml_meta = LinkMLMeta({'default_prefix': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/schema.yaml#',
+     'description': 'Combined source data schemas.',
+     'id': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/schema.yaml#',
+     'imports': ['./assemblies',
+                 './organisms',
+                 './outbreaks',
+                 './workflow_categories',
+                 './workflows'],
+     'name': 'schema',
+     'prefixes': {'linkml': {'prefix_prefix': 'linkml',
+                             'prefix_reference': 'https://w3id.org/linkml/'}},
+     'source_file': '/Users/dannon/work/brc-analytics/catalog/py_package/catalog_build/schema_utils/../schema/schema.yaml'} )
 
 class OrganismPloidy(str, Enum):
     """
     Possible ploidies of an organism.
     """
-
     DIPLOID = "DIPLOID"
     HAPLOID = "HAPLOID"
     POLYPLOID = "POLYPLOID"
@@ -81,7 +89,6 @@ class OutbreakPriority(str, Enum):
     """
     Possible priorities of an outbreak.
     """
-
     HIGHEST = "HIGHEST"
     CRITICAL = "CRITICAL"
     HIGH = "HIGH"
@@ -93,7 +100,6 @@ class OutbreakResourceType(str, Enum):
     """
     Possible types of an outbreak resource.
     """
-
     PUBLICATION = "PUBLICATION"
     REFERENCE = "REFERENCE"
     NEWS = "NEWS"
@@ -107,7 +113,6 @@ class WorkflowCategoryId(str, Enum):
     """
     Set of IDs of workflow categories.
     """
-
     VARIANT_CALLING = "VARIANT_CALLING"
     TRANSCRIPTOMICS = "TRANSCRIPTOMICS"
     REGULATION = "REGULATION"
@@ -122,7 +127,6 @@ class WorkflowParameterVariable(str, Enum):
     """
     Possible variables that can be inserted into workflow parameters.
     """
-
     ASSEMBLY_ID = "ASSEMBLY_ID"
     ASSEMBLY_FASTA_URL = "ASSEMBLY_FASTA_URL"
     GENE_MODEL_URL = "GENE_MODEL_URL"
@@ -133,264 +137,104 @@ class WorkflowPloidy(str, Enum):
     """
     Possible ploidies supported by workflows.
     """
-
     ANY = "ANY"
     DIPLOID = "DIPLOID"
     HAPLOID = "HAPLOID"
     POLYPLOID = "POLYPLOID"
 
 
+
 class Assemblies(ConfiguredBaseModel):
     """
     Root object containing a collection of genomic assembly definitions for the BRC Analytics platform.
     """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/assemblies.yaml#',
+         'tree_root': True})
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/assemblies.yaml#",
-            "tree_root": True,
-        }
-    )
-
-    assemblies: List[Assembly] = Field(
-        default=...,
-        description="""Collection of genomic assembly entries that will be available for analysis in the BRC Analytics platform.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "assemblies", "domain_of": ["Assemblies"]}
-        },
-    )
+    assemblies: List[Assembly] = Field(default=..., description="""Collection of genomic assembly entries that will be available for analysis in the BRC Analytics platform.""", json_schema_extra = { "linkml_meta": {'alias': 'assemblies', 'domain_of': ['Assemblies']} })
 
 
 class Assembly(ConfiguredBaseModel):
     """
     Definition of a genomic assembly with its unique identifier.
     """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/assemblies.yaml#'})
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/assemblies.yaml#"
-        }
-    )
-
-    accession: str = Field(
-        default=...,
-        description="""The unique accession identifier for the assembly (e.g., GCA_000001405.28 for GRCh38), used to retrieve the assembly data from public repositories.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "accession", "domain_of": ["Assembly"]}
-        },
-    )
+    accession: str = Field(default=..., description="""The unique accession identifier for the assembly (e.g., GCA_000001405.28 for GRCh38), used to retrieve the assembly data from public repositories.""", json_schema_extra = { "linkml_meta": {'alias': 'accession', 'domain_of': ['Assembly']} })
 
 
 class Organisms(ConfiguredBaseModel):
     """
     Root object containing a collection of organism definitions for the BRC Analytics platform.
     """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/organisms.yaml#',
+         'tree_root': True})
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/organisms.yaml#",
-            "tree_root": True,
-        }
-    )
-
-    organisms: List[Organism] = Field(
-        default=...,
-        description="""Collection of organism entries that will be available in the BRC Analytics platform.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "organisms", "domain_of": ["Organisms"]}
-        },
-    )
+    organisms: List[Organism] = Field(default=..., description="""Collection of organism entries that will be available in the BRC Analytics platform.""", json_schema_extra = { "linkml_meta": {'alias': 'organisms', 'domain_of': ['Organisms']} })
 
 
 class Organism(ConfiguredBaseModel):
     """
     Definition of an organism with its taxonomic and genetic characteristics.
     """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/organisms.yaml#'})
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/organisms.yaml#"
-        }
-    )
-
-    taxonomy_id: int = Field(
-        default=...,
-        description="""An NCBI Taxonomy ID at rank 'species'.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "taxonomy_id",
-                "domain_of": ["Organism", "Outbreak", "Workflow"],
-            }
-        },
-    )
-    ploidy: List[OrganismPloidy] = Field(
-        default=...,
-        description="""The possible ploidy states (number of chromosome sets) that the organism may have, which determines compatible workflows.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "ploidy", "domain_of": ["Organism", "Workflow"]}
-        },
-    )
+    taxonomy_id: int = Field(default=..., description="""An NCBI Taxonomy ID at rank 'species'.""", json_schema_extra = { "linkml_meta": {'alias': 'taxonomy_id', 'domain_of': ['Organism', 'Outbreak', 'Workflow']} })
+    ploidy: List[OrganismPloidy] = Field(default=..., description="""The possible ploidy states (number of chromosome sets) that the organism may have, which determines compatible workflows.""", json_schema_extra = { "linkml_meta": {'alias': 'ploidy', 'domain_of': ['Organism', 'Workflow']} })
 
 
 class Outbreaks(ConfiguredBaseModel):
     """
     Root object containing a collection of pathogen definitions for the BRC Analytics platform to highlight as outbreaks/priority pathogens.
     """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/outbreaks.yaml#',
+         'tree_root': True})
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/outbreaks.yaml#",
-            "tree_root": True,
-        }
-    )
-
-    outbreaks: List[Outbreak] = Field(
-        default=...,
-        description="""Collection of pathogen entries that will be displayed in the BRC Analytics platform as outbreaks/priority pathogens.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "outbreaks", "domain_of": ["Outbreaks"]}
-        },
-    )
+    outbreaks: List[Outbreak] = Field(default=..., description="""Collection of pathogen entries that will be displayed in the BRC Analytics platform as outbreaks/priority pathogens.""", json_schema_extra = { "linkml_meta": {'alias': 'outbreaks', 'domain_of': ['Outbreaks']} })
 
 
 class Outbreak(ConfiguredBaseModel):
     """
     Definition of a priority pathogen with its taxonomic classification, priority level, and associated resources.
     """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/outbreaks.yaml#'})
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/outbreaks.yaml#"
-        }
-    )
-
-    name: str = Field(
-        default=...,
-        description="""The display name of the pathogen as it will appear in the BRC Analytics interface.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "name",
-                "domain_of": ["Outbreak", "WorkflowCategory"],
-            }
-        },
-    )
-    taxonomy_id: int = Field(
-        default=...,
-        description="""The NCBI Taxonomy ID for the pathogen. Used to link to relevant genomic data and workflows.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "taxonomy_id",
-                "domain_of": ["Organism", "Outbreak", "Workflow"],
-            }
-        },
-    )
-    priority: OutbreakPriority = Field(
-        default=...,
-        description="""The priority level of the pathogen, which determines its visibility and prominence in the BRC Analytics interface.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "priority", "domain_of": ["Outbreak"]}
-        },
-    )
-    resources: List[OutbreakResource] = Field(
-        default=...,
-        description="""Collection of external resources (references, tools, databases) related to the pathogen.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "resources", "domain_of": ["Outbreak"]}
-        },
-    )
-    description: MarkdownFileReference = Field(
-        default=...,
-        description="""Reference to a markdown file containing detailed information about the pathogen.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "description",
-                "domain_of": ["Outbreak", "WorkflowCategory"],
-            }
-        },
-    )
-    active: bool = Field(
-        default=...,
-        description="""Boolean flag that determines if the pathogen should be included in the BRC Analytics interface. Used to manage visibility as pathogen relevance changes over time.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "active", "domain_of": ["Outbreak", "Workflow"]}
-        },
-    )
-    highlight_descendant_taxonomy_ids: Optional[List[int]] = Field(
-        default=None,
-        description="""List of NCBI Taxonomy IDs for descendant taxa (e.g., specific strains or serotypes) that should be highlighted within the outbreak category.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "highlight_descendant_taxonomy_ids",
-                "domain_of": ["Outbreak"],
-            }
-        },
-    )
+    name: str = Field(default=..., description="""The display name of the pathogen as it will appear in the BRC Analytics interface.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Outbreak', 'WorkflowCategory']} })
+    taxonomy_id: int = Field(default=..., description="""The NCBI Taxonomy ID for the pathogen. Used to link to relevant genomic data and workflows.""", json_schema_extra = { "linkml_meta": {'alias': 'taxonomy_id', 'domain_of': ['Organism', 'Outbreak', 'Workflow']} })
+    priority: OutbreakPriority = Field(default=..., description="""The priority level of the pathogen, which determines its visibility and prominence in the BRC Analytics interface.""", json_schema_extra = { "linkml_meta": {'alias': 'priority', 'domain_of': ['Outbreak']} })
+    resources: List[OutbreakResource] = Field(default=..., description="""Collection of external resources (references, tools, databases) related to the pathogen.""", json_schema_extra = { "linkml_meta": {'alias': 'resources', 'domain_of': ['Outbreak']} })
+    description: MarkdownFileReference = Field(default=..., description="""Reference to a markdown file containing detailed information about the pathogen.""", json_schema_extra = { "linkml_meta": {'alias': 'description', 'domain_of': ['Outbreak', 'WorkflowCategory']} })
+    active: bool = Field(default=..., description="""Boolean flag that determines if the pathogen should be included in the BRC Analytics interface. Used to manage visibility as pathogen relevance changes over time.""", json_schema_extra = { "linkml_meta": {'alias': 'active', 'domain_of': ['Outbreak', 'Workflow']} })
+    highlight_descendant_taxonomy_ids: Optional[List[int]] = Field(default=None, description="""List of NCBI Taxonomy IDs for descendant taxa (e.g., specific strains or serotypes) that should be highlighted within the outbreak category.""", json_schema_extra = { "linkml_meta": {'alias': 'highlight_descendant_taxonomy_ids', 'domain_of': ['Outbreak']} })
 
 
 class OutbreakResource(ConfiguredBaseModel):
     """
     Definition of an external resource (reference, tool, database) associated with a priority pathogen.
     """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/outbreaks.yaml#'})
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/outbreaks.yaml#"
-        }
-    )
-
-    url: str = Field(
-        default=...,
-        description="""The complete URL (including http/https protocol) to the external resource.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "url",
-                "domain_of": ["OutbreakResource", "WorkflowUrlSpec"],
-            }
-        },
-    )
-    title: str = Field(
-        default=...,
-        description="""The display title for the resource link as it will appear in the BRC Analytics interface.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "title", "domain_of": ["OutbreakResource"]}
-        },
-    )
-    type: OutbreakResourceType = Field(
-        default=...,
-        description="""The category or type of the resource (e.g., REFERENCE, TOOL, DATABASE), which determines how it is displayed and organized.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "type", "domain_of": ["OutbreakResource"]}
-        },
-    )
+    url: str = Field(default=..., description="""The complete URL (including http/https protocol) to the external resource.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['OutbreakResource', 'WorkflowUrlSpec']} })
+    title: str = Field(default=..., description="""The display title for the resource link as it will appear in the BRC Analytics interface.""", json_schema_extra = { "linkml_meta": {'alias': 'title', 'domain_of': ['OutbreakResource']} })
+    type: OutbreakResourceType = Field(default=..., description="""The category or type of the resource (e.g., REFERENCE, TOOL, DATABASE), which determines how it is displayed and organized.""", json_schema_extra = { "linkml_meta": {'alias': 'type', 'domain_of': ['OutbreakResource']} })
 
 
 class MarkdownFileReference(ConfiguredBaseModel):
     """
     A reference to a markdown file containing detailed content about a priority pathogen.
     """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/outbreaks.yaml#'})
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/outbreaks.yaml#"
-        }
-    )
+    path: str = Field(default=..., description="""Relative path to the markdown file from the project root. Must end with .md extension.""", json_schema_extra = { "linkml_meta": {'alias': 'path', 'domain_of': ['MarkdownFileReference']} })
 
-    path: str = Field(
-        default=...,
-        description="""Relative path to the markdown file from the project root. Must end with .md extension.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "path", "domain_of": ["MarkdownFileReference"]}
-        },
-    )
-
-    @field_validator("path")
+    @field_validator('path')
     def pattern_path(cls, v):
-        pattern = re.compile(r".*\.md$")
-        if isinstance(v, list):
+        pattern=re.compile(r".*\.md$")
+        if isinstance(v,list):
             for element in v:
                 if isinstance(v, str) and not pattern.match(element):
                     raise ValueError(f"Invalid path format: {element}")
-        elif isinstance(v, str):
+        elif isinstance(v,str):
             if not pattern.match(v):
                 raise ValueError(f"Invalid path format: {v}")
         return v
@@ -400,252 +244,72 @@ class WorkflowCategories(ConfiguredBaseModel):
     """
     Root object containing a collection of workflow category definitions used to organize workflows in the BRC Analytics platform.
     """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflow_categories.yaml#',
+         'tree_root': True})
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflow_categories.yaml#",
-            "tree_root": True,
-        }
-    )
-
-    workflow_categories: List[WorkflowCategory] = Field(
-        default=...,
-        description="""Collection of workflow category entries that will be used to group and organize workflows in the BRC Analytics interface.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "workflow_categories",
-                "domain_of": ["WorkflowCategories"],
-            }
-        },
-    )
+    workflow_categories: List[WorkflowCategory] = Field(default=..., description="""Collection of workflow category entries that will be used to group and organize workflows in the BRC Analytics interface.""", json_schema_extra = { "linkml_meta": {'alias': 'workflow_categories', 'domain_of': ['WorkflowCategories']} })
 
 
 class WorkflowCategory(ConfiguredBaseModel):
     """
     Definition of a workflow category used to group related workflows for organization and display purposes.
     """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflow_categories.yaml#'})
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflow_categories.yaml#"
-        }
-    )
-
-    category: WorkflowCategoryId = Field(
-        default=...,
-        description="""The unique identifier for the workflow category, used to link workflows to their respective categories.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "category", "domain_of": ["WorkflowCategory"]}
-        },
-    )
-    name: str = Field(
-        default=...,
-        description="""The human-readable display name of the workflow category as it will appear in the BRC Analytics interface.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "name",
-                "domain_of": ["Outbreak", "WorkflowCategory"],
-            }
-        },
-    )
-    description: str = Field(
-        default=...,
-        description="""A detailed description of the workflow category explaining its purpose and the types of workflows it contains.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "description",
-                "domain_of": ["Outbreak", "WorkflowCategory"],
-            }
-        },
-    )
-    show_coming_soon: bool = Field(
-        default=...,
-        description="""Boolean flag that determines whether to display a 'Coming Soon' indicator for this category in the BRC Analytics interface when workflows in this category are not yet available.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "show_coming_soon",
-                "domain_of": ["WorkflowCategory"],
-            }
-        },
-    )
+    category: WorkflowCategoryId = Field(default=..., description="""The unique identifier for the workflow category, used to link workflows to their respective categories.""", json_schema_extra = { "linkml_meta": {'alias': 'category', 'domain_of': ['WorkflowCategory']} })
+    name: str = Field(default=..., description="""The human-readable display name of the workflow category as it will appear in the BRC Analytics interface.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Outbreak', 'WorkflowCategory']} })
+    description: str = Field(default=..., description="""A detailed description of the workflow category explaining its purpose and the types of workflows it contains.""", json_schema_extra = { "linkml_meta": {'alias': 'description', 'domain_of': ['Outbreak', 'WorkflowCategory']} })
+    show_coming_soon: bool = Field(default=..., description="""Boolean flag that determines whether to display a 'Coming Soon' indicator for this category in the BRC Analytics interface when workflows in this category are not yet available.""", json_schema_extra = { "linkml_meta": {'alias': 'show_coming_soon', 'domain_of': ['WorkflowCategory']} })
 
 
 class Workflows(ConfiguredBaseModel):
     """
     Root object containing a collection of Galaxy workflow definitions for the BRC Analytics platform.
     """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#',
+         'tree_root': True})
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#",
-            "tree_root": True,
-        }
-    )
-
-    workflows: List[Workflow] = Field(
-        default=...,
-        description="""Collection of workflow entries that will be available to users in the BRC Analytics platform.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "workflows", "domain_of": ["Workflows"]}
-        },
-    )
+    workflows: List[Workflow] = Field(default=..., description="""Collection of workflow entries that will be available to users in the BRC Analytics platform.""", json_schema_extra = { "linkml_meta": {'alias': 'workflows', 'domain_of': ['Workflows']} })
 
 
 class Workflow(ConfiguredBaseModel):
     """
     Definition of a Galaxy workflow with its metadata, parameters, and organism compatibility information.
     """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#'})
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#"
-        }
-    )
-
-    trs_id: str = Field(
-        default=...,
-        description="""The Tool Repository Service (TRS) identifier for the workflow, used to locate and retrieve the workflow from a Galaxy server.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "trs_id", "domain_of": ["Workflow"]}
-        },
-    )
-    categories: List[WorkflowCategoryId] = Field(
-        default=...,
-        description="""List of category identifiers that this workflow belongs to, determining how it is organized and displayed in the BRC Analytics interface.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "categories", "domain_of": ["Workflow"]}
-        },
-    )
-    workflow_name: str = Field(
-        default=...,
-        description="""The human-readable display name of the workflow as it will appear in the BRC Analytics interface.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "workflow_name", "domain_of": ["Workflow"]}
-        },
-    )
-    workflow_description: str = Field(
-        default=...,
-        description="""A detailed description of the workflow's purpose, functionality, and expected outputs for users.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "workflow_description", "domain_of": ["Workflow"]}
-        },
-    )
-    ploidy: WorkflowPloidy = Field(
-        default=...,
-        description="""The ploidy state (number of chromosome sets) that this workflow is designed to work with, ensuring compatibility with organism data.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "ploidy", "domain_of": ["Organism", "Workflow"]}
-        },
-    )
-    taxonomy_id: Optional[int] = Field(
-        default=None,
-        description="""The NCBI Taxonomy ID of the organism this workflow is designed for. If specified, the workflow will be available for all assemblies with this ID in their taxonomic lineage.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "taxonomy_id",
-                "domain_of": ["Organism", "Outbreak", "Workflow"],
-            }
-        },
-    )
-    parameters: List[WorkflowParameter] = Field(
-        default=...,
-        description="""Collection of input parameters that will be passed to the workflow when it is executed, including data sources and configuration options.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "parameters", "domain_of": ["Workflow"]}
-        },
-    )
-    active: bool = Field(
-        default=...,
-        description="""Boolean flag that determines if the workflow should be included in the BRC Analytics interface. Used to manage visibility of workflows that may be under development or deprecated.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "active", "domain_of": ["Outbreak", "Workflow"]}
-        },
-    )
-    iwc_id: Optional[str] = Field(
-        default=None,
-        description="""The Intergalactic Workflow Commission (IWC) identifier for the workflow, used to link to the workflow's page on the IWC website.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "iwc_id", "domain_of": ["Workflow"]}
-        },
-    )
+    trs_id: str = Field(default=..., description="""The Tool Repository Service (TRS) identifier for the workflow, used to locate and retrieve the workflow from a Galaxy server.""", json_schema_extra = { "linkml_meta": {'alias': 'trs_id', 'domain_of': ['Workflow']} })
+    categories: List[WorkflowCategoryId] = Field(default=..., description="""List of category identifiers that this workflow belongs to, determining how it is organized and displayed in the BRC Analytics interface.""", json_schema_extra = { "linkml_meta": {'alias': 'categories', 'domain_of': ['Workflow']} })
+    workflow_name: str = Field(default=..., description="""The human-readable display name of the workflow as it will appear in the BRC Analytics interface.""", json_schema_extra = { "linkml_meta": {'alias': 'workflow_name', 'domain_of': ['Workflow']} })
+    workflow_description: str = Field(default=..., description="""A detailed description of the workflow's purpose, functionality, and expected outputs for users.""", json_schema_extra = { "linkml_meta": {'alias': 'workflow_description', 'domain_of': ['Workflow']} })
+    ploidy: WorkflowPloidy = Field(default=..., description="""The ploidy state (number of chromosome sets) that this workflow is designed to work with, ensuring compatibility with organism data.""", json_schema_extra = { "linkml_meta": {'alias': 'ploidy', 'domain_of': ['Organism', 'Workflow']} })
+    taxonomy_id: Optional[int] = Field(default=None, description="""The NCBI Taxonomy ID of the organism this workflow is designed for. If specified, the workflow will be available for all assemblies with this ID in their taxonomic lineage.""", json_schema_extra = { "linkml_meta": {'alias': 'taxonomy_id', 'domain_of': ['Organism', 'Outbreak', 'Workflow']} })
+    parameters: List[WorkflowParameter] = Field(default=..., description="""Collection of input parameters that will be passed to the workflow when it is executed, including data sources and configuration options.""", json_schema_extra = { "linkml_meta": {'alias': 'parameters', 'domain_of': ['Workflow']} })
+    active: bool = Field(default=..., description="""Boolean flag that determines if the workflow should be included in the BRC Analytics interface. Used to manage visibility of workflows that may be under development or deprecated.""", json_schema_extra = { "linkml_meta": {'alias': 'active', 'domain_of': ['Outbreak', 'Workflow']} })
+    iwc_id: Optional[str] = Field(default=None, description="""The Intergalactic Workflow Commission (IWC) identifier for the workflow, used to link to the workflow's page on the IWC website.""", json_schema_extra = { "linkml_meta": {'alias': 'iwc_id', 'domain_of': ['Workflow']} })
 
 
 class WorkflowParameter(ConfiguredBaseModel):
     """
     Definition of an input parameter for a Galaxy workflow, specifying how the parameter value should be determined when the workflow is executed.
     """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#'})
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#"
-        }
-    )
-
-    key: str = Field(
-        default=...,
-        description="""The identifier for the parameter as expected by the Galaxy workflow, used to map the parameter value to the correct input.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "key", "domain_of": ["WorkflowParameter"]}
-        },
-    )
-    variable: Optional[WorkflowParameterVariable] = Field(
-        default=None,
-        description="""A predefined variable that will be substituted as the value of the parameter at runtime, such as assembly information.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "variable", "domain_of": ["WorkflowParameter"]}
-        },
-    )
-    url_spec: Optional[WorkflowUrlSpec] = Field(
-        default=None,
-        description="""A direct URL specification for the parameter, allowing for external data sources to be provided to the workflow.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "url_spec", "domain_of": ["WorkflowParameter"]}
-        },
-    )
-    type_guide: Optional[Any] = Field(
-        default=None,
-        description="""Arbitrary data describing the expected type and format of the parameter, intended as a reference for catalog maintainers and not used in workflow execution.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "type_guide", "domain_of": ["WorkflowParameter"]}
-        },
-    )
+    key: str = Field(default=..., description="""The identifier for the parameter as expected by the Galaxy workflow, used to map the parameter value to the correct input.""", json_schema_extra = { "linkml_meta": {'alias': 'key', 'domain_of': ['WorkflowParameter']} })
+    variable: Optional[WorkflowParameterVariable] = Field(default=None, description="""A predefined variable that will be substituted as the value of the parameter at runtime, such as assembly information.""", json_schema_extra = { "linkml_meta": {'alias': 'variable', 'domain_of': ['WorkflowParameter']} })
+    url_spec: Optional[WorkflowUrlSpec] = Field(default=None, description="""A direct URL specification for the parameter, allowing for external data sources to be provided to the workflow.""", json_schema_extra = { "linkml_meta": {'alias': 'url_spec', 'domain_of': ['WorkflowParameter']} })
+    type_guide: Optional[Any] = Field(default=None, description="""Arbitrary data describing the expected type and format of the parameter, intended as a reference for catalog maintainers and not used in workflow execution.""", json_schema_extra = { "linkml_meta": {'alias': 'type_guide', 'domain_of': ['WorkflowParameter']} })
 
 
 class WorkflowUrlSpec(ConfiguredBaseModel):
     """
     Definition of a URL-based data source for a workflow parameter, typically used for reference data or external resources.
     """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#'})
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#"
-        }
-    )
-
-    ext: str = Field(
-        default=...,
-        description="""The file extension of the resource at the URL, which determines how Galaxy will interpret the data (e.g., 'fasta', 'gff', 'tabular').""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "ext", "domain_of": ["WorkflowUrlSpec"]}
-        },
-    )
-    src: str = Field(
-        default=...,
-        description="""The source type for the parameter, typically 'url' to indicate an external URL source rather than a Galaxy dataset or other source type.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "src", "domain_of": ["WorkflowUrlSpec"]}
-        },
-    )
-    url: str = Field(
-        default=...,
-        description="""The complete URL (including http/https protocol) to the external resource that will be used as input to the workflow.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "url",
-                "domain_of": ["OutbreakResource", "WorkflowUrlSpec"],
-            }
-        },
-    )
+    ext: str = Field(default=..., description="""The file extension of the resource at the URL, which determines how Galaxy will interpret the data (e.g., 'fasta', 'gff', 'tabular').""", json_schema_extra = { "linkml_meta": {'alias': 'ext', 'domain_of': ['WorkflowUrlSpec']} })
+    src: str = Field(default=..., description="""The source type for the parameter, typically 'url' to indicate an external URL source rather than a Galaxy dataset or other source type.""", json_schema_extra = { "linkml_meta": {'alias': 'src', 'domain_of': ['WorkflowUrlSpec']} })
+    url: str = Field(default=..., description="""The complete URL (including http/https protocol) to the external resource that will be used as input to the workflow.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['OutbreakResource', 'WorkflowUrlSpec']} })
 
 
 # Model rebuild
@@ -664,3 +328,4 @@ Workflows.model_rebuild()
 Workflow.model_rebuild()
 WorkflowParameter.model_rebuild()
 WorkflowUrlSpec.model_rebuild()
+

--- a/catalog/py_package/catalog_build/generated_schema/schema.py
+++ b/catalog/py_package/catalog_build/generated_schema/schema.py
@@ -9,6 +9,7 @@ from typing import Any, ClassVar, Dict, List, Literal, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field, RootModel, field_validator
 
+
 metamodel_version = "None"
 version = "None"
 
@@ -61,7 +62,7 @@ linkml_meta = LinkMLMeta(
                 "prefix_reference": "https://w3id.org/linkml/",
             }
         },
-        "source_file": "/Users/hunter/git-repos/brc-analytics/catalog/py_package/catalog_build/schema_utils/../schema/schema.yaml",
+        "source_file": "/Users/dannon/work/brc-analytics/catalog/py_package/catalog_build/schema_utils/../schema/schema.yaml",
     }
 )
 
@@ -558,6 +559,13 @@ class Workflow(ConfiguredBaseModel):
         description="""Boolean flag that determines if the workflow should be included in the BRC Analytics interface. Used to manage visibility of workflows that may be under development or deprecated.""",
         json_schema_extra={
             "linkml_meta": {"alias": "active", "domain_of": ["Outbreak", "Workflow"]}
+        },
+    )
+    iwc_id: Optional[str] = Field(
+        default=None,
+        description="""The Intergalactic Workflow Commission (IWC) identifier for the workflow, used to link to the workflow's page on the IWC website.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "iwc_id", "domain_of": ["Workflow"]}
         },
     )
 

--- a/catalog/py_package/catalog_build/iwc_manifest_to_workflows_yaml.py
+++ b/catalog/py_package/catalog_build/iwc_manifest_to_workflows_yaml.py
@@ -28,6 +28,7 @@ MANIFEST_SOURCE_OF_TRUTH = (
     "workflow_name",
     "categories",
     "workflow_description",
+    "iwc_id",
 )
 
 
@@ -108,6 +109,7 @@ def generate_current_workflows():
                 ),
                 workflow_description=workflow["definition"]["annotation"],
                 ploidy=WorkflowPloidy.ANY,
+                iwc_id=workflow.get("iwcID"),
                 # readme=workflow["readme"],
                 # shortcut so we don't need to parse out the whole inputs section
                 parameters=get_input_types(workflow["definition"]),

--- a/catalog/py_package/catalog_build/schema/workflows.yaml
+++ b/catalog/py_package/catalog_build/schema/workflows.yaml
@@ -65,7 +65,7 @@ classes:
         range: boolean
       iwc_id:
         description: The Intergalactic Workflow Commission (IWC) identifier for the workflow, used to link to the workflow's page on the IWC website.
-        required: false
+        required: true
         range: string
 
   WorkflowParameter:

--- a/catalog/py_package/catalog_build/schema/workflows.yaml
+++ b/catalog/py_package/catalog_build/schema/workflows.yaml
@@ -63,6 +63,10 @@ classes:
         description: Boolean flag that determines if the workflow should be included in the BRC Analytics interface. Used to manage visibility of workflows that may be under development or deprecated.
         required: true
         range: boolean
+      iwc_id:
+        description: The Intergalactic Workflow Commission (IWC) identifier for the workflow, used to link to the workflow's page on the IWC website.
+        required: false
+        range: string
 
   WorkflowParameter:
     description: Definition of an input parameter for a Galaxy workflow, specifying how the parameter value should be determined when the workflow is executed.

--- a/catalog/schema/generated/schema.ts
+++ b/catalog/schema/generated/schema.ts
@@ -217,6 +217,8 @@ export interface Workflow {
     parameters: WorkflowParameter[],
     /** Boolean flag that determines if the workflow should be included in the BRC Analytics interface. Used to manage visibility of workflows that may be under development or deprecated. */
     active: boolean,
+    /** The Intergalactic Workflow Commission (IWC) identifier for the workflow, used to link to the workflow's page on the IWC website. */
+    iwc_id: string,
 }
 
 

--- a/catalog/schema/generated/workflows.json
+++ b/catalog/schema/generated/workflows.json
@@ -27,6 +27,10 @@
                     },
                     "type": "array"
                 },
+                "iwc_id": {
+                    "description": "The Intergalactic Workflow Commission (IWC) identifier for the workflow, used to link to the workflow's page on the IWC website.",
+                    "type": "string"
+                },
                 "parameters": {
                     "description": "Collection of input parameters that will be passed to the workflow when it is executed, including data sources and configuration options.",
                     "items": {
@@ -65,7 +69,8 @@
                 "workflow_description",
                 "ploidy",
                 "parameters",
-                "active"
+                "active",
+                "iwc_id"
             ],
             "title": "Workflow",
             "type": "object"

--- a/catalog/source/workflows.yml
+++ b/catalog/source/workflows.yml
@@ -1,4 +1,34 @@
 workflows:
+  - trs_id: "#workflow/github.com/iwc-workflows/annotation-maker/main/versions/v0.1"
+    categories: []
+    workflow_name: Genome annotation with Maker
+    workflow_description:
+      This workflow allows for genome annotation using Maker and
+      evaluates the quality of the annotation.
+    ploidy: ANY
+    parameters:
+      - key: BUSCO lineage
+        type_guide:
+          class: text
+      - key: Genome sequence
+        type_guide:
+          class: File
+          ext: fasta
+      - key: Genome assembly
+        type_guide:
+          class: File
+          ext: fasta
+      - key: Protein sequences
+        type_guide:
+          class: File
+      - key: Augustus training
+        type_guide:
+          class: File
+      - key: SNAP training
+        type_guide:
+          class: File
+    active: false
+    iwc_id: annotation-maker-main
   - trs_id: "#workflow/github.com/iwc-workflows/assembly-with-flye/main/versions/v0.2"
     categories:
       - ASSEMBLY
@@ -12,6 +42,7 @@ workflows:
         type_guide:
           class: File
     active: false
+    iwc_id: assembly-with-flye-main
   - trs_id: "#workflow/github.com/iwc-workflows/atacseq/main/versions/v1.0"
     categories:
       - REGULATION
@@ -29,6 +60,7 @@ workflows:
       - key: reference_genome
         variable: ASSEMBLY_ID
     active: true
+    iwc_id: atacseq-main
   - trs_id: "#workflow/github.com/iwc-workflows/average-bigwig-between-replicates/main/versions/v0.2"
     categories:
       - REGULATION
@@ -49,7 +81,8 @@ workflows:
         type_guide:
           class: integer
     active: false
-  - trs_id: "#workflow/github.com/iwc-workflows/bacterial-genome-assembly/main/versions/v1.1.5"
+    iwc_id: average-bigwig-between-replicates-main
+  - trs_id: "#workflow/github.com/iwc-workflows/bacterial-genome-assembly/main/versions/v1.1.7"
     categories:
       - ASSEMBLY
     workflow_name: Bacterial Genome Assembly using Shovill
@@ -75,6 +108,7 @@ workflows:
             - fastqsanger
             - fastqsanger.gz
     active: false
+    iwc_id: bacterial-genome-assembly-main
   - trs_id: "#workflow/github.com/iwc-workflows/baredsc/baredSC-1d-logNorm/versions/v0.6"
     categories:
       - TRANSCRIPTOMICS
@@ -101,6 +135,7 @@ workflows:
         type_guide:
           class: integer
     active: false
+    iwc_id: baredsc-baredsc-1d-lognorm
   - trs_id: "#workflow/github.com/iwc-workflows/baredsc/baredSC-2d-logNorm/versions/v0.6"
     categories:
       - TRANSCRIPTOMICS
@@ -136,6 +171,7 @@ workflows:
         type_guide:
           class: boolean
     active: false
+    iwc_id: baredsc-baredsc-2d-lognorm
   - trs_id: "#workflow/github.com/iwc-workflows/brew3r/main/versions/v0.2"
     categories:
       - TRANSCRIPTOMICS
@@ -167,6 +203,7 @@ workflows:
         type_guide:
           class: float
     active: false
+    iwc_id: brew3r-main
   - trs_id: "#workflow/github.com/iwc-workflows/chipseq-pe/main/versions/v0.14"
     categories:
       - REGULATION
@@ -183,6 +220,7 @@ workflows:
       - key: reference_genome
         variable: ASSEMBLY_ID
     active: true
+    iwc_id: chipseq-pe-main
   - trs_id: "#workflow/github.com/iwc-workflows/chipseq-sr/main/versions/v0.14"
     categories:
       - REGULATION
@@ -199,6 +237,7 @@ workflows:
       - key: reference_genome
         variable: ASSEMBLY_ID
     active: true
+    iwc_id: chipseq-sr-main
   - trs_id: "#workflow/github.com/iwc-workflows/consensus-peaks/consensus-peaks-atac-cutandrun/versions/v1.3"
     categories:
       - REGULATION
@@ -213,6 +252,7 @@ workflows:
     ploidy: ANY
     parameters: []
     active: true
+    iwc_id: consensus-peaks-consensus-peaks-atac-cutandrun
   - trs_id: "#workflow/github.com/iwc-workflows/consensus-peaks/consensus-peaks-chip-pe/versions/v1.3"
     categories:
       - REGULATION
@@ -227,6 +267,7 @@ workflows:
     ploidy: ANY
     parameters: []
     active: false
+    iwc_id: consensus-peaks-consensus-peaks-chip-pe
   - trs_id: "#workflow/github.com/iwc-workflows/consensus-peaks/consensus-peaks-chip-sr/versions/v1.3"
     categories:
       - REGULATION
@@ -241,6 +282,7 @@ workflows:
     ploidy: ANY
     parameters: []
     active: false
+    iwc_id: consensus-peaks-consensus-peaks-chip-sr
   - trs_id: "#workflow/github.com/iwc-workflows/cutandrun/main/versions/v0.14"
     categories:
       - REGULATION
@@ -257,6 +299,7 @@ workflows:
       - key: reference_genome
         variable: ASSEMBLY_ID
     active: true
+    iwc_id: cutandrun-main
   - trs_id: "#workflow/github.com/iwc-workflows/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex/versions/v0.6.2"
     categories:
       - TRANSCRIPTOMICS
@@ -277,6 +320,7 @@ workflows:
       - key: gtf
         variable: GENE_MODEL_URL
     active: true
+    iwc_id: fastq-to-matrix-10x-scrna-seq-fastq-to-matrix-10x-cellplex
   - trs_id: "#workflow/github.com/iwc-workflows/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-v3/versions/v0.6.2"
     categories:
       - TRANSCRIPTOMICS
@@ -295,6 +339,7 @@ workflows:
       - key: gtf
         variable: GENE_MODEL_URL
     active: true
+    iwc_id: fastq-to-matrix-10x-scrna-seq-fastq-to-matrix-10x-v3
   - trs_id: "#workflow/github.com/iwc-workflows/generic-variant-calling-wgs-pe/main/versions/v0.1.1"
     categories:
       - VARIANT_CALLING
@@ -318,6 +363,7 @@ workflows:
         type_guide:
           class: text
     active: false
+    iwc_id: generic-variant-calling-wgs-pe-main
   - trs_id: "#workflow/github.com/iwc-workflows/goseq/main/versions/v0.1"
     categories:
       - TRANSCRIPTOMICS
@@ -351,6 +397,7 @@ workflows:
           class: File
           ext: tabular
     active: false
+    iwc_id: goseq-main
   - trs_id: "#workflow/github.com/iwc-workflows/haploid-variant-calling-wgs-pe/main/versions/v0.1"
     categories:
       - VARIANT_CALLING
@@ -361,17 +408,18 @@ workflows:
     ploidy: HAPLOID
     parameters:
       - key: Paired Collection
+        variable: SANGER_READ_RUN
         type_guide:
           class: Collection
           ext:
             - fastqsanger
             - fastqsanger.gz
-        variable: SANGER_READ_RUN
       - key: Annotation GTF
         variable: GENE_MODEL_URL
       - key: Genome fasta
         variable: ASSEMBLY_FASTA_URL
     active: true
+    iwc_id: haploid-variant-calling-wgs-pe-main
   - trs_id: "#workflow/github.com/iwc-workflows/hic-hicup-cooler/chic-fastq-to-cool-hicup-cooler/versions/v0.3"
     categories:
       - REGULATION
@@ -416,6 +464,7 @@ workflows:
         type_guide:
           class: integer
     active: false
+    iwc_id: hic-hicup-cooler-chic-fastq-to-cool-hicup-cooler
   - trs_id: "#workflow/github.com/iwc-workflows/hic-hicup-cooler/hic-fastq-to-cool-hicup-cooler/versions/v0.3"
     categories:
       - REGULATION
@@ -454,6 +503,7 @@ workflows:
         type_guide:
           class: text
     active: false
+    iwc_id: hic-hicup-cooler-hic-fastq-to-cool-hicup-cooler
   - trs_id: "#workflow/github.com/iwc-workflows/hic-hicup-cooler/hic-fastq-to-pairs-hicup/versions/v0.3"
     categories:
       - REGULATION
@@ -484,6 +534,7 @@ workflows:
         type_guide:
           class: integer
     active: false
+    iwc_id: hic-hicup-cooler-hic-fastq-to-pairs-hicup
   - trs_id: "#workflow/github.com/iwc-workflows/hic-hicup-cooler/hic-juicermediumtabix-to-cool-cooler/versions/v0.3"
     categories:
       - REGULATION
@@ -509,6 +560,24 @@ workflows:
         type_guide:
           class: text
     active: false
+    iwc_id: hic-hicup-cooler-hic-juicermediumtabix-to-cool-cooler
+  - trs_id: "#workflow/github.com/iwc-workflows/influenza-isolates-consensus-and-subtyping/main/versions/v0.2"
+    categories:
+      - CONSENSUS_SEQUENCES
+    workflow_name: Influenza A isolate subtyping and consensus sequence generation
+    workflow_description:
+      This workflow performs subtyping and consensus sequence generation
+      for batches of Illumina PE sequenced Influenza A isolates.
+    ploidy: ANY
+    parameters:
+      - key: References per segment collection
+        type_guide:
+          class: Collection
+      - key: Sequenced paired-end data
+        type_guide:
+          class: Collection
+    active: false
+    iwc_id: influenza-isolates-consensus-and-subtyping-main
   - trs_id: "#workflow/github.com/iwc-workflows/mapseq-to-ampvis2/main/versions/v0.2"
     categories: []
     workflow_name: MAPseq to ampvis2
@@ -525,6 +594,7 @@ workflows:
         type_guide:
           class: File
     active: false
+    iwc_id: mapseq-to-ampvis2-main
   - trs_id: "#workflow/github.com/iwc-workflows/polish-with-long-reads/main/versions/v0.1"
     categories:
       - ASSEMBLY
@@ -542,6 +612,7 @@ workflows:
         type_guide:
           class: text
     active: false
+    iwc_id: polish-with-long-reads-main
   - trs_id: "#workflow/github.com/iwc-workflows/pox-virus-amplicon/main/versions/v0.3"
     categories:
       - CONSENSUS_SEQUENCES
@@ -573,6 +644,7 @@ workflows:
         type_guide:
           class: float
     active: true
+    iwc_id: pox-virus-amplicon-main
   - trs_id: "#workflow/github.com/iwc-workflows/pseudobulk-worflow-decoupler-edger/main/versions/v0.1.1"
     categories:
       - TRANSCRIPTOMICS
@@ -614,7 +686,8 @@ workflows:
         type_guide:
           class: text
     active: false
-  - trs_id: "#workflow/github.com/iwc-workflows/quality-and-contamination-control/main/versions/v1.1.6"
+    iwc_id: pseudobulk-worflow-decoupler-edger-main
+  - trs_id: "#workflow/github.com/iwc-workflows/quality-and-contamination-control/main/versions/v1.1.9"
     categories:
       - ASSEMBLY
     workflow_name: Quality and Contamination Control For Genome Assembly
@@ -646,6 +719,7 @@ workflows:
         type_guide:
           class: text
     active: false
+    iwc_id: quality-and-contamination-control-main
   - trs_id: "#workflow/github.com/iwc-workflows/rnaseq-de/main/versions/v0.4"
     categories:
       - TRANSCRIPTOMICS
@@ -679,6 +753,7 @@ workflows:
         type_guide:
           class: float
     active: false
+    iwc_id: rnaseq-de-main
   - trs_id: "#workflow/github.com/iwc-workflows/rnaseq-pe/main/versions/v1.2"
     categories:
       - TRANSCRIPTOMICS
@@ -698,6 +773,7 @@ workflows:
       - key: GTF file of annotation
         variable: GENE_MODEL_URL
     active: true
+    iwc_id: rnaseq-pe-main
   - trs_id: "#workflow/github.com/iwc-workflows/rnaseq-sr/main/versions/v1.2"
     categories:
       - TRANSCRIPTOMICS
@@ -717,6 +793,7 @@ workflows:
       - key: GTF file of annotation
         variable: GENE_MODEL_URL
     active: true
+    iwc_id: rnaseq-sr-main
   - trs_id: "#workflow/github.com/iwc-workflows/sars-cov-2-ont-artic-variant-calling/COVID-19-ARTIC-ONT/versions/v0.3.2"
     categories:
       - VARIANT_CALLING
@@ -755,6 +832,33 @@ workflows:
           class: File
           ext: bed
     active: false
+    iwc_id: sars-cov-2-ont-artic-variant-calling-covid-19-artic-ont
+  - trs_id: "#workflow/github.com/iwc-workflows/sars-cov-2-pe-illumina-artic-ivar-analysis/SARS-COV-2-ILLUMINA-AMPLICON-IVAR-PANGOLIN-NEXTCLADE/versions/v0.2.3"
+    categories:
+      - VARIANT_CALLING
+    workflow_name: SARS-CoV-2 Illumina Amplicon pipeline - iVar based
+    workflow_description:
+      Find and annotate variants in ampliconic SARS-CoV-2 Illumina
+      sequencing data and classify samples with pangolin and nextclade
+    ploidy: ANY
+    parameters:
+      - key: Paired read collection for samples
+        type_guide:
+          class: Collection
+      - key: Reference FASTA
+        type_guide:
+          class: File
+      - key: Primer BED
+        type_guide:
+          class: File
+      - key: Read fraction to call variant
+        type_guide:
+          class: float
+      - key: Minimum quality score to call base
+        type_guide:
+          class: integer
+    active: false
+    iwc_id: sars-cov-2-pe-illumina-artic-ivar-analysis-sars-cov-2-illumina-amplicon-ivar-pangolin-nextclade
   - trs_id: "#workflow/github.com/iwc-workflows/sars-cov-2-pe-illumina-artic-variant-calling/COVID-19-PE-ARTIC-ILLUMINA/versions/v0.5.4"
     categories:
       - VARIANT_CALLING
@@ -800,6 +904,7 @@ workflows:
         type_guide:
           class: integer
     active: true
+    iwc_id: sars-cov-2-pe-illumina-artic-variant-calling-covid-19-pe-artic-illumina
   - trs_id: "#workflow/github.com/iwc-workflows/sars-cov-2-pe-illumina-wgs-variant-calling/COVID-19-PE-WGS-ILLUMINA/versions/v0.2.4"
     categories:
       - VARIANT_CALLING
@@ -819,6 +924,7 @@ workflows:
       - key: NC_045512.2 FASTA sequence of SARS-CoV-2
         variable: ASSEMBLY_FASTA_URL
     active: true
+    iwc_id: sars-cov-2-pe-illumina-wgs-variant-calling-covid-19-pe-wgs-illumina
   - trs_id: "#workflow/github.com/iwc-workflows/sars-cov-2-se-illumina-wgs-variant-calling/COVID-19-SE-WGS-ILLUMINA/versions/v0.1.6"
     categories:
       - VARIANT_CALLING
@@ -838,6 +944,7 @@ workflows:
       - key: NC_045512.2 FASTA sequence of SARS-CoV-2
         variable: ASSEMBLY_FASTA_URL
     active: true
+    iwc_id: sars-cov-2-se-illumina-wgs-variant-calling-covid-19-se-wgs-illumina
   - trs_id: "#workflow/github.com/iwc-workflows/sars-cov-2-variation-reporting/COVID-19-VARIATION-REPORTING/versions/v0.3.4"
     categories:
       - VARIANT_CALLING
@@ -872,6 +979,7 @@ workflows:
         type_guide:
           class: integer
     active: false
+    iwc_id: sars-cov-2-variation-reporting-covid-19-variation-reporting
   - trs_id: "#workflow/github.com/iwc-workflows/variation-reporting/main/versions/v0.1.1"
     categories:
       - VARIANT_CALLING
@@ -899,3 +1007,4 @@ workflows:
         type_guide:
           class: integer
     active: false
+    iwc_id: variation-reporting-main


### PR DESCRIPTION
## Description

<img width="825" alt="image" src="https://github.com/user-attachments/assets/167faf57-eced-4ed8-b237-5157f6647e1a" />


WIP, tinkering with display still, that button isn't right -- I think instead of a button we might want just a regular link below, anyway?  This is one option.  Adds iwcID to the schema for workflows and links them up to their README page on the IWC.



## Related Issue

closes #583 
