### PR TITLE
feat: add responsive view to priority pathogens view (#610)

### DIFF
--- a/app/views/PriorityPathogensView/components/PriorityPathogens/priorityPathogens.styles.ts
+++ b/app/views/PriorityPathogensView/components/PriorityPathogens/priorityPathogens.styles.ts
@@ -1,12 +1,17 @@
 import { Grid, Typography } from "@mui/material";
 import styled from "@emotion/styled";
+import { mediaTabletUp } from "@databiosphere/findable-ui/lib/styles/common/mixins/breakpoints";
 
 export const StyledGrid = styled(Grid)`
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: 1fr;
 
   .MuiPaper-root {
     align-self: flex-start;
+  }
+
+  ${mediaTabletUp} {
+    grid-template-columns: repeat(2, 1fr);
   }
 `;
 

--- a/app/views/PriorityPathogensView/components/PriorityPathogens/priorityPathogens.tsx
+++ b/app/views/PriorityPathogensView/components/PriorityPathogens/priorityPathogens.tsx
@@ -8,7 +8,7 @@ import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/m
 import { CHIP_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/chip";
 import { MDXRemote } from "next-mdx-remote";
 import { StyledGrid, StyledSectionText } from "./priorityPathogens.styles";
-import { RoundedPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/paper.styles";
+import { FluidPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/paper.styles";
 import { getPriorityColor, getPriorityLabel } from "./utils";
 
 export const PriorityPathogens = ({
@@ -17,7 +17,7 @@ export const PriorityPathogens = ({
   return (
     <StyledGrid container gap={4}>
       {priorityPathogens.map((priorityPathogen) => (
-        <RoundedPaper key={priorityPathogen.name}>
+        <FluidPaper key={priorityPathogen.name}>
           <Section>
             <SectionContent>
               <Typography
@@ -38,7 +38,7 @@ export const PriorityPathogens = ({
               variant={CHIP_PROPS.VARIANT.STATUS}
             />
           </Section>
-        </RoundedPaper>
+        </FluidPaper>
       ))}
     </StyledGrid>
   );

--- a/app/views/PriorityPathogensView/priorityPathogensView.styles.ts
+++ b/app/views/PriorityPathogensView/priorityPathogensView.styles.ts
@@ -1,0 +1,13 @@
+import styled from "@emotion/styled";
+import { Index } from "@databiosphere/findable-ui/lib/components/Index/index.styles";
+import { mediaTabletUp } from "@databiosphere/findable-ui/lib/styles/common/mixins/breakpoints";
+
+export const StyledIndex = styled(Index)`
+  grid-template-columns: 1fr;
+
+  ${mediaTabletUp} {
+    margin-left: auto;
+    margin-right: auto;
+    max-width: min(calc(100% - 32px), 1232px);
+  }
+`;

--- a/app/views/PriorityPathogensView/priorityPathogensView.tsx
+++ b/app/views/PriorityPathogensView/priorityPathogensView.tsx
@@ -1,11 +1,11 @@
 import { Props } from "./types";
 import { useLayoutDimensions } from "@databiosphere/findable-ui/lib/providers/layoutDimensions/hook";
-import { Index } from "@databiosphere/findable-ui/lib/components/Index/index.styles";
 import { HeroLayout } from "@databiosphere/findable-ui/lib/components/Index/components/Hero/hero.styles";
 import { Title } from "@databiosphere/findable-ui/lib/components/common/Title/title";
 import { useConfig } from "@databiosphere/findable-ui/lib/hooks/useConfig";
 import { PriorityPathogens } from "./components/PriorityPathogens/priorityPathogens";
 import { sortPriorityPathogen } from "./utils";
+import { StyledIndex } from "./priorityPathogensView.styles";
 
 export const PriorityPathogensView = (props: Props): JSX.Element => {
   const { entityConfig } = useConfig();
@@ -19,11 +19,11 @@ export const PriorityPathogensView = (props: Props): JSX.Element => {
   const priorityPathogens = hits.sort(sortPriorityPathogen);
 
   return (
-    <Index marginTop={dimensions.header.height}>
+    <StyledIndex marginTop={dimensions.header.height}>
       <HeroLayout>
         <Title title={entityConfig.explorerTitle} />
       </HeroLayout>
       <PriorityPathogens priorityPathogens={priorityPathogens} />
-    </Index>
+    </StyledIndex>
   );
 };


### PR DESCRIPTION
Closes #610.

This pull request refactors the `PriorityPathogensView` component to improve responsiveness and update the styling for better alignment with design guidelines. Key changes include introducing responsive grid layouts, replacing `RoundedPaper` with `FluidPaper`, and customizing the `Index` component for consistent styling.

### Grid and Layout Responsiveness:
* Updated `StyledGrid` in `priorityPathogens.styles.ts` to use a single-column layout by default and switch to a two-column layout on tablet-sized screens or larger using the `mediaTabletUp` mixin.
* Added a styled `Index` component in `priorityPathogensView.styles.ts` to centralize layout adjustments, including responsive margins and maximum width for larger screens.

### Component Styling Updates:
* Replaced `RoundedPaper` with `FluidPaper` in `PriorityPathogens` for a more modern and fluid design. This change was applied in multiple places within `priorityPathogens.tsx`. [[1]](diffhunk://#diff-fb4589c55958ad5b885edc19cd6fe6b922b8fad65b65793905c2623a97c05f3dL11-R11) [[2]](diffhunk://#diff-fb4589c55958ad5b885edc19cd6fe6b922b8fad65b65793905c2623a97c05f3dL20-R20) [[3]](diffhunk://#diff-fb4589c55958ad5b885edc19cd6fe6b922b8fad65b65793905c2623a97c05f3dL41-R41)
* Updated `PriorityPathogensView` to use the new `StyledIndex` component instead of the default `Index` for better alignment with the responsive design. [[1]](diffhunk://#diff-079998bbf5a6f76df1b037f7f7ff08ca485429bb750581379ef07e08dac6bd0fL3-R8) [[2]](diffhunk://#diff-079998bbf5a6f76df1b037f7f7ff08ca485429bb750581379ef07e08dac6bd0fL22-R27)

<img width="552" alt="image" src="https://github.com/user-attachments/assets/9ae8d47a-462a-48c9-a1f4-1a77b3e09ffd" />
