### PR TITLE
chore: release tooling tweaks and doc updates

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       release_id:
-        description: "ID of the draft release to publish"
+        description: "Tag name of the draft release to publish (e.g., v0.13.0)"
         required: true
 
 permissions:

--- a/scripts/set-version.sh
+++ b/scripts/set-version.sh
@@ -13,7 +13,12 @@ GIT_HASH=$(git rev-parse HEAD)
 BUILD_DATE=$(TZ="America/Los_Angeles" date +"%Y-%m-%d %H:%M:%S %Z")
 
 # Get the current code version from git
-VERSION=$(git tag --points-at HEAD)
+# Using git describe to handle commits after tags gracefully
+# This will show:
+# - "v0.13.0" when HEAD is exactly on a tag
+# - "v0.13.0-2-g1234567" when HEAD is 2 commits after v0.13.0
+# - Just the commit hash if no tags exist
+VERSION=$(git describe --tags --always 2>/dev/null || git rev-parse --short HEAD)
 
 # Append newline to ensure following lines are separated from existing content
 echo "" >> "$TARGET_ENV_FILE"


### PR DESCRIPTION
## Description

fix: update version detection to be slightly more flexible/robust
docs: clarify tag usage in release publishing workflow

## Related Issue

another pass at https://github.com/galaxyproject/brc-analytics/issues/588
