### PR TITLE
feat: implement outbreak detail page (#507)

### DIFF
--- a/app/components/Entity/components/Section/KeyValueSection/components/KeyElType/keyElType.tsx
+++ b/app/components/Entity/components/Section/KeyValueSection/components/KeyElType/keyElType.tsx
@@ -1,0 +1,19 @@
+import { ChildrenProps } from "@databiosphere/findable-ui/lib/components/types";
+import { TypographyProps } from "@mui/material";
+import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
+import { Typography } from "@mui/material";
+
+export const KeyElType = ({
+  children,
+  ...props /* Mui Typography Props */
+}: ChildrenProps & TypographyProps): JSX.Element => {
+  return (
+    <Typography
+      color={TYPOGRAPHY_PROPS.COLOR.INK_LIGHT}
+      variant={TYPOGRAPHY_PROPS.VARIANT.TEXT_BODY_400}
+      {...props}
+    >
+      {children}
+    </Typography>
+  );
+};

--- a/app/components/Entity/components/Section/KeyValueSection/components/KeyValueElType/keyValueElType.tsx
+++ b/app/components/Entity/components/Section/KeyValueSection/components/KeyValueElType/keyValueElType.tsx
@@ -1,0 +1,20 @@
+import { KeyValueElTypeProps } from "@databiosphere/findable-ui/lib/components/common/KeyValuePairs/components/KeyValueElType/keyValueElType";
+import { ChildrenProps } from "@databiosphere/findable-ui/lib/components/types";
+import { Grid, GridProps } from "@mui/material";
+
+export const KeyValueElType = ({
+  children,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- `keyValue` is unused.
+  keyValue,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- `keyValueFn` is unused.
+  keyValueFn,
+  ...props /* Mui Grid Props */
+}: ChildrenProps &
+  GridProps &
+  Pick<KeyValueElTypeProps, "keyValue" | "keyValueFn">): JSX.Element => {
+  return (
+    <Grid container direction="column" gap={1} {...props}>
+      {children}
+    </Grid>
+  );
+};

--- a/app/components/Entity/components/Section/KeyValueSection/components/ValueElType/valueElType.tsx
+++ b/app/components/Entity/components/Section/KeyValueSection/components/ValueElType/valueElType.tsx
@@ -1,0 +1,15 @@
+import { ChildrenProps } from "@databiosphere/findable-ui/lib/components/types";
+import { TypographyProps } from "@mui/material";
+import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
+import { Typography } from "@mui/material";
+
+export const ValueElType = ({
+  children,
+  ...props /* Mui Typography Props */
+}: ChildrenProps & TypographyProps): JSX.Element => {
+  return (
+    <Typography variant={TYPOGRAPHY_PROPS.VARIANT.TEXT_BODY_400} {...props}>
+      {children}
+    </Typography>
+  );
+};

--- a/app/components/Entity/components/Section/KeyValueSection/keyValueSection.styles.ts
+++ b/app/components/Entity/components/Section/KeyValueSection/keyValueSection.styles.ts
@@ -1,0 +1,49 @@
+import { mediaTabletDown } from "@databiosphere/findable-ui/lib/styles/common/mixins/breakpoints";
+import { textBody4002Lines } from "@databiosphere/findable-ui/lib/styles/common/mixins/fonts";
+import styled from "@emotion/styled";
+
+// See https://github.com/emotion-js/emotion/issues/1105.
+// See https://github.com/emotion-js/emotion/releases/tag/%40emotion%2Fcache%4011.10.2.
+const ignoreSsrWarning =
+  "/* emotion-disable-server-rendering-unsafe-selector-warning-please-do-not-use-this-the-warning-exists-for-a-reason */";
+
+export const StyledH2 = styled("h2")`
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 24px;
+  margin: 16px 0 8px 0;
+
+  &:first-child:not(style)${ignoreSsrWarning} {
+    margin-top: 0;
+  }
+`;
+
+export const StyledP = styled("p")`
+  ${textBody4002Lines}
+`;
+
+export const StyledUL = styled("ul")`
+  ${textBody4002Lines}
+  margin: 0;
+  padding-left: 24px;
+
+  li {
+    margin: 4px 0;
+
+    &:first-of-type {
+      margin-top: 0;
+    }
+
+    &:last-of-type {
+      margin-bottom: 0;
+    }
+  }
+`;
+
+export const StyledWrapper = styled("div")`
+  padding: 20px;
+
+  ${mediaTabletDown} {
+    padding: 20px 16px;
+  }
+`;

--- a/app/components/Entity/components/Section/KeyValueSection/keyValueSection.tsx
+++ b/app/components/Entity/components/Section/KeyValueSection/keyValueSection.tsx
@@ -1,0 +1,26 @@
+import { SectionTitle } from "@databiosphere/findable-ui/lib/components/common/Section/components/SectionTitle/sectionTitle";
+import { Props } from "./types";
+import { GridPaperSection } from "@databiosphere/findable-ui/lib/components/common/Section/section.styles";
+import { KeyValuePairs } from "@databiosphere/findable-ui/lib/components/common/KeyValuePairs/keyValuePairs";
+import { Fragment } from "react";
+import { KeyValueElType } from "./components/KeyValueElType/keyValueElType";
+import { KeyElType } from "./components/KeyElType/keyElType";
+import { ValueElType } from "./components/ValueElType/valueElType";
+
+export const KeyValueSection = ({
+  title,
+  ...props /* KeyValuePairs Props */
+}: Props): JSX.Element => {
+  return (
+    <GridPaperSection>
+      {title && <SectionTitle title={title} />}
+      <KeyValuePairs
+        KeyElType={KeyElType}
+        KeyValueElType={KeyValueElType}
+        KeyValuesElType={Fragment}
+        ValueElType={ValueElType}
+        {...props}
+      />
+    </GridPaperSection>
+  );
+};

--- a/app/components/Entity/components/Section/KeyValueSection/types.ts
+++ b/app/components/Entity/components/Section/KeyValueSection/types.ts
@@ -1,0 +1,5 @@
+import { KeyValuePairsProps } from "@databiosphere/findable-ui/lib/components/common/KeyValuePairs/keyValuePairs";
+
+export interface Props extends KeyValuePairsProps {
+  title?: string;
+}

--- a/app/components/Entity/components/Section/MDXSection/constants.ts
+++ b/app/components/Entity/components/Section/MDXSection/constants.ts
@@ -1,0 +1,7 @@
+import { StyledH2, StyledP, StyledUL } from "./mdxSection.styles";
+
+export const COMPONENTS = {
+  h2: StyledH2,
+  p: StyledP,
+  ul: StyledUL,
+};

--- a/app/components/Entity/components/Section/MDXSection/mdxSection.styles.ts
+++ b/app/components/Entity/components/Section/MDXSection/mdxSection.styles.ts
@@ -1,0 +1,40 @@
+import { textBody4002Lines } from "@databiosphere/findable-ui/lib/styles/common/mixins/fonts";
+import styled from "@emotion/styled";
+
+// See https://github.com/emotion-js/emotion/issues/1105.
+// See https://github.com/emotion-js/emotion/releases/tag/%40emotion%2Fcache%4011.10.2.
+const ignoreSsrWarning =
+  "/* emotion-disable-server-rendering-unsafe-selector-warning-please-do-not-use-this-the-warning-exists-for-a-reason */";
+
+export const StyledH2 = styled("h2")`
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 24px;
+  margin: 16px 0 8px 0;
+
+  &:first-child:not(style)${ignoreSsrWarning} {
+    margin-top: 0;
+  }
+`;
+
+export const StyledP = styled("p")`
+  ${textBody4002Lines}
+`;
+
+export const StyledUL = styled("ul")`
+  ${textBody4002Lines}
+  margin: 0;
+  padding-left: 24px;
+
+  li {
+    margin: 4px 0;
+
+    &:first-of-type {
+      margin-top: 0;
+    }
+
+    &:last-of-type {
+      margin-bottom: 0;
+    }
+  }
+`;

--- a/app/components/Entity/components/Section/MDXSection/mdxSection.tsx
+++ b/app/components/Entity/components/Section/MDXSection/mdxSection.tsx
@@ -1,0 +1,20 @@
+import { Props } from "./types";
+import { COMPONENTS } from "./constants";
+import { MDXRemote } from "next-mdx-remote";
+import { Section } from "../section";
+import { FluidPaper } from "../../../../../components/common/Paper/components/FluidPaper/fluidPaper";
+
+export const MDXSection = ({
+  components,
+  mdxRemoteSerializeResult,
+  ...props /* Section Props */
+}: Props): JSX.Element => {
+  return (
+    <Section Paper={FluidPaper} {...props}>
+      <MDXRemote
+        components={{ ...COMPONENTS, ...components }}
+        {...mdxRemoteSerializeResult}
+      />
+    </Section>
+  );
+};

--- a/app/components/Entity/components/Section/MDXSection/types.ts
+++ b/app/components/Entity/components/Section/MDXSection/types.ts
@@ -1,0 +1,8 @@
+import { MDXRemoteProps, MDXRemoteSerializeResult } from "next-mdx-remote";
+import { SectionProps } from "../types";
+
+export interface Props
+  extends SectionProps,
+    Pick<MDXRemoteProps, "components"> {
+  mdxRemoteSerializeResult: MDXRemoteSerializeResult;
+}

--- a/app/components/Entity/components/Section/section.styles.ts
+++ b/app/components/Entity/components/Section/section.styles.ts
@@ -1,0 +1,19 @@
+import { mediaTabletDown } from "@databiosphere/findable-ui/lib/styles/common/mixins/breakpoints";
+import styled from "@emotion/styled";
+import { Typography } from "@mui/material";
+
+export const StyledTypography = styled(Typography)`
+  padding: 20px;
+
+  ${mediaTabletDown} {
+    padding: 20px 16px;
+  }
+` as typeof Typography;
+
+export const Content = styled("div")`
+  padding: 20px;
+
+  ${mediaTabletDown} {
+    padding: 20px 16px;
+  }
+`;

--- a/app/components/Entity/components/Section/section.tsx
+++ b/app/components/Entity/components/Section/section.tsx
@@ -1,0 +1,27 @@
+import { SectionProps } from "./types";
+import { Fragment } from "react";
+import { Divider } from "@mui/material";
+import { Content, StyledTypography } from "./section.styles";
+import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
+
+export const Section = ({
+  children,
+  className,
+  Paper: PaperComponent,
+  title,
+}: SectionProps): JSX.Element => {
+  const Paper = PaperComponent ?? Fragment;
+  const paperProps = PaperComponent ? { className } : {};
+  return (
+    <Paper {...paperProps}>
+      <StyledTypography
+        component="h2"
+        variant={TYPOGRAPHY_PROPS.VARIANT.TEXT_HEADING_XSMALL}
+      >
+        {title}
+      </StyledTypography>
+      <Divider />
+      <Content>{children}</Content>
+    </Paper>
+  );
+};

--- a/app/components/Entity/components/Section/types.ts
+++ b/app/components/Entity/components/Section/types.ts
@@ -1,0 +1,11 @@
+import {
+  BaseComponentProps,
+  ChildrenProps,
+} from "@databiosphere/findable-ui/lib/components/types";
+import { PaperProps } from "@mui/material";
+import { ComponentType } from "react";
+
+export interface SectionProps extends BaseComponentProps, ChildrenProps {
+  Paper?: ComponentType<PaperProps>;
+  title: string;
+}

--- a/app/components/Entity/components/Sections/sections.tsx
+++ b/app/components/Entity/components/Sections/sections.tsx
@@ -1,0 +1,17 @@
+import { SectionsProps } from "./types";
+import { Fragment } from "react";
+import { GridPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/paper.styles";
+
+export const Sections = ({
+  children,
+  className,
+  Paper: PaperComponent,
+}: SectionsProps): JSX.Element => {
+  const Paper = PaperComponent ?? Fragment;
+  const paperProps = PaperComponent ? { className } : {};
+  return (
+    <Paper {...paperProps}>
+      <GridPaper>{children}</GridPaper>
+    </Paper>
+  );
+};

--- a/app/components/Entity/components/Sections/types.ts
+++ b/app/components/Entity/components/Sections/types.ts
@@ -1,0 +1,10 @@
+import {
+  BaseComponentProps,
+  ChildrenProps,
+} from "@databiosphere/findable-ui/lib/components/types";
+import { PaperProps } from "@mui/material";
+import { ComponentType } from "react";
+
+export interface SectionsProps extends BaseComponentProps, ChildrenProps {
+  Paper?: ComponentType<PaperProps>;
+}

--- a/app/components/common/Chip/chip.tsx
+++ b/app/components/common/Chip/chip.tsx
@@ -1,0 +1,5 @@
+import { Chip as MChip, ChipProps } from "@mui/material";
+
+export const Chip = (props: ChipProps): JSX.Element => {
+  return <MChip {...props} />;
+};

--- a/app/components/common/Paper/components/FluidPaper/fluidPaper.styles.ts
+++ b/app/components/common/Paper/components/FluidPaper/fluidPaper.styles.ts
@@ -1,0 +1,20 @@
+import { Paper } from "@mui/material";
+import styled from "@emotion/styled";
+import { mediaTabletDown } from "@databiosphere/findable-ui/lib/styles/common/mixins/breakpoints";
+import { PALETTE } from "@databiosphere/findable-ui/lib/styles/common/constants/palette";
+import { SHADOWS } from "@databiosphere/findable-ui/lib/styles/common/constants/shadows";
+
+export const StyledPaper = styled(Paper)`
+  align-self: stretch;
+  border: 1px solid ${PALETTE.SMOKE_MAIN};
+  border-radius: 8px;
+  box-shadow: ${SHADOWS["01"]};
+  overflow: hidden;
+
+  ${mediaTabletDown} {
+    border-left: none;
+    border-radius: 0;
+    border-right: none;
+    box-shadow: none;
+  }
+`;

--- a/app/components/common/Paper/components/FluidPaper/fluidPaper.tsx
+++ b/app/components/common/Paper/components/FluidPaper/fluidPaper.tsx
@@ -1,0 +1,9 @@
+import { PaperProps } from "@mui/material";
+import { StyledPaper } from "./fluidPaper.styles";
+import { BaseComponentProps } from "@databiosphere/findable-ui/lib/components/types";
+
+export const FluidPaper = (
+  props: PaperProps & BaseComponentProps
+): JSX.Element => {
+  return <StyledPaper {...props} />;
+};

--- a/app/components/index.ts
+++ b/app/components/index.ts
@@ -36,3 +36,6 @@ export { GridPaperSection } from "./Layout/components/Detail/components/Section/
 export { Branding } from "./Layout/components/Footer/components/Branding/branding";
 export { AnalyzeGenome } from "./Table/components/TableCell/components/AnalyzeGenome/analyzeGenome";
 export { TypographyWordBreak } from "@databiosphere/findable-ui/lib/components/common/Typography/TypographyWordBreak/TypographyWordBreak";
+export { MDXSection } from "./Entity/components/Section/MDXSection/mdxSection";
+export { Chip } from "./common/Chip/chip";
+export { Sections } from "./Entity/components/Sections/sections";

--- a/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
@@ -8,6 +8,7 @@ import { ROUTES } from "../../../../../routes/constants";
 import {
   BRCDataCatalogGenome,
   BRCDataCatalogOrganism,
+  Outbreak,
   Workflow,
 } from "../../../../apis/catalog/brc-analytics-catalog/common/entities";
 import * as C from "../../../../components";
@@ -30,6 +31,17 @@ import {
 } from "../../../../apis/catalog/brc-analytics-catalog/common/utils";
 import { COLUMN_IDENTIFIER } from "@databiosphere/findable-ui/lib/components/Table/common/columnIdentifier";
 import { ConfiguredInput } from "../../../../views/WorkflowInputsView/hooks/UseConfigureInputs/types";
+import { CHIP_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/chip";
+import {
+  getPriorityColor,
+  getPriorityLabel,
+} from "../../../../views/PriorityPathogensView/components/PriorityPathogens/utils";
+import { KeyValueSection } from "../../../../components/Entity/components/Section/KeyValueSection/keyValueSection";
+import {
+  getActiveColor,
+  getActiveLabel,
+} from "../../../../views/PriorityPathogenView/utils";
+import { ResourcesSection } from "app/views/PriorityPathogenView/components/ResourcesSection/resourcesSection";
 
 /**
  * Build props for the accession cell.
@@ -311,6 +323,79 @@ export const buildOrganismTaxonomicLevelStrain = (
   return {
     label: "strains",
     values: organism.taxonomicLevelStrain,
+  };
+};
+
+/**
+ * Build props for the priority pathogen BackPageHero component.
+ * @param priorityPathogen - Priority pathogen entity.
+ * @returns Props to be used for the BackPageHero component.
+ */
+export const buildPriorityPathogenHero = (
+  priorityPathogen: Outbreak
+): ComponentProps<typeof C.BackPageHero> => {
+  return {
+    breadcrumbs: getPriorityPathogenEntityBreadcrumbs(priorityPathogen),
+    title: priorityPathogen.name,
+  };
+};
+
+/**
+ * Build props for the priority pathogen description section.
+ * @param priorityPathogen - Priority pathogen entity.
+ * @returns Props to be used for the MDXSection component.
+ */
+export const buildPriorityPathogenDescription = (
+  priorityPathogen: Outbreak
+): ComponentProps<typeof C.MDXSection> => {
+  return {
+    mdxRemoteSerializeResult: priorityPathogen.description,
+    title: "Description",
+  };
+};
+
+/**
+ * Build props for the priority pathogen details section..
+ * @param priorityPathogen - Priority pathogen entity.
+ * @returns Props to be used for the KeyValuePairs component.
+ */
+export const buildPriorityPathogenDetails = (
+  priorityPathogen: Outbreak
+): ComponentProps<typeof KeyValueSection> => {
+  const keyValuePairs = new Map<Key, Value>();
+  keyValuePairs.set(
+    "Status",
+    C.Chip({
+      color: getActiveColor(priorityPathogen.active),
+      label: getActiveLabel(priorityPathogen.active),
+      variant: CHIP_PROPS.VARIANT.STATUS,
+    })
+  );
+  keyValuePairs.set(
+    "Priority",
+    C.Chip({
+      color: getPriorityColor(priorityPathogen.priority),
+      label: getPriorityLabel(priorityPathogen.priority),
+      variant: CHIP_PROPS.VARIANT.STATUS,
+    })
+  );
+  return {
+    keyValuePairs,
+    title: "Priority Pathogen details",
+  };
+};
+
+/**
+ * Build props for the priority pathogen resources section.
+ * @param priorityPathogen - Priority pathogen entity.
+ * @returns Props to be used for the ResourcesSection component.
+ */
+export const buildPriorityPathogenResources = (
+  priorityPathogen: Outbreak
+): ComponentProps<typeof ResourcesSection> => {
+  return {
+    resources: priorityPathogen.resources,
+    title: "Resources",
   };
 };
 
@@ -743,5 +828,19 @@ function getOrganismEntityAssembliesBreadcrumbs(
     { path: ROUTES.ORGANISMS, text: "Organisms" },
     { path: "", text: `${organism.taxonomicLevelSpecies}` },
     { path: "", text: "Assemblies" },
+  ];
+}
+
+/**
+ * Get the priority pathogen entity breadcrumbs.
+ * @param priorityPathogen - Priority pathogen entity.
+ * @returns Breadcrumbs.
+ */
+function getPriorityPathogenEntityBreadcrumbs(
+  priorityPathogen: Outbreak
+): Breadcrumb[] {
+  return [
+    { path: ROUTES.PRIORITY_PATHOGENS, text: "Priority Pathogens" },
+    { path: "", text: priorityPathogen.name },
   ];
 }

--- a/app/views/PriorityPathogenView/components/ResourcesSection/resourcesSection.styles.ts
+++ b/app/views/PriorityPathogenView/components/ResourcesSection/resourcesSection.styles.ts
@@ -1,0 +1,22 @@
+import { textBody4002Lines } from "@databiosphere/findable-ui/lib/styles/common/mixins/fonts";
+import styled from "@emotion/styled";
+import { List } from "@mui/material";
+
+export const StyledList = styled(List)`
+  ${textBody4002Lines};
+  list-style-type: disc;
+  padding-left: 24px;
+
+  .MuiListItem-root {
+    display: list-item;
+    margin: 4px 0;
+
+    &:first-of-type {
+      margin-top: 0;
+    }
+
+    &:last-of-type {
+      margin-bottom: 0;
+    }
+  }
+`;

--- a/app/views/PriorityPathogenView/components/ResourcesSection/resourcesSection.tsx
+++ b/app/views/PriorityPathogenView/components/ResourcesSection/resourcesSection.tsx
@@ -1,0 +1,23 @@
+import { Props } from "./types";
+import { Section } from "../../../../components/Entity/components/Section/section";
+import { FluidPaper } from "../../../../components/common/Paper/components/FluidPaper/fluidPaper";
+import { ListItem } from "@mui/material";
+import { Link } from "@databiosphere/findable-ui/lib/components/Links/components/Link/link";
+import { StyledList } from "./resourcesSection.styles";
+
+export const ResourcesSection = ({
+  resources,
+  ...props /* Section Props */
+}: Props): JSX.Element => {
+  return (
+    <Section Paper={FluidPaper} {...props}>
+      <StyledList disablePadding>
+        {resources.map((resource, i) => (
+          <ListItem key={i} disableGutters disablePadding>
+            <Link label={resource.title} url={resource.url} />
+          </ListItem>
+        ))}
+      </StyledList>
+    </Section>
+  );
+};

--- a/app/views/PriorityPathogenView/components/ResourcesSection/types.ts
+++ b/app/views/PriorityPathogenView/components/ResourcesSection/types.ts
@@ -1,0 +1,6 @@
+import { SectionProps } from "../../../../components/Entity/components/Section/types";
+import { OutbreakResource } from "../../../../apis/catalog/brc-analytics-catalog/common/entities";
+
+export interface Props extends Omit<SectionProps, "children"> {
+  resources: OutbreakResource[];
+}

--- a/app/views/PriorityPathogenView/utils.ts
+++ b/app/views/PriorityPathogenView/utils.ts
@@ -1,0 +1,34 @@
+import { ChipProps } from "@mui/material";
+import { CHIP_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/chip";
+
+/**
+ * Returns the color for the active status of the outbreak.
+ * @param active - The active status of the outbreak.
+ * @returns The color for the active status of the outbreak.
+ */
+export function getActiveColor(active: boolean): ChipProps["color"] {
+  switch (active) {
+    case true:
+      return CHIP_PROPS.COLOR.SUCCESS;
+    case false:
+      return CHIP_PROPS.COLOR.WARNING;
+    default:
+      return CHIP_PROPS.COLOR.DEFAULT;
+  }
+}
+
+/**
+ * Returns the label for the outbreak's active status.
+ * @param active - The active status of the outbreak.
+ * @returns The label for the active status of the outbreak.
+ */
+export function getActiveLabel(active: boolean): string {
+  switch (active) {
+    case true:
+      return "Active";
+    case false:
+      return "Inactive";
+    default:
+      return "Unknown";
+  }
+}

--- a/app/views/PriorityPathogensView/components/PriorityPathogens/priorityPathogens.styles.ts
+++ b/app/views/PriorityPathogensView/components/PriorityPathogens/priorityPathogens.styles.ts
@@ -1,6 +1,7 @@
 import { Grid, Typography } from "@mui/material";
 import styled from "@emotion/styled";
 import { mediaTabletUp } from "@databiosphere/findable-ui/lib/styles/common/mixins/breakpoints";
+import { PALETTE } from "@databiosphere/findable-ui/lib/styles/common/constants/palette";
 
 export const StyledGrid = styled(Grid)`
   display: grid;
@@ -8,6 +9,16 @@ export const StyledGrid = styled(Grid)`
 
   .MuiPaper-root {
     align-self: flex-start;
+  }
+
+  .MuiCardActionArea-root {
+    &:hover {
+      background-color: ${PALETTE.SMOKE_LIGHTEST};
+
+      .MuiCardActionArea-focusHighlight {
+        opacity: 0;
+      }
+    }
   }
 
   ${mediaTabletUp} {

--- a/app/views/PriorityPathogensView/components/PriorityPathogens/priorityPathogens.tsx
+++ b/app/views/PriorityPathogensView/components/PriorityPathogens/priorityPathogens.tsx
@@ -3,43 +3,60 @@ import {
   Section,
   SectionContent,
 } from "@databiosphere/findable-ui/lib/components/common/Section/section.styles";
-import { Chip, Typography } from "@mui/material";
+import { CardActionArea, Chip, Typography } from "@mui/material";
 import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
 import { CHIP_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/chip";
 import { MDXRemote } from "next-mdx-remote";
 import { StyledGrid, StyledSectionText } from "./priorityPathogens.styles";
 import { FluidPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/paper.styles";
 import { getPriorityColor, getPriorityLabel } from "./utils";
+import { useRouter } from "next/router";
+import { ROUTES } from "../../../../../routes/constants";
+import slugify from "slugify";
+import { SLUGIFY_OPTIONS } from "../../constants";
 
 export const PriorityPathogens = ({
   priorityPathogens,
 }: Props): JSX.Element => {
+  const { push } = useRouter();
   return (
     <StyledGrid container gap={4}>
-      {priorityPathogens.map((priorityPathogen) => (
-        <FluidPaper key={priorityPathogen.name}>
-          <Section>
-            <SectionContent>
-              <Typography
-                variant={TYPOGRAPHY_PROPS.VARIANT.TEXT_HEADING_XSMALL}
-              >
-                {priorityPathogen.name}
-              </Typography>
-              <StyledSectionText
-                color={TYPOGRAPHY_PROPS.COLOR.INK_LIGHT}
-                variant={TYPOGRAPHY_PROPS.VARIANT.TEXT_BODY_400_2_LINES}
-              >
-                <MDXRemote {...priorityPathogen.description} />
-              </StyledSectionText>
-            </SectionContent>
-            <Chip
-              color={getPriorityColor(priorityPathogen.priority)}
-              label={getPriorityLabel(priorityPathogen.priority)}
-              variant={CHIP_PROPS.VARIANT.STATUS}
-            />
-          </Section>
-        </FluidPaper>
-      ))}
+      {priorityPathogens.map((priorityPathogen) => {
+        const entityId = slugify(priorityPathogen.name, SLUGIFY_OPTIONS);
+        return (
+          <FluidPaper key={priorityPathogen.name}>
+            <CardActionArea
+              onClick={() =>
+                push({
+                  pathname: ROUTES.PRIORITY_PATHOGEN,
+                  query: { entityId },
+                })
+              }
+            >
+              <Section>
+                <SectionContent>
+                  <Typography
+                    variant={TYPOGRAPHY_PROPS.VARIANT.TEXT_HEADING_XSMALL}
+                  >
+                    {priorityPathogen.name}
+                  </Typography>
+                  <StyledSectionText
+                    color={TYPOGRAPHY_PROPS.COLOR.INK_LIGHT}
+                    variant={TYPOGRAPHY_PROPS.VARIANT.TEXT_BODY_400_2_LINES}
+                  >
+                    <MDXRemote {...priorityPathogen.description} />
+                  </StyledSectionText>
+                </SectionContent>
+                <Chip
+                  color={getPriorityColor(priorityPathogen.priority)}
+                  label={getPriorityLabel(priorityPathogen.priority)}
+                  variant={CHIP_PROPS.VARIANT.STATUS}
+                />
+              </Section>
+            </CardActionArea>
+          </FluidPaper>
+        );
+      })}
     </StyledGrid>
   );
 };

--- a/app/views/PriorityPathogensView/constants.ts
+++ b/app/views/PriorityPathogensView/constants.ts
@@ -1,0 +1,1 @@
+export const SLUGIFY_OPTIONS = { lower: true, remove: /[()/]/g };

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "remark-gfm": "^3.0.1",
         "remark-parse": "^10.0.2",
         "remark-rehype": "^10.1.0",
+        "slugify": "^1.6.6",
         "unified": "^10.1.2",
         "uuid": "8.3.2",
         "yup": "^1.6.1"
@@ -20638,6 +20639,14 @@
       "resolved": "https://registry.npmjs.org/slashes/-/slashes-3.0.12.tgz",
       "integrity": "sha512-Q9VME8WyGkc7pJf6QEkj3wE+2CnvZMI+XJhwdTPR8Z/kWQRXi7boAWLDibRPyHRTUTPx5FaU7MsyrjI3yLB4HA==",
       "dev": true
+    },
+    "node_modules/slugify": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
+      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/source-map": {
       "version": "0.5.7",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "remark-gfm": "^3.0.1",
     "remark-parse": "^10.0.2",
     "remark-rehype": "^10.1.0",
+    "slugify": "^1.6.6",
     "unified": "^10.1.2",
     "uuid": "8.3.2",
     "yup": "^1.6.1"

--- a/site-config/brc-analytics/local/entity/priorityPathogen/priorityPathogenMainColumn.ts
+++ b/site-config/brc-analytics/local/entity/priorityPathogen/priorityPathogenMainColumn.ts
@@ -1,0 +1,24 @@
+import {
+  ComponentsConfig,
+  ComponentConfig,
+} from "@databiosphere/findable-ui/lib/config/entities";
+import * as C from "../../../../../app/components";
+import * as V from "../../../../../app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders";
+import { ResourcesSection } from "../../../../../app/views/PriorityPathogenView/components/ResourcesSection/resourcesSection";
+import { Outbreak } from "../../../../../app/apis/catalog/brc-analytics-catalog/common/entities";
+
+export const priorityPathogenMainColumn: ComponentsConfig = [
+  {
+    children: [
+      {
+        component: C.MDXSection,
+        viewBuilder: V.buildPriorityPathogenDescription,
+      } as ComponentConfig<typeof C.MDXSection, Outbreak>,
+      {
+        component: ResourcesSection,
+        viewBuilder: V.buildPriorityPathogenResources,
+      } as ComponentConfig<typeof ResourcesSection, Outbreak>,
+    ],
+    component: C.BackPageContentMainColumn,
+  },
+];

--- a/site-config/brc-analytics/local/entity/priorityPathogen/priorityPathogenSideColumn.ts
+++ b/site-config/brc-analytics/local/entity/priorityPathogen/priorityPathogenSideColumn.ts
@@ -1,0 +1,27 @@
+import {
+  ComponentConfig,
+  ComponentsConfig,
+} from "@databiosphere/findable-ui/lib/config/entities";
+import * as C from "../../../../../app/components";
+import * as V from "../../../../../app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders";
+import { Outbreak } from "../../../../../app/apis/catalog/brc-analytics-catalog/common/entities";
+import { FluidPaper } from "../../../../../app/components/common/Paper/components/FluidPaper/fluidPaper";
+import { KeyValueSection } from "../../../../../app/components/Entity/components/Section/KeyValueSection/keyValueSection";
+
+export const priorityPathogenSideColumn: ComponentsConfig = [
+  {
+    children: [
+      {
+        children: [
+          {
+            component: KeyValueSection,
+            viewBuilder: V.buildPriorityPathogenDetails,
+          } as ComponentConfig<typeof KeyValueSection, Outbreak>,
+        ],
+        component: C.Sections,
+        props: { Paper: FluidPaper },
+      } as ComponentConfig<typeof C.Sections, Outbreak>,
+    ],
+    component: C.BackPageContentSideColumn,
+  },
+];

--- a/site-config/brc-analytics/local/entity/priorityPathogen/priorityPathogenTop.ts
+++ b/site-config/brc-analytics/local/entity/priorityPathogen/priorityPathogenTop.ts
@@ -1,0 +1,14 @@
+import {
+  ComponentConfig,
+  ComponentsConfig,
+} from "@databiosphere/findable-ui/lib/config/entities";
+import { Outbreak } from "../../../../../app/apis/catalog/brc-analytics-catalog/common/entities";
+import * as C from "../../../../../app/components";
+import * as V from "../../../../../app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders";
+
+export const priorityPathogenTop: ComponentsConfig = [
+  {
+    component: C.BackPageHero,
+    viewBuilder: V.buildPriorityPathogenHero,
+  } as ComponentConfig<typeof C.BackPageHero, Outbreak>,
+];

--- a/site-config/brc-analytics/local/index/priorityPathogensEntityConfig.ts
+++ b/site-config/brc-analytics/local/index/priorityPathogensEntityConfig.ts
@@ -1,6 +1,11 @@
 import { EXPLORE_MODE } from "@databiosphere/findable-ui/lib/hooks/useExploreMode/types";
 import { Outbreak } from "../../../../app/apis/catalog/brc-analytics-catalog/common/entities";
 import { BRCEntityConfig } from "../../../common/entities";
+import { priorityPathogenMainColumn } from "../entity/priorityPathogen/priorityPathogenMainColumn";
+import { priorityPathogenTop } from "../entity/priorityPathogen/priorityPathogenTop";
+import slugify from "slugify";
+import { SLUGIFY_OPTIONS } from "../../../../app/views/PriorityPathogensView/constants";
+import { priorityPathogenSideColumn } from "../entity/priorityPathogen/priorityPathogenSideColumn";
 
 /**
  * Entity config object responsible to config anything related to the /priority-pathogens route.
@@ -10,11 +15,19 @@ export const priorityPathogensEntityConfig: BRCEntityConfig<Outbreak> = {
   detail: {
     detailOverviews: [],
     staticLoad: true,
-    tabs: [],
+    tabs: [
+      {
+        label: "Priority Pathogen",
+        mainColumn: priorityPathogenMainColumn,
+        route: "",
+        sideColumn: priorityPathogenSideColumn,
+        top: priorityPathogenTop,
+      },
+    ],
   },
   exploreMode: EXPLORE_MODE.CS_FETCH_CS_FILTERING,
   explorerTitle: "Priority Pathogens",
-  getId: () => "",
+  getId: (priorityPathogen) => slugify(priorityPathogen.name, SLUGIFY_OPTIONS),
   label: "Priority Pathogens",
   list: {
     columns: [],


### PR DESCRIPTION
Closes #507.

This pull request introduces a set of reusable components and styles for rendering sections, key-value pairs, and MDX content within the application. It also adds utilities for building view models for priority pathogens. The changes focus on modularizing the codebase, improving reusability, and standardizing styles.

### Component Additions and Enhancements:

* **Key-Value Components**:
  - Added `KeyElType`, `ValueElType`, and `KeyValueElType` components for rendering key-value pairs with consistent styles using Material-UI's `Typography` and `Grid` components. (`[[1]](diffhunk://#diff-c2b34d4a53b9686a2f02e8ad190d1e5fe10e9842ce33b6e0cb953e72f400c892R1-R19)`, `[[2]](diffhunk://#diff-3b726a5e0b739738d7c5ea3400e022fe5c47d7b476612905e8a0297703ec73c1R1-R20)`, `[[3]](diffhunk://#diff-05d352818b9476e1ae296430d331b3ea15f8abd6d9d89722ba419c3d825e5123R1-R15)`)
  - Introduced `KeyValueSection` for displaying a titled section with key-value pairs. (`[[1]](diffhunk://#diff-20d520c8de937472158f6f1d272bb3cd49d161c990de353593514f15a16ef2d2R1-R26)`, `[[2]](diffhunk://#diff-41cb880287d7ea3a47a9a560b4924cf85fecac547da16e8beb7f4b0c281cb810R1-R5)`)

* **MDX Section**:
  - Added `MDXSection` component to render MDX content with styled headers, paragraphs, and lists. (`[[1]](diffhunk://#diff-22dc890d24a5199b5c6e1cee7eb14bd3f9c3500dde76f090aab833d1dbc42f23R1-R20)`, `[[2]](diffhunk://#diff-0bfc871e166587fcf35332b84c33c4ffbe36d49c6d4ee740bed105febb8ad028R1-R7)`, `[[3]](diffhunk://#diff-c40c53acdf8c97950dc470e8a6e0b7894f728342798ede2f74221b802d6ae3f1R1-R40)`, `[[4]](diffhunk://#diff-a54f03e89d6201af1791a828161ed13e52dde33858bd0c4694e62fbec57b261dR1-R8)`)

* **General Section Components**:
  - Created a reusable `Section` component for rendering titled sections with optional paper wrapping and dividers. (`[[1]](diffhunk://#diff-00f2f468ada079c5e996c7bf2bdc8f35609bfef378df7e534e1f19d9647feb8cR1-R27)`, `[[2]](diffhunk://#diff-2497bc85e69248613778aa95ab08aa25bf9dbf409299c04ac44a1d1e5b13ccb0R1-R11)`)
  - Added `Sections` component for grouping multiple sections with optional paper wrapping. (`[[1]](diffhunk://#diff-919f5432f374641cbe340b36278b842d011579e3d9347a0ed289cad0b6d3e763R1-R17)`, `[[2]](diffhunk://#diff-198a169ab45ab1b5ea502be621adf14a9ccbb2d3080b78d84aecf2ef90dcc76fR1-R10)`)

* **Common Components**:
  - Introduced a wrapper for Material-UI's `Chip` component to standardize usage. (`[app/components/common/Chip/chip.tsxR1-R5](diffhunk://#diff-89d2c4cbedc9f8ee1bc43fa02f923c555d0e4dd50c583b4a872681bf0076a14eR1-R5)`)
  - Added `FluidPaper` for responsive paper styling with consistent borders and shadows. (`[[1]](diffhunk://#diff-d43f85b88d9b96992adc1430a6514bd16f986d14a4cb487b28a399bb3ef568ecR1-R20)`, `[[2]](diffhunk://#diff-efc6a0fa9947624245fd603f0cad4d92bb1d59543777973f5626118c1a23cb74R1-R9)`)

### Styling Improvements:

* Added shared styled components (`StyledH2`, `StyledP`, `StyledUL`, `StyledTypography`, `Content`) to ensure consistent typography and layout across sections. (`[[1]](diffhunk://#diff-9835f44a0fee77bfed1880956ada88ff33bbff2f39b5f5d9f146cc7d4a7cca1aR1-R49)`, `[[2]](diffhunk://#diff-c40c53acdf8c97950dc470e8a6e0b7894f728342798ede2f74221b802d6ae3f1R1-R40)`, `[[3]](diffhunk://#diff-7dc9c260008e5322503fcdf0d1774cd9918b46dcbe67dc3bc03f05990c9eba35R1-R19)`)

### View Model Enhancements:

* Added utility functions to build view models for priority pathogens, including:
  - Hero component props (`buildPriorityPathogenHero`)
  - MDX description section props (`buildPriorityPathogenDescription`)
  - Key-value details section props (`buildPriorityPathogenDetails`)
  - Resources section props (`buildPriorityPathogenResources`) (`[[1]](diffhunk://#diff-c7a9aefa9288341532869ba9987b67c489fce1e3b9e10c08643d92d54691ee11R329-R401)`, `[[2]](diffhunk://#diff-c7a9aefa9288341532869ba9987b67c489fce1e3b9e10c08643d92d54691ee11R833-R846)`)

### Miscellaneous Updates:

* Exported new components (`MDXSection`, `Chip`, `Sections`) for external use. (`[app/components/index.tsR39-R41](diffhunk://#diff-ab5acd52d2bbe58facfe338cfed6cec00e93a9e328a89b7f9e0d9c6867745d8dR39-R41)`)
* Updated imports to include new utilities and components. (`[[1]](diffhunk://#diff-c7a9aefa9288341532869ba9987b67c489fce1e3b9e10c08643d92d54691ee11R11)`, `[[2]](diffhunk://#diff-c7a9aefa9288341532869ba9987b67c489fce1e3b9e10c08643d92d54691ee11R34-R44)`)
 
<img width="1131" alt="image" src="https://github.com/user-attachments/assets/e66cf99b-ff49-4fff-891f-51e3d914d3e0" />
 