### PR TITLE
feat: implement outbreaks page (#506)

### DIFF
--- a/@types/theme.d.ts
+++ b/@types/theme.d.ts
@@ -1,0 +1,24 @@
+import { PaletteColorOptions } from "@mui/material/styles";
+
+/**
+ * Palette definitions.
+ */
+declare module "@mui/material/styles" {
+  interface Palette {
+    caution: PaletteColor;
+  }
+
+  interface PaletteOptions {
+    caution?: PaletteColorOptions;
+  }
+}
+
+/**
+ * Chip prop options.
+ */
+declare module "@mui/material/Chip" {
+  interface ChipPropsColorOverrides {
+    alert: true;
+    caution: true;
+  }
+}

--- a/app/apis/catalog/brc-analytics-catalog/common/entities.ts
+++ b/app/apis/catalog/brc-analytics-catalog/common/entities.ts
@@ -8,7 +8,10 @@ import {
   WORKFLOW_PLOIDY,
 } from "./schema-entities";
 
-export type BRCCatalog = BRCDataCatalogGenome;
+export type BRCCatalog =
+  | BRCDataCatalogGenome
+  | BRCDataCatalogOrganism
+  | Outbreak;
 
 export interface BRCDataCatalogGenome {
   accession: string;

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PairedEndStep/components/ENASequencingData/components/AccessionSelector/accessionSelector.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PairedEndStep/components/ENASequencingData/components/AccessionSelector/accessionSelector.tsx
@@ -14,7 +14,7 @@ import { Props } from "./types";
 import { DialogTitle } from "@databiosphere/findable-ui/lib/components/common/Dialog/components/DialogTitle/dialogTitle";
 import { BUTTON_PROPS } from "@databiosphere/findable-ui/lib/components/common/Button/constants";
 import { FormEvent } from "react";
-import { ErrorIcon } from "@databiosphere/findable-ui/src/components/common/CustomIcon/components/ErrorIcon/errorIcon";
+import { ErrorIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/ErrorIcon/errorIcon";
 import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
 
 export const AccessionSelector = ({

--- a/app/styles/common/constants/palette.ts
+++ b/app/styles/common/constants/palette.ts
@@ -1,0 +1,4 @@
+export const PALETTE = {
+  CAUTION_LIGHT: `var(--mui-palette-caution-light)`,
+  CAUTION_MAIN: `var(--mui-palette-caution-main)`,
+} as const;

--- a/app/styles/common/mui/chip.ts
+++ b/app/styles/common/mui/chip.ts
@@ -1,0 +1,14 @@
+import { ChipProps } from "@mui/material";
+
+type ChipPropsOptions = {
+  COLOR: typeof COLOR;
+};
+
+const COLOR: Record<string, ChipProps["color"]> = {
+  ALERT: "alert",
+  CAUTION: "caution",
+};
+
+export const CHIP_PROPS: ChipPropsOptions = {
+  COLOR,
+};

--- a/app/theme/common/components.ts
+++ b/app/theme/common/components.ts
@@ -3,6 +3,8 @@ import { Components, Theme } from "@mui/material";
 import { COLOR_MIXES } from "@databiosphere/findable-ui/lib/styles/common/constants/colorMixes";
 import { PALETTE } from "@databiosphere/findable-ui/lib/styles/common/constants/palette";
 import { BUTTON_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/button";
+import { CHIP_PROPS as APP_CHIP_PROPS } from "../../styles/common/mui/chip";
+import { PALETTE as APP_PALETTE } from "../../styles/common/constants/palette";
 
 /**
  * MuiButton Component
@@ -63,4 +65,32 @@ export const MuiCssBaseline = (theme: Theme): Components["MuiCssBaseline"] => {
       },
     },
   };
+};
+
+/**
+ * MuiChip Component
+ * @param theme - Theme.
+ * @returns MuiChip component theme styles.
+ */
+export const MuiChip: Components["MuiChip"] = {
+  styleOverrides: {
+    root: {
+      variants: [
+        {
+          props: { color: APP_CHIP_PROPS.COLOR.ALERT },
+          style: {
+            backgroundColor: PALETTE.ALERT_LIGHT,
+            color: PALETTE.WARNING_MAIN,
+          },
+        },
+        {
+          props: { color: APP_CHIP_PROPS.COLOR.CAUTION },
+          style: {
+            backgroundColor: APP_PALETTE.CAUTION_LIGHT,
+            color: APP_PALETTE.CAUTION_MAIN,
+          },
+        },
+      ],
+    },
+  },
 };

--- a/app/theme/common/palette.ts
+++ b/app/theme/common/palette.ts
@@ -1,4 +1,12 @@
-import { PaletteColorOptions } from "@mui/material";
+import { PaletteColorOptions, PaletteOptions } from "@mui/material";
+
+/**
+ * Palette "Caution"
+ */
+const CAUTION = {
+  LIGHT: "#FFEB78",
+  MAIN: "#956F00",
+};
 
 /**
  * Palette "Primary"
@@ -9,10 +17,26 @@ const PRIMARY = {
 };
 
 /**
+ * Palette Option "Caution"
+ */
+const caution: PaletteColorOptions = {
+  light: CAUTION.LIGHT,
+  main: CAUTION.MAIN,
+};
+
+/**
  * Palette Option "Primary"
  */
-export const primary: PaletteColorOptions = {
+const primary: PaletteColorOptions = {
   contrastText: "#FFFFFF",
   dark: PRIMARY.DARK,
   main: PRIMARY.MAIN,
+};
+
+/**
+ * App Palette
+ */
+export const palette: PaletteOptions = {
+  caution,
+  primary,
 };

--- a/app/theme/theme.ts
+++ b/app/theme/theme.ts
@@ -2,7 +2,7 @@ import { createAppTheme } from "@databiosphere/findable-ui/lib/theme/theme";
 import { createTheme, Theme, ThemeOptions } from "@mui/material";
 import { deepmerge } from "@mui/utils";
 import * as C from "./common/components";
-import { primary } from "./common/palette";
+import { palette } from "./common/palette";
 
 /**
  * Returns BRC customized theme.
@@ -17,7 +17,7 @@ export function mergeAppTheme(
   // Merge custom options (palette, shadows, typography).
   const customOptions = deepmerge(baseThemeOptions, {
     ...themeOptions,
-    palette: { ...themeOptions?.palette, primary },
+    palette: { ...themeOptions?.palette, ...palette },
   });
   // Create base app theme with custom options.
   const baseAppTheme = createAppTheme(customOptions);
@@ -26,6 +26,7 @@ export function mergeAppTheme(
     components: {
       MuiButton: C.MuiButton,
       MuiButtonGroup: C.MuiButtonGroup,
+      MuiChip: C.MuiChip,
       MuiCssBaseline: C.MuiCssBaseline(baseAppTheme),
     },
   });

--- a/app/views/PriorityPathogenView/components/PriorityPathogens/priorityPathogens.styles.ts
+++ b/app/views/PriorityPathogenView/components/PriorityPathogens/priorityPathogens.styles.ts
@@ -1,0 +1,23 @@
+import { Grid, Typography } from "@mui/material";
+import styled from "@emotion/styled";
+
+export const StyledGrid = styled(Grid)`
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+
+  .MuiPaper-root {
+    align-self: flex-start;
+  }
+`;
+
+export const StyledSectionText = styled(Typography)`
+  h2,
+  h3 {
+    display: none;
+  }
+
+  -webkit-box-orient: vertical;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+`;

--- a/app/views/PriorityPathogenView/components/PriorityPathogens/priorityPathogens.tsx
+++ b/app/views/PriorityPathogenView/components/PriorityPathogens/priorityPathogens.tsx
@@ -1,0 +1,45 @@
+import { Props } from "./types";
+import {
+  Section,
+  SectionContent,
+} from "@databiosphere/findable-ui/lib/components/common/Section/section.styles";
+import { Chip, Typography } from "@mui/material";
+import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
+import { CHIP_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/chip";
+import { MDXRemote } from "next-mdx-remote";
+import { StyledGrid, StyledSectionText } from "./priorityPathogens.styles";
+import { RoundedPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/paper.styles";
+import { getPriorityColor, getPriorityLabel } from "./utils";
+
+export const PriorityPathogens = ({
+  priorityPathogens,
+}: Props): JSX.Element => {
+  return (
+    <StyledGrid container gap={4}>
+      {priorityPathogens.map((priorityPathogen) => (
+        <RoundedPaper key={priorityPathogen.name}>
+          <Section>
+            <SectionContent>
+              <Typography
+                variant={TYPOGRAPHY_PROPS.VARIANT.TEXT_HEADING_XSMALL}
+              >
+                {priorityPathogen.name}
+              </Typography>
+              <StyledSectionText
+                color={TYPOGRAPHY_PROPS.COLOR.INK_LIGHT}
+                variant={TYPOGRAPHY_PROPS.VARIANT.TEXT_BODY_400_2_LINES}
+              >
+                <MDXRemote {...priorityPathogen.description} />
+              </StyledSectionText>
+            </SectionContent>
+            <Chip
+              color={getPriorityColor(priorityPathogen.priority)}
+              label={getPriorityLabel(priorityPathogen.priority)}
+              variant={CHIP_PROPS.VARIANT.STATUS}
+            />
+          </Section>
+        </RoundedPaper>
+      ))}
+    </StyledGrid>
+  );
+};

--- a/app/views/PriorityPathogenView/components/PriorityPathogens/types.ts
+++ b/app/views/PriorityPathogenView/components/PriorityPathogens/types.ts
@@ -1,0 +1,5 @@
+import { Outbreak } from "../../../../apis/catalog/brc-analytics-catalog/common/entities";
+
+export interface Props {
+  priorityPathogens: Outbreak[];
+}

--- a/app/views/PriorityPathogenView/components/PriorityPathogens/utils.ts
+++ b/app/views/PriorityPathogenView/components/PriorityPathogens/utils.ts
@@ -1,0 +1,50 @@
+import { OUTBREAK_PRIORITY } from "app/apis/catalog/brc-analytics-catalog/common/schema-entities";
+import { ChipProps } from "@mui/material";
+import { CHIP_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/chip";
+import { CHIP_PROPS as APP_CHIP_PROPS } from "../../../../styles/common/mui/chip";
+
+/**
+ * Returns the color for the priority of the outbreak.
+ * @param priority - The priority of the outbreak.
+ * @returns The color for the priority of the outbreak.
+ */
+export function getPriorityColor(
+  priority: OUTBREAK_PRIORITY
+): ChipProps["color"] {
+  switch (priority) {
+    case OUTBREAK_PRIORITY.CRITICAL:
+      return CHIP_PROPS.COLOR.WARNING;
+    case OUTBREAK_PRIORITY.HIGH:
+      return APP_CHIP_PROPS.COLOR.CAUTION;
+    case OUTBREAK_PRIORITY.HIGHEST:
+      return APP_CHIP_PROPS.COLOR.ALERT;
+    case OUTBREAK_PRIORITY.MODERATE:
+      return CHIP_PROPS.COLOR.DEFAULT;
+    case OUTBREAK_PRIORITY.MODERATE_HIGH:
+      return CHIP_PROPS.COLOR.DEFAULT;
+    default:
+      return CHIP_PROPS.COLOR.DEFAULT;
+  }
+}
+
+/**
+ * Returns the label for the priority of the outbreak.
+ * @param priority - The priority of the outbreak.
+ * @returns The label for the priority of the outbreak.
+ */
+export function getPriorityLabel(priority: OUTBREAK_PRIORITY): string {
+  switch (priority) {
+    case OUTBREAK_PRIORITY.CRITICAL:
+      return "Critical Priority";
+    case OUTBREAK_PRIORITY.HIGH:
+      return "High Priority";
+    case OUTBREAK_PRIORITY.HIGHEST:
+      return "Highest Priority";
+    case OUTBREAK_PRIORITY.MODERATE:
+      return "Moderate Priority";
+    case OUTBREAK_PRIORITY.MODERATE_HIGH:
+      return "Moderate High Priority";
+    default:
+      return "Unknown Priority";
+  }
+}

--- a/app/views/PriorityPathogenView/priorityPathogensView.tsx
+++ b/app/views/PriorityPathogenView/priorityPathogensView.tsx
@@ -1,0 +1,22 @@
+import { Props } from "./types";
+import { useLayoutDimensions } from "@databiosphere/findable-ui/lib/providers/layoutDimensions/hook";
+import { Index } from "@databiosphere/findable-ui/lib/components/Index/index.styles";
+import { HeroLayout } from "@databiosphere/findable-ui/lib/components/Index/components/Hero/hero.styles";
+import { Title } from "@databiosphere/findable-ui/lib/components/common/Title/title";
+import { useConfig } from "@databiosphere/findable-ui/lib/hooks/useConfig";
+import { PriorityPathogens } from "./components/PriorityPathogens/priorityPathogens";
+
+export const PriorityPathogensView = (props: Props): JSX.Element => {
+  const { entityConfig } = useConfig();
+  const { dimensions } = useLayoutDimensions();
+  const { data } = props;
+  const { hits } = data;
+  return (
+    <Index marginTop={dimensions.header.height}>
+      <HeroLayout>
+        <Title title={entityConfig.explorerTitle} />
+      </HeroLayout>
+      <PriorityPathogens priorityPathogens={hits} />
+    </Index>
+  );
+};

--- a/app/views/PriorityPathogenView/priorityPathogensView.tsx
+++ b/app/views/PriorityPathogenView/priorityPathogensView.tsx
@@ -5,18 +5,25 @@ import { HeroLayout } from "@databiosphere/findable-ui/lib/components/Index/comp
 import { Title } from "@databiosphere/findable-ui/lib/components/common/Title/title";
 import { useConfig } from "@databiosphere/findable-ui/lib/hooks/useConfig";
 import { PriorityPathogens } from "./components/PriorityPathogens/priorityPathogens";
+import { sortPriorityPathogen } from "./utils";
 
 export const PriorityPathogensView = (props: Props): JSX.Element => {
   const { entityConfig } = useConfig();
   const { dimensions } = useLayoutDimensions();
+
+  // Get priority pathogens data.
   const { data } = props;
   const { hits } = data;
+
+  // Sort priority pathogens.
+  const priorityPathogens = hits.sort(sortPriorityPathogen);
+
   return (
     <Index marginTop={dimensions.header.height}>
       <HeroLayout>
         <Title title={entityConfig.explorerTitle} />
       </HeroLayout>
-      <PriorityPathogens priorityPathogens={hits} />
+      <PriorityPathogens priorityPathogens={priorityPathogens} />
     </Index>
   );
 };

--- a/app/views/PriorityPathogenView/types.ts
+++ b/app/views/PriorityPathogenView/types.ts
@@ -1,0 +1,6 @@
+import { Outbreak } from "../../apis/catalog/brc-analytics-catalog/common/entities";
+import { EntitiesResponse } from "../../apis/catalog/brc-analytics-catalog/common/entities";
+
+export interface Props {
+  data: EntitiesResponse<Outbreak>;
+}

--- a/app/views/PriorityPathogenView/utils.ts
+++ b/app/views/PriorityPathogenView/utils.ts
@@ -1,0 +1,12 @@
+import { COLLATOR_CASE_INSENSITIVE } from "@databiosphere/findable-ui/lib/common/constants";
+import { Outbreak } from "../../apis/catalog/brc-analytics-catalog/common/entities";
+
+/**
+ * Sorts priority pathogens by name.
+ * @param pp01 - First priority pathogen.
+ * @param pp02 - Second priority pathogen.
+ * @returns -1 if pp01 < pp02, 0 if pp01 === pp02, 1 if pp01 > pp02.
+ */
+export function sortPriorityPathogen(pp01: Outbreak, pp02: Outbreak): number {
+  return COLLATOR_CASE_INSENSITIVE.compare(pp01.name, pp02.name);
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -22,10 +22,13 @@ import { mergeAppTheme } from "../app/theme/theme";
 import { GoogleSignInAuthenticationProvider } from "@databiosphere/findable-ui/lib/providers/googleSignInAuthentication/provider";
 import { ServicesProvider } from "@databiosphere/findable-ui/lib/providers/services/provider";
 import { setFeatureFlags } from "@databiosphere/findable-ui/lib/hooks/useFeatureFlag/common/utils";
+import { useFeatureFlag } from "@databiosphere/findable-ui/lib/hooks/useFeatureFlag/useFeatureFlag";
+import { ROUTES } from "../routes/constants";
+import { Navigation } from "@databiosphere/findable-ui/lib/components/Layout/components/Header/common/entities";
 
 const DEFAULT_ENTITY_LIST_TYPE = "organisms";
 
-setFeatureFlags(["workflow"]);
+setFeatureFlags(["priority-pathogens", "workflow"]);
 
 export interface PageProps extends AzulEntitiesStaticResponse {
   pageTitle?: string;
@@ -58,6 +61,18 @@ function MyApp({ Component, pageProps }: AppPropsWithComponent): JSX.Element {
   const appTheme = mergeAppTheme(baseThemeOptions, themeOptions);
   const AppLayout = Component.AppLayout || DXAppLayout;
   const Main = Component.Main || DXMain;
+
+  // Determine if priority pathogens feature is enabled.
+  const isPriorityPathogensEnabled = useFeatureFlag("priority-pathogens");
+
+  // Temporarily filter out priority pathogens navigation item until feature is ready.
+  const navigation = header?.navigation?.map((nav) =>
+    nav?.filter(
+      (item) =>
+        isPriorityPathogensEnabled || item.url !== ROUTES.PRIORITY_PATHOGENS
+    )
+  ) as Navigation;
+
   return (
     <EmotionThemeProvider theme={appTheme}>
       <ThemeProvider theme={appTheme}>
@@ -69,7 +84,7 @@ function MyApp({ Component, pageProps }: AppPropsWithComponent): JSX.Element {
               <GoogleSignInAuthenticationProvider>
                 <LayoutDimensionsProvider>
                   <AppLayout>
-                    <DXHeader {...header} />
+                    <DXHeader {...header} navigation={navigation} />
                     <ExploreStateProvider entityListType={entityListType}>
                       <Main>
                         <ErrorBoundary

--- a/pages/data/[entityListType]/index.tsx
+++ b/pages/data/[entityListType]/index.tsx
@@ -11,6 +11,9 @@ import {
 import { config } from "../../../app/config/config";
 import { seedDatabase } from "../../../app/utils/seedDatabase";
 import { StyledExploreView } from "../../../app/views/ExploreView/exploreView.styles";
+import { PriorityPathogensView } from "../../../app/views/PriorityPathogenView/priorityPathogensView";
+import { Outbreak } from "../../../app/apis/catalog/brc-analytics-catalog/common/entities";
+import { useFeatureFlag } from "@databiosphere/findable-ui/lib/hooks/useFeatureFlag/useFeatureFlag";
 
 interface PageUrl extends ParsedUrlQuery {
   entityListType: string;
@@ -31,7 +34,24 @@ const IndexPage = <R,>({
   entityListType,
   ...props
 }: EntitiesPageProps<R>): JSX.Element => {
+  const isPriorityPathogensEnabled = useFeatureFlag("priority-pathogens");
   if (!entityListType) return <></>;
+
+  // Return the PriorityPathogensView component for the priority pathogens route.
+  if (entityListType === "priority-pathogens") {
+    // Temporarily disable priority pathogens feature.
+    if (!isPriorityPathogensEnabled) return <></>;
+
+    // Throw an error if no priority pathogen data is provided.
+    if (!props.data) throw new Error("No priority pathogen data provided");
+
+    // Return the PriorityPathogensView component.
+    return (
+      <PriorityPathogensView data={props.data as EntitiesResponse<Outbreak>} />
+    );
+  }
+
+  // Return the ExploreView component for all other routes.
   return <StyledExploreView entityListType={entityListType} {...props} />;
 };
 

--- a/routes/constants.ts
+++ b/routes/constants.ts
@@ -4,5 +4,7 @@ export const ROUTES = {
   GENOME: "/data/assemblies/{entityId}",
   GENOMES: "/data/assemblies",
   ORGANISMS: "/data/organisms",
+  PRIORITY_PATHOGEN: "/data/priority-pathogens/[entityId]",
+  PRIORITY_PATHOGENS: "/data/priority-pathogens",
   ROADMAP: "/roadmap",
 };

--- a/site-config/brc-analytics/local/config.ts
+++ b/site-config/brc-analytics/local/config.ts
@@ -4,12 +4,14 @@ import { EntityConfig } from "@databiosphere/findable-ui/lib/config/entities";
 import {
   BRCDataCatalogGenome,
   BRCDataCatalogOrganism,
+  Outbreak,
 } from "../../../app/apis/catalog/brc-analytics-catalog/common/entities";
 import * as C from "../../../app/components";
 import { ROUTES } from "../../../routes/constants";
 import { floating } from "./floating/floating";
 import { genomeEntityConfig } from "./index/genomeEntityConfig";
 import { organismEntityConfig } from "./index/organismEntityConfig";
+import { priorityPathogensEntityConfig } from "./index/priorityPathogensEntityConfig";
 import { socialMedia } from "./socialMedia";
 
 const LOCALHOST = "http://localhost:3000";
@@ -45,6 +47,7 @@ export function makeConfig(
     entities: [
       organismEntityConfig as EntityConfig<BRCDataCatalogOrganism>,
       genomeEntityConfig as EntityConfig<BRCDataCatalogGenome>,
+      priorityPathogensEntityConfig as EntityConfig<Outbreak>,
     ],
     explorerTitle: APP_TITLE,
     gitHubUrl,
@@ -80,6 +83,7 @@ export function makeConfig(
             { label: "About", url: ROUTES.ABOUT },
             { label: "Organisms", url: ROUTES.ORGANISMS },
             { label: "Assemblies", url: ROUTES.GENOMES },
+            { label: "Priority Pathogens", url: ROUTES.PRIORITY_PATHOGENS },
             { label: "Roadmap", url: ROUTES.ROADMAP },
           ],
           undefined,

--- a/site-config/brc-analytics/local/index/priorityPathogensEntityConfig.ts
+++ b/site-config/brc-analytics/local/index/priorityPathogensEntityConfig.ts
@@ -1,0 +1,24 @@
+import { EXPLORE_MODE } from "@databiosphere/findable-ui/lib/hooks/useExploreMode/types";
+import { Outbreak } from "../../../../app/apis/catalog/brc-analytics-catalog/common/entities";
+import { BRCEntityConfig } from "../../../common/entities";
+
+/**
+ * Entity config object responsible to config anything related to the /priority-pathogens route.
+ */
+export const priorityPathogensEntityConfig: BRCEntityConfig<Outbreak> = {
+  categoryGroupConfig: undefined,
+  detail: {
+    detailOverviews: [],
+    staticLoad: true,
+    tabs: [],
+  },
+  exploreMode: EXPLORE_MODE.CS_FETCH_CS_FILTERING,
+  explorerTitle: "Priority Pathogens",
+  getId: (priorityPathogen) => priorityPathogen.name,
+  label: "Priority Pathogens",
+  list: {
+    columns: [],
+  },
+  route: "priority-pathogens",
+  staticLoadFile: "catalog/output/outbreaks.json",
+};

--- a/site-config/brc-analytics/local/index/priorityPathogensEntityConfig.ts
+++ b/site-config/brc-analytics/local/index/priorityPathogensEntityConfig.ts
@@ -14,7 +14,7 @@ export const priorityPathogensEntityConfig: BRCEntityConfig<Outbreak> = {
   },
   exploreMode: EXPLORE_MODE.CS_FETCH_CS_FILTERING,
   explorerTitle: "Priority Pathogens",
-  getId: (priorityPathogen) => priorityPathogen.name,
+  getId: () => "",
   label: "Priority Pathogens",
   list: {
     columns: [],


### PR DESCRIPTION
Closes #506.

This pull request introduces a new "Priority Pathogens" feature, adds support for custom theming with new palette options, and updates navigation and routing to accommodate the new feature. The most significant changes include adding the "Priority Pathogens" view and related components, extending the theme with caution-related colors, and updating the app's navigation and routing logic.

### New "Priority Pathogens" Feature:
* Added a `PriorityPathogensView` component to display priority pathogens data, including a styled grid layout, custom chips for priority levels, and a description section using `MDXRemote` for rendering. (`[[1]](diffhunk://#diff-dbbf351b6711744330990380fe4139a5af973b1cfefd6a773fc3e5f83ed36717R1-R45)`, `[[2]](diffhunk://#diff-ee4772085a389e9bb7a7bec09bc8b34d22f2e8086897ba90d67f29caa503fedfR1-R22)`, `[[3]](diffhunk://#diff-32d6d733e80f8f2ab69350548e2ea5672913e0531aeb6ecb0d9afb30dd750f1bR1-R5)`, `[[4]](diffhunk://#diff-bad64f3fba098de1455b0baeb44953f4d2e1a35973d96203c7372008c72eff3bR1-R50)`, `[[5]](diffhunk://#diff-f68b50941197f5d5d1d54f949273eeb25d54bc910f33af7ebc02cdc3124c7ce9R1-R23)`)
* Introduced a new `priorityPathogensEntityConfig` to configure the "Priority Pathogens" route, including its title, route path, and static data file. (`[site-config/brc-analytics/local/index/priorityPathogensEntityConfig.tsR1-R24](diffhunk://#diff-af37b33b695f799659433fc3a3b8ffe85114de694970dd213ac92dd1388d1521R1-R24)`)
* Updated the `makeConfig` function to include the "Priority Pathogens" entity and navigation item. (`[[1]](diffhunk://#diff-d8a05cfdd5e948c0abdb37e8934842bce48a70d4dc011e7a3ebf253daf9528fdR50)`, `[[2]](diffhunk://#diff-d8a05cfdd5e948c0abdb37e8934842bce48a70d4dc011e7a3ebf253daf9528fdR86)`)

### Theming Enhancements:
* Added a new `PALETTE` constant with caution-related colors (`CAUTION_LIGHT` and `CAUTION_MAIN`) and integrated it into the app's theme. (`[[1]](diffhunk://#diff-005efa8ef64a267b9abdaf5a34932f706b98f1be50e6ad260ea13f8cc3f51b6aR1-R4)`, `[[2]](diffhunk://#diff-f05ac637f9f89a04f6a2455be102ec6e7f658c259ca200b7fe1e98ed5e93a5feL1-R9)`, `[[3]](diffhunk://#diff-f05ac637f9f89a04f6a2455be102ec6e7f658c259ca200b7fe1e98ed5e93a5feR19-R42)`)
* Created `CHIP_PROPS` to define custom chip color options (`ALERT` and `CAUTION`) and applied them to the `MuiChip` component for styling. (`[[1]](diffhunk://#diff-7cc85b4dcacf0342c4d7772f55de9331b1f00ad8d9ff85862a728a70ce20da2cR1-R14)`, `[[2]](diffhunk://#diff-8a40703d5724447d51373aa033631b3d933836f20ad02fc162bbe66fac6718a6R6-R7)`, `[[3]](diffhunk://#diff-8a40703d5724447d51373aa033631b3d933836f20ad02fc162bbe66fac6718a6R69-R96)`)

### Navigation and Routing Updates:
* Updated the app's navigation to include a "Priority Pathogens" link, conditionally displayed based on a feature flag. (`[[1]](diffhunk://#diff-a9827ce1be32c607c948881a89b99c592f752898f9c49e0dea0b7199eb151029R25-R31)`, `[[2]](diffhunk://#diff-a9827ce1be32c607c948881a89b99c592f752898f9c49e0dea0b7199eb151029R64-R75)`, `[[3]](diffhunk://#diff-a9827ce1be32c607c948881a89b99c592f752898f9c49e0dea0b7199eb151029L72-R87)`)
* Added new routes for "Priority Pathogens" and its detail pages in the `ROUTES` constant. (`[routes/constants.tsR7-R8](diffhunk://#diff-7ebd9e98055eaac29228f42c33478b95f17575f8f3985c398ab07656c2f3cf3fR7-R8)`)
* Modified the `IndexPage` component to render the `PriorityPathogensView` for the "priority-pathogens" route. (`[pages/data/[entityListType]/index.tsxR14-R16](diffhunk://#diff-e231012c3498e1d91bcdd5f020af0d1f33607b663d935a6e53b7b44b3aa2ea5cR14-R16)`, `[pages/data/[entityListType]/index.tsxR37-R54](diffhunk://#diff-e231012c3498e1d91bcdd5f020af0d1f33607b663d935a6e53b7b44b3aa2ea5cR37-R54)`) 

### Minor Fixes:
* Fixed an incorrect import path for `ErrorIcon` in `accessionSelector.tsx`. (`[app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PairedEndStep/components/ENASequencingData/components/AccessionSelector/accessionSelector.tsxL17-R17](diffhunk://#diff-3826bd95e8b41bb348e73dfc5bbccea2858bda6555488379d5f9e3213bf580ebL17-R17)`)
 
<img width="1343" alt="image" src="https://github.com/user-attachments/assets/f1940867-1830-4a3a-b55a-43fdb58803bd" />
 