### PR TITLE
feat: order pathogen list by priority then by name (#625)

### DIFF
--- a/app/views/PriorityPathogensView/constants.ts
+++ b/app/views/PriorityPathogensView/constants.ts
@@ -1,0 +1,9 @@
+import { OUTBREAK_PRIORITY } from "app/apis/catalog/brc-analytics-catalog/common/schema-entities";
+
+export const PRIORITY: Record<OUTBREAK_PRIORITY, number> = {
+  CRITICAL: 1,
+  HIGH: 3,
+  HIGHEST: 2,
+  MODERATE: 5,
+  MODERATE_HIGH: 4,
+};

--- a/app/views/PriorityPathogensView/utils.ts
+++ b/app/views/PriorityPathogensView/utils.ts
@@ -1,12 +1,16 @@
 import { COLLATOR_CASE_INSENSITIVE } from "@databiosphere/findable-ui/lib/common/constants";
 import { Outbreak } from "../../apis/catalog/brc-analytics-catalog/common/entities";
+import { PRIORITY } from "./constants";
 
 /**
- * Sorts priority pathogens by name.
+ * Sorts priority pathogens by priority, then name.
  * @param pp01 - First priority pathogen.
  * @param pp02 - Second priority pathogen.
  * @returns -1 if pp01 < pp02, 0 if pp01 === pp02, 1 if pp01 > pp02.
  */
 export function sortPriorityPathogen(pp01: Outbreak, pp02: Outbreak): number {
-  return COLLATOR_CASE_INSENSITIVE.compare(pp01.name, pp02.name);
+  return (
+    PRIORITY[pp01.priority] - PRIORITY[pp02.priority] ||
+    COLLATOR_CASE_INSENSITIVE.compare(pp01.name, pp02.name)
+  );
 }


### PR DESCRIPTION
Closes #625.

This pull request introduces a priority-based sorting mechanism for priority pathogens in the `PriorityPathogensView`. The changes include defining a priority mapping and updating the sorting logic to consider priority before name.

### Changes related to priority-based sorting:

* [`app/views/PriorityPathogensView/constants.ts`](diffhunk://#diff-71c1244d4f495efc7700806d641aa8e01bc75867d23f846a3e145e783781f0c8R1-R9): Added a `PRIORITY` mapping that assigns numerical values to different priority levels (`CRITICAL`, `HIGH`, etc.) for outbreak entities.
* [`app/views/PriorityPathogensView/utils.ts`](diffhunk://#diff-83aa09e7dfbf8d87f4dca0f7a6d9a4524a0a0789cb367d636701b7dbe88781abR3-R15): Updated the `sortPriorityPathogen` function to sort pathogens first by their priority (using the `PRIORITY` mapping) and then by name as a secondary criterion.

<img width="1284" alt="image" src="https://github.com/user-attachments/assets/41da11f3-e9c4-4a19-8859-e2ac38737e7a" />
