### PR TITLE
feat: revert roadmap typography to match brc design mocks (#637)

### DIFF
--- a/app/components/content/sectionRoadmap.mdx
+++ b/app/components/content/sectionRoadmap.mdx
@@ -3,13 +3,13 @@
     <SectionHeadline paired>
       ## Our plan
       <SubHeadline>
-        ### Creating an integrated platform that connects public data, analysis tools, and community knowledge
+        Creating an integrated platform that connects public data, analysis tools, and community knowledge
       </SubHeadline>
     </SectionHeadline>
     <SectionContent paired>
       <Grid gridSx={{ gap: 4 }}>
         <Accordion>
-          <AccordionSummary><b>★ Upcoming features</b></AccordionSummary>
+          <AccordionSummary>★ Upcoming features</AccordionSummary>
           <AccordionDetails>
             Specific features planned for upcoming releases:
 
@@ -24,7 +24,7 @@
           </AccordionDetails>
         </Accordion>
         <Accordion>
-          <AccordionSummary><b>Community-driven knowledge platform</b></AccordionSummary>
+          <AccordionSummary>Community-driven knowledge platform</AccordionSummary>
           <AccordionDetails>
             In building a collaborative environment where researchers can share insights and analyses, we aim to:
 
@@ -35,7 +35,7 @@
           </AccordionDetails>
         </Accordion>
         <Accordion>
-          <AccordionSummary><b>Tailored support for organisms</b></AccordionSummary>
+          <AccordionSummary>Tailored support for organisms</AccordionSummary>
           <AccordionDetails>
             We recognize that each organism is different, with unique biology, research communities, and funding landscapes that drive diverse analytical needs. To address this, we intend to:
 
@@ -49,7 +49,7 @@
           </AccordionDetails>
         </Accordion>
         <Accordion>
-          <AccordionSummary><b>Seamless data integration</b></AccordionSummary>
+          <AccordionSummary>Seamless data integration</AccordionSummary>
           <AccordionDetails>
             We aim to create a unified experience that brings together diverse data sources and analysis capabilities. Our goals include:
 
@@ -63,7 +63,7 @@
           </AccordionDetails>
         </Accordion>
         <Accordion>
-          <AccordionSummary><b>Lowering barriers to bioinformatics</b></AccordionSummary>
+          <AccordionSummary>Lowering barriers to bioinformatics</AccordionSummary>
           <AccordionDetails>
             In order to make complex analyses accessible to researchers with varying computational expertise, we will:
 

--- a/app/views/RoadmapView/roadmapView.tsx
+++ b/app/views/RoadmapView/roadmapView.tsx
@@ -17,7 +17,7 @@ export const RoadmapView = (): JSX.Element => {
             highlight and provide dedicated resources for priority pathogens
             while simultaneously supporting neglected organisms. Our goal is to
             create a{" "}
-            <Typography component="span" sx={{ fontWeight: "bold" }}>
+            <Typography component="span" variant={"text-body-large-500"}>
               community-driven knowledge platform
             </Typography>{" "}
             that lowers barriers to entry for complex bioinformatics analyses.


### PR DESCRIPTION
Closes #637.

This pull request focuses on improving the visual consistency and readability of the roadmap section by removing unnecessary bold tags and using semantic styling for text elements. The changes affect both the `sectionRoadmap.mdx` and `roadmapView.tsx` files.

### Visual consistency improvements in roadmap section:

* [`app/components/content/sectionRoadmap.mdx`](diffhunk://#diff-19046c0a31a2f52d1b8101d6f3e2008f4071e86920d7d3d9a15d58c7d3a19d53L6-R12): Removed `<b>` tags from `AccordionSummary` elements to simplify the markup and improve readability. [[1]](diffhunk://#diff-19046c0a31a2f52d1b8101d6f3e2008f4071e86920d7d3d9a15d58c7d3a19d53L6-R12) [[2]](diffhunk://#diff-19046c0a31a2f52d1b8101d6f3e2008f4071e86920d7d3d9a15d58c7d3a19d53L27-R27) [[3]](diffhunk://#diff-19046c0a31a2f52d1b8101d6f3e2008f4071e86920d7d3d9a15d58c7d3a19d53L38-R38) [[4]](diffhunk://#diff-19046c0a31a2f52d1b8101d6f3e2008f4071e86920d7d3d9a15d58c7d3a19d53L52-R52) [[5]](diffhunk://#diff-19046c0a31a2f52d1b8101d6f3e2008f4071e86920d7d3d9a15d58c7d3a19d53L66-R66)

### Text styling enhancements:

* [`app/views/RoadmapView/roadmapView.tsx`](diffhunk://#diff-5968e08945ca9f590e72ea5733829ff663f2a41f2f829b21240cd5c0553c3d79L20-R20): Replaced `fontWeight: "bold"` with `variant: "text-body-large-500"` in the `Typography` component to use a consistent semantic style for large text.

<img width="1432" height="1087" alt="image" src="https://github.com/user-attachments/assets/cdbcac55-8dda-4dbb-8aaa-32555b9ec9e3" />
