### PR TITLE
feat: filter organism and assemblies by priority and priority group (#609)

### DIFF
--- a/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
@@ -326,9 +326,22 @@ export const buildOrganismTaxonomicLevelStrain = (
 };
 
 /**
+ * Build props for the priority cell.
+ * @param entity - Genome or organism entity.
+ * @returns Props to be used for the BasicCell component.
+ */
+export const buildPriority = (
+  entity: BRCDataCatalogGenome | BRCDataCatalogOrganism
+): ComponentProps<typeof C.BasicCell> => {
+  return {
+    value: entity.priority ?? "Unprioritized",
+  };
+};
+
+/**
  * Build props for the priority pathogen cell.
  * @param entity - Genome or organism entity.
- * @returns Props to be used for the Chip cell.
+ * @returns Props to be used for the Chip component.
  */
 export const buildPriorityPathogen = (
   entity: BRCDataCatalogGenome | BRCDataCatalogOrganism

--- a/site-config/brc-analytics/local/index/common/category/categories.ts
+++ b/site-config/brc-analytics/local/index/common/category/categories.ts
@@ -1,0 +1,12 @@
+import { CategoryGroup } from "@databiosphere/findable-ui/lib/config/entities";
+import { CATEGORY_REGISTRY } from "./categoryRegistry";
+
+export const CATEGORY_GROUPS: Record<string, CategoryGroup> = {
+  PRIORITY_PATHOGENS: {
+    categoryConfigs: [
+      CATEGORY_REGISTRY.PRIORITY_PATHOGEN_NAME,
+      CATEGORY_REGISTRY.PRIORITY,
+    ],
+    label: "Priority Pathogens",
+  },
+};

--- a/site-config/brc-analytics/local/index/common/category/categoryRegistry.ts
+++ b/site-config/brc-analytics/local/index/common/category/categoryRegistry.ts
@@ -1,0 +1,7 @@
+import { CategoryConfig } from "@databiosphere/findable-ui/lib/common/categories/config/types";
+import * as CATEGORY_CONFIG from "./configs";
+
+export const CATEGORY_REGISTRY: Record<string, CategoryConfig> = {
+  PRIORITY: CATEGORY_CONFIG.PRIORITY,
+  PRIORITY_PATHOGEN_NAME: CATEGORY_CONFIG.PRIORITY_PATHOGEN_NAME,
+};

--- a/site-config/brc-analytics/local/index/common/category/configs.ts
+++ b/site-config/brc-analytics/local/index/common/category/configs.ts
@@ -1,0 +1,19 @@
+import { CategoryConfig } from "@databiosphere/findable-ui/lib/common/categories/config/types";
+import {
+  BRC_DATA_CATALOG_CATEGORY_KEY,
+  BRC_DATA_CATALOG_CATEGORY_LABEL,
+} from "../../../../category";
+import { mapSelectCategoryValue } from "./mapSelectCategoryValue";
+import { mapPriority, mapPriorityPathogenName } from "./utils";
+
+export const PRIORITY: CategoryConfig = {
+  key: BRC_DATA_CATALOG_CATEGORY_KEY.PRIORITY,
+  label: BRC_DATA_CATALOG_CATEGORY_LABEL.PRIORITY,
+  mapSelectCategoryValue: mapSelectCategoryValue(mapPriority),
+};
+
+export const PRIORITY_PATHOGEN_NAME: CategoryConfig = {
+  key: BRC_DATA_CATALOG_CATEGORY_KEY.PRIORITY_PATHOGEN_NAME,
+  label: BRC_DATA_CATALOG_CATEGORY_LABEL.PRIORITY_PATHOGEN_NAME,
+  mapSelectCategoryValue: mapSelectCategoryValue(mapPriorityPathogenName),
+};

--- a/site-config/brc-analytics/local/index/common/category/mapSelectCategoryValue.ts
+++ b/site-config/brc-analytics/local/index/common/category/mapSelectCategoryValue.ts
@@ -1,0 +1,17 @@
+import { SelectCategoryValue } from "@databiosphere/findable-ui/lib/common/entities";
+
+/**
+ * Returns select category value with formatted label.
+ * @param formatLabel - Function to format label.
+ * @returns select category value with formatted label.
+ */
+export function mapSelectCategoryValue(
+  formatLabel: (label: string) => string
+): (select: SelectCategoryValue) => SelectCategoryValue {
+  return (selectCategoryValue: SelectCategoryValue) => {
+    return {
+      ...selectCategoryValue,
+      label: formatLabel(selectCategoryValue.label),
+    };
+  };
+}

--- a/site-config/brc-analytics/local/index/common/category/typeGuards.ts
+++ b/site-config/brc-analytics/local/index/common/category/typeGuards.ts
@@ -1,0 +1,12 @@
+import { OUTBREAK_PRIORITY } from "app/apis/catalog/brc-analytics-catalog/common/schema-entities";
+
+/**
+ * Checks if the value is an Outbreak Priority.
+ * @param value - Value.
+ * @returns True if the value is an Outbreak Priority, false otherwise.
+ */
+export function isOutbreakPriority(value: unknown): value is OUTBREAK_PRIORITY {
+  if (!value) return false;
+  if (typeof value !== "string") return false;
+  return Object.values(OUTBREAK_PRIORITY).includes(value as OUTBREAK_PRIORITY);
+}

--- a/site-config/brc-analytics/local/index/common/category/utils.ts
+++ b/site-config/brc-analytics/local/index/common/category/utils.ts
@@ -1,0 +1,22 @@
+import { isOutbreakPriority } from "./typeGuards";
+import { getPriorityLabel } from "../../../../../../app/views/PriorityPathogensView/components/PriorityPathogens/utils";
+
+/**
+ * Returns the priority label for the given value.
+ * @param value - Value.
+ * @returns Priority label.
+ */
+export function mapPriority(value: string): string {
+  if (isOutbreakPriority(value)) return getPriorityLabel(value);
+  return "Unprioritized";
+}
+
+/**
+ * Returns the priority pathogen name for the given value.
+ * @param value - Value.
+ * @returns Priority pathogen name.
+ */
+export function mapPriorityPathogenName(value: string): string {
+  if (!value) return "Unprioritized";
+  return value;
+}

--- a/site-config/brc-analytics/local/index/common/column/columnDefs.ts
+++ b/site-config/brc-analytics/local/index/common/column/columnDefs.ts
@@ -1,0 +1,21 @@
+import { ColumnConfig } from "@databiosphere/findable-ui/lib/config/entities";
+import {
+  BRCDataCatalogGenome,
+  BRCDataCatalogOrganism,
+} from "../../../../../../app/apis/catalog/brc-analytics-catalog/common/entities";
+import {
+  BRC_DATA_CATALOG_CATEGORY_KEY,
+  BRC_DATA_CATALOG_CATEGORY_LABEL,
+} from "../../../../category";
+import * as C from "../../../../../../app/components";
+import * as V from "../../../../../../app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders";
+
+export const PRIORITY: ColumnConfig<
+  BRCDataCatalogGenome | BRCDataCatalogOrganism
+> = {
+  componentConfig: { component: C.BasicCell, viewBuilder: V.buildPriority },
+  enableHiding: false,
+  header: BRC_DATA_CATALOG_CATEGORY_LABEL.PRIORITY,
+  id: BRC_DATA_CATALOG_CATEGORY_KEY.PRIORITY,
+  width: "auto",
+};

--- a/site-config/brc-analytics/local/index/common/column/columnDefs.ts
+++ b/site-config/brc-analytics/local/index/common/column/columnDefs.ts
@@ -14,7 +14,7 @@ export const PRIORITY: ColumnConfig<
   BRCDataCatalogGenome | BRCDataCatalogOrganism
 > = {
   componentConfig: { component: C.BasicCell, viewBuilder: V.buildPriority },
-  enableHiding: false,
+  enableHiding: true,
   header: BRC_DATA_CATALOG_CATEGORY_LABEL.PRIORITY,
   id: BRC_DATA_CATALOG_CATEGORY_KEY.PRIORITY,
   width: "auto",

--- a/site-config/brc-analytics/local/index/common/column/columnRegistry.ts
+++ b/site-config/brc-analytics/local/index/common/column/columnRegistry.ts
@@ -1,0 +1,13 @@
+import { ColumnConfig } from "@databiosphere/findable-ui/lib/config/entities";
+import {
+  BRCDataCatalogGenome,
+  BRCDataCatalogOrganism,
+} from "../../../../../../app/apis/catalog/brc-analytics-catalog/common/entities";
+import * as COLUMN_DEFS from "./columnDefs";
+
+export const COLUMN_REGISTRY: Record<
+  string,
+  ColumnConfig<BRCDataCatalogOrganism | BRCDataCatalogGenome>
+> = {
+  PRIORITY: COLUMN_DEFS.PRIORITY,
+};

--- a/site-config/brc-analytics/local/index/genomeEntityConfig.ts
+++ b/site-config/brc-analytics/local/index/genomeEntityConfig.ts
@@ -19,6 +19,8 @@ import {
 import { mainColumn as analysisMethodsMainColumn } from "../entity/genome/analysisMethodMainColumn";
 import { sideColumn as analysisMethodsSideColumn } from "../entity/genome/analysisMethodsSideColumn";
 import { top as analysisMethodsTop } from "../entity/genome/analysisMethodsTop";
+import { CATEGORY_GROUPS } from "./common/category/categories";
+import { COLUMN_REGISTRY } from "./common/column/columnRegistry";
 
 /**
  * Entity config object responsible to config anything related to the /assemblies route.
@@ -47,6 +49,7 @@ export const genomeEntityConfig: BRCEntityConfig<BRCDataCatalogGenome> = {
         ],
         label: "Organism",
       },
+      CATEGORY_GROUPS.PRIORITY_PATHOGENS,
       {
         categoryConfigs: [
           {
@@ -374,10 +377,12 @@ export const genomeEntityConfig: BRCEntityConfig<BRCDataCatalogGenome> = {
         id: BRC_DATA_CATALOG_CATEGORY_KEY.ANNOTATION_STATUS,
         width: { max: "0.5fr", min: "142px" },
       },
+      COLUMN_REGISTRY.PRIORITY,
     ],
     tableOptions: {
       initialState: {
         columnVisibility: {
+          [BRC_DATA_CATALOG_CATEGORY_KEY.PRIORITY]: false,
           [BRC_DATA_CATALOG_CATEGORY_KEY.TAXONOMIC_LEVEL_CLASS]: false,
           [BRC_DATA_CATALOG_CATEGORY_KEY.TAXONOMIC_LEVEL_FAMILY]: false,
           [BRC_DATA_CATALOG_CATEGORY_KEY.TAXONOMIC_LEVEL_GENUS]: false,

--- a/site-config/brc-analytics/local/index/organismEntityConfig.ts
+++ b/site-config/brc-analytics/local/index/organismEntityConfig.ts
@@ -15,6 +15,8 @@ import {
 } from "../../category";
 import { assembliesMainColumn } from "../entity/organism/assembliesMainColumn";
 import { assembliesTop } from "../entity/organism/assembliesTop";
+import { CATEGORY_GROUPS } from "./common/category/categories";
+import { COLUMN_REGISTRY } from "./common/column/columnRegistry";
 
 /**
  * Entity config object responsible to config anything related to the /genomes route.
@@ -42,6 +44,7 @@ export const organismEntityConfig: BRCEntityConfig<BRCDataCatalogOrganism> = {
           },
         ],
       },
+      CATEGORY_GROUPS.PRIORITY_PATHOGENS,
       {
         categoryConfigs: [
           {
@@ -241,10 +244,12 @@ export const organismEntityConfig: BRCEntityConfig<BRCDataCatalogOrganism> = {
         id: BRC_DATA_CATALOG_CATEGORY_KEY.ASSEMBLY_COUNT,
         width: { max: "0.65fr", min: "164px" },
       },
+      COLUMN_REGISTRY.PRIORITY,
     ],
     tableOptions: {
       initialState: {
         columnVisibility: {
+          [BRC_DATA_CATALOG_CATEGORY_KEY.PRIORITY]: false,
           [BRC_DATA_CATALOG_CATEGORY_KEY.TAXONOMIC_LEVEL_CLASS]: false,
           [BRC_DATA_CATALOG_CATEGORY_KEY.TAXONOMIC_LEVEL_FAMILY]: false,
           [BRC_DATA_CATALOG_CATEGORY_KEY.TAXONOMIC_LEVEL_GENUS]: false,


### PR DESCRIPTION
Closes #609.

<img width="1535" alt="image" src="https://github.com/user-attachments/assets/ff5be6f9-29df-4f7f-ad38-f7a98cc7f809" />

This pull request introduces functionality to support the display and management of "Priority" and "Priority Pathogen" data in the BRC Analytics Catalog. The changes include new utility functions, configurations for categories and columns, and updates to entity configurations to integrate these new features.

### New utilities and helper functions:

* Added `mapSelectCategoryValue` function to format select category values with a custom label formatter (`site-config/brc-analytics/local/index/common/category/mapSelectCategoryValue.ts`).
* Introduced `isOutbreakPriority` type guard to validate "Outbreak Priority" values (`site-config/brc-analytics/local/index/common/category/typeGuards.ts`).
* Created utility functions `mapPriority` and `mapPriorityPathogenName` to handle priority labels and pathogen names (`site-config/brc-analytics/local/index/common/category/utils.ts`).

### Category and column configurations:

* Added `CATEGORY_REGISTRY` to centralize category configurations and `CATEGORY_GROUPS` to group related categories (`site-config/brc-analytics/local/index/common/category/categoryRegistry.ts`, `site-config/brc-analytics/local/index/common/category/categories.ts`). [[1]](diffhunk://#diff-b755a4813b92ece1a89b16b3d90b0c9ad7e44a72371283506664405d1be6911cR1-R7) [[2]](diffhunk://#diff-887bb5eb1761348d9c959da8bf169ba9278f67fd51d81d3930ed69211ea2f91aR1-R12)
* Defined `PRIORITY` and `PRIORITY_PATHOGEN_NAME` category configurations with mapping functions for label formatting (`site-config/brc-analytics/local/index/common/category/configs.ts`).
* Added `PRIORITY` column configuration with a `BasicCell` component and `buildPriority` view model builder (`site-config/brc-analytics/local/index/common/column/columnDefs.ts`).
* Registered the `PRIORITY` column in the `COLUMN_REGISTRY` (`site-config/brc-analytics/local/index/common/column/columnRegistry.ts`).

### Integration into entity configurations:

* Updated `genomeEntityConfig` and `organismEntityConfig` to include the `PRIORITY_PATHOGENS` category group and the `PRIORITY` column, with initial visibility set to hidden (`site-config/brc-analytics/local/index/genomeEntityConfig.ts`, `site-config/brc-analytics/local/index/organismEntityConfig.ts`). [[1]](diffhunk://#diff-4108318bbfd5edc450fb9ed3200ca627e0bbc349c5105d96d70235896d592037R22-R23) [[2]](diffhunk://#diff-4108318bbfd5edc450fb9ed3200ca627e0bbc349c5105d96d70235896d592037R52) [[3]](diffhunk://#diff-4108318bbfd5edc450fb9ed3200ca627e0bbc349c5105d96d70235896d592037R380-R385) [[4]](diffhunk://#diff-7c6aca36be1e442bdd70577dca605ac48c3843b7dab490ac151be00b1cd33c5eR18-R19) [[5]](diffhunk://#diff-7c6aca36be1e442bdd70577dca605ac48c3843b7dab490ac151be00b1cd33c5eR47) [[6]](diffhunk://#diff-7c6aca36be1e442bdd70577dca605ac48c3843b7dab490ac151be00b1cd33c5eR247-R252)

### View model builder:

* Added a new `buildPriority` function to generate props for the `BasicCell` component based on priority data (`app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts`).