### PR TITLE
feat: link pathogen detail pages priority tag to the organism list filtered by the prioirty (#630)

### DIFF
--- a/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
@@ -429,6 +429,19 @@ export const buildPriorityPathogenDetails = (
     C.Chip({
       color: getPriorityColor(priorityPathogen.priority),
       label: getPriorityLabel(priorityPathogen.priority),
+      onClick: (): void => {
+        Router.push({
+          pathname: ROUTES.ORGANISMS,
+          query: {
+            filter: JSON.stringify([
+              {
+                categoryKey: BRC_DATA_CATALOG_CATEGORY_KEY.PRIORITY,
+                value: [priorityPathogen.priority],
+              },
+            ]),
+          },
+        });
+      },
       variant: CHIP_PROPS.VARIANT.STATUS,
     })
   );


### PR DESCRIPTION
Closes #630.

This pull request introduces a new functionality to improve user interaction with priority pathogen details in the BRC Analytics Catalog. Specifically, it adds a click handler to the priority pathogen chip, allowing users to navigate to a filtered view of organisms based on the priority pathogen's category and value.

### Enhancements to navigation functionality:

* [`app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts`](diffhunk://#diff-c7a9aefa9288341532869ba9987b67c489fce1e3b9e10c08643d92d54691ee11R431-R443): Added an `onClick` handler to the `Chip` component in `buildPriorityPathogenDetails`. The handler uses `Router.push` to navigate to the `ROUTES.ORGANISMS` page with a query filter based on the priority pathogen's category and value.