### PR TITLE
fix: allow priority pathogen page scrolling

### DIFF
--- a/app/views/PriorityPathogensView/priorityPathogensView.styles.ts
+++ b/app/views/PriorityPathogensView/priorityPathogensView.styles.ts
@@ -8,11 +8,15 @@ import { Title } from "@databiosphere/findable-ui/lib/components/Index/component
 
 export const StyledGrid = styled(StyledGridEntityView)`
   grid-template-columns: 1fr;
+  height: auto;
+  max-height: none;
+  overflow: visible;
 
   ${mediaTabletUp} {
     margin-left: auto;
     margin-right: auto;
     max-width: min(calc(100% - 32px), 1232px);
+    padding-bottom: 24px;
   }
 `;
 


### PR DESCRIPTION
## Description

This fixes the new priority pathogen page not being scrollable by allowing natural content height, removing the viewport constraint.

## Related Issue

closes #655 
