### PR TITLE
chore: update findable-ui to latest version v38.2.0 (#668)

### DIFF
--- a/app/views/PriorityPathogensView/priorityPathogensView.styles.ts
+++ b/app/views/PriorityPathogensView/priorityPathogensView.styles.ts
@@ -8,15 +8,14 @@ import { Title } from "@databiosphere/findable-ui/lib/components/Index/component
 
 export const StyledGrid = styled(StyledGridEntityView)`
   grid-template-columns: 1fr;
-  height: auto;
-  max-height: none;
-  overflow: visible;
+  max-height: unset; // override StyledGridEntityView max-height property to allow for scrolling
+  overflow: unset; // override StyledGridEntityView overflow property to allow for scrolling
+  padding-bottom: 24px;
 
   ${mediaTabletUp} {
     margin-left: auto;
     margin-right: auto;
     max-width: min(calc(100% - 32px), 1232px);
-    padding-bottom: 24px;
   }
 `;
 

--- a/app/views/PriorityPathogensView/priorityPathogensView.styles.ts
+++ b/app/views/PriorityPathogensView/priorityPathogensView.styles.ts
@@ -8,8 +8,8 @@ import { Title } from "@databiosphere/findable-ui/lib/components/Index/component
 
 export const StyledGrid = styled(StyledGridEntityView)`
   grid-template-columns: 1fr;
-  max-height: unset; // override StyledGridEntityView max-height property to allow for scrolling
-  overflow: unset; // override StyledGridEntityView overflow property to allow for scrolling
+  max-height: unset; // remove the max-height limitation inherited from StyledGridEntityView
+  overflow: unset; // remove the overflow limitation inherited from StyledGridEntityView
   padding-bottom: 24px;
 
   ${mediaTabletUp} {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "brc-analytics",
       "version": "0.13.0",
       "dependencies": {
-        "@databiosphere/findable-ui": "^38.1.0",
+        "@databiosphere/findable-ui": "^38.2.0",
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",
         "@mdx-js/loader": "^3.0.1",
@@ -2408,9 +2408,9 @@
       }
     },
     "node_modules/@databiosphere/findable-ui": {
-      "version": "38.1.0",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-38.1.0.tgz",
-      "integrity": "sha512-6SY8nJX22euMsa+mmuWohtjsNo44RzdAiguKFAZYMg983E87w3vpMzgMjR8sqsoX+uKDHNuGRpAccDtX0VSnhw==",
+      "version": "38.2.0",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-38.2.0.tgz",
+      "integrity": "sha512-NNnPRw0KGY2LhtTiV/8d83ENl/Iz7DmDqo+5iXPb2CnlHCEyJ7VIvon5fij0HZ655tpIbU5Ou8x61BPwlw9YYw==",
       "engines": {
         "node": "20.10.0"
       },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "validate-catalog": "./catalog/schema/scripts/validate-catalog.sh"
   },
   "dependencies": {
-    "@databiosphere/findable-ui": "^38.1.0",
+    "@databiosphere/findable-ui": "^38.2.0",
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@mdx-js/loader": "^3.0.1",


### PR DESCRIPTION
Closes #668.

This pull request includes updates to the `StyledGrid` component styling and a dependency version bump for `@databiosphere/findable-ui`. The changes improve scrolling behavior and ensure compatibility with the latest UI library features.

### Styling updates:
* [`app/views/PriorityPathogensView/priorityPathogensView.styles.ts`](diffhunk://#diff-03b0be57212edecf2f1b92c6724278cdee0985e5db2e7c15fcea16037a452072L11-L19): Modified the `StyledGrid` component to override `max-height` and `overflow` properties - rather than specifying a value, provided "unset". Height override not required; refactored padding from media specificity. 

### Dependency updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L26-R26): Updated `@databiosphere/findable-ui` dependency from version `^38.1.0` to `^38.2.0`.