### PR TITLE
fix: set dbkey when sending reference fasta or dbkey (#634)

### DIFF
--- a/app/utils/galaxy-api/entities.ts
+++ b/app/utils/galaxy-api/entities.ts
@@ -26,6 +26,7 @@ export type WorkflowParameterValue =
   | WorkflowPairedCollectionParameter;
 
 export interface WorkflowUrlParameter {
+  dbkey?: string;
   ext: string;
   src: string;
   url: string;

--- a/app/utils/galaxy-api/galaxy-api.ts
+++ b/app/utils/galaxy-api/galaxy-api.ts
@@ -77,6 +77,7 @@ function paramVariableToRequestValue(
       return referenceGenome;
     case WORKFLOW_PARAMETER_VARIABLE.ASSEMBLY_FASTA_URL:
       return {
+        dbkey: referenceGenome,
         ext: "fasta.gz",
         src: "url",
         url: buildFastaUrl(referenceGenome),
@@ -84,6 +85,7 @@ function paramVariableToRequestValue(
     case WORKFLOW_PARAMETER_VARIABLE.GENE_MODEL_URL:
       return geneModelUrl
         ? {
+            dbkey: referenceGenome,
             ext: "gtf.gz",
             src: "url",
             url: geneModelUrl,


### PR DESCRIPTION
## Description

Sets the dbkey where it makes sense

## Related Issue

Closes #634 