### PR TITLE
fix: don't run eslint on anything that's in .gitignore

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,25 @@
 {
   "parser": "@typescript-eslint/parser",
+  "ignorePatterns": [
+    "node_modules",
+    ".next/",
+    ".DS_Store",
+    "*.pem",
+    "npm-debug.log*",
+    ".env*.local",
+    ".env.development",
+    ".env.production",
+    "*.tsbuildinfo",
+    ".vscode",
+    ".idea",
+    ".nvmrc",
+    "public/favicons/*",
+    "playwright-report",
+    "test-results",
+    "out",
+    "venv",
+    "__pycache__"
+  ],
   "plugins": [
     "@typescript-eslint",
     "sonarjs",


### PR DESCRIPTION
## Description

running eslint takes some time on my setup, probably since it descends into node_modules and the venv.
with these changes it's a lot faster

## Related Issue

If this addresses an existing GitHub issue, link it here (e.g., "Closes #123"). If no existing issue exists, consider creating one first to discuss the changes.
