### PR TITLE
feat: add outbreak tag to workflow (#508)

### DIFF
--- a/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
@@ -144,6 +144,10 @@ export const buildAssemblyDetails = (
       value: assembly.accession,
     })
   );
+  keyValuePairs.set(
+    "Priority Pathogen",
+    C.Chip(buildPriorityPathogen(assembly))
+  );
   return {
     KeyElType: C.KeyElType,
     KeyValuesElType: (props) => C.Stack({ ...props, gap: 4 }),

--- a/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
@@ -145,7 +145,7 @@ export const buildAssemblyDetails = (
     })
   );
   keyValuePairs.set(
-    "Priority Pathogen",
+    BRC_DATA_CATALOG_CATEGORY_LABEL.PRIORITY_PATHOGEN_NAME,
     C.Chip(buildPriorityPathogen(assembly))
   );
   return {


### PR DESCRIPTION
Closes #508.

This pull request adds a new key-value pair to the `buildAssemblyDetails` function, enhancing the assembly details with information about "Priority Pathogen."

### Enhancements to `buildAssemblyDetails`:
* Added a new key-value pair `"Priority Pathogen"` to the `keyValuePairs` map, using the `buildPriorityPathogen` function to generate its value. This provides additional context for assemblies. (`[app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.tsR147-R150](diffhunk://#diff-c7a9aefa9288341532869ba9987b67c489fce1e3b9e10c08643d92d54691ee11R147-R150)`)

<img width="1534" alt="image" src="https://github.com/user-attachments/assets/02922a84-68f2-44af-9710-9e57c2b39820" />
