### PR TITLE
feat: re-order priority to make highest first (#625)

### DIFF
--- a/app/views/PriorityPathogensView/constants.ts
+++ b/app/views/PriorityPathogensView/constants.ts
@@ -1,9 +1,9 @@
 import { OUTBREAK_PRIORITY } from "../../apis/catalog/brc-analytics-catalog/common/schema-entities";
 
 export const PRIORITY: Record<OUTBREAK_PRIORITY, number> = {
-  CRITICAL: 1,
+  CRITICAL: 2,
   HIGH: 3,
-  HIGHEST: 2,
+  HIGHEST: 1,
   MODERATE: 5,
   MODERATE_HIGH: 4,
 };


### PR DESCRIPTION
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/090fc321-fbd1-443e-afcf-f7d8d3272d54" />

This pull request updates the priority mapping in the `PRIORITY` constant to reflect a revised priority ranking system.

Changes to priority mapping:

* [`app/views/PriorityPathogensView/constants.ts`](diffhunk://#diff-71c1244d4f495efc7700806d641aa8e01bc75867d23f846a3e145e783781f0c8L4-R6): Adjusted the numeric values for `CRITICAL` (from 1 to 2) and `HIGHEST` (from 2 to 1) to reflect their updated priority levels.