### PR TITLE
feat: add hgPhyloPlace link for measles

### DIFF
--- a/catalog/output/outbreaks.json
+++ b/catalog/output/outbreaks.json
@@ -733,7 +733,7 @@
     "resources": [
       {
         "title": "hgPhyloPlace | Place you sequences in a global phylogenetic tree (Measles)",
-        "url": "https://genome.ucsc.edu/cgi-bin/hgPhyloPlace?hgpp_org=hub_6572355_GCF_000854845.1",
+        "url": "https://genome.ucsc.edu/cgi-bin/hgPhyloPlace?hgpp_org=hub_3526175_GCF_000854845.1",
         "type": "HGPHYLOPLACE"
       },
       {

--- a/catalog/output/outbreaks.json
+++ b/catalog/output/outbreaks.json
@@ -732,6 +732,11 @@
     "priority": "HIGH",
     "resources": [
       {
+        "title": "hgPhyloPlace | Place you sequences in a global phylogenetic tree (Measles)",
+        "url": "https://genome.ucsc.edu/cgi-bin/hgPhyloPlace?hgpp_org=hub_6572355_GCF_000854845.1",
+        "type": "HGPHYLOPLACE"
+      },
+      {
         "title": "WHO | Measles",
         "url": "https://www.who.int/news-room/fact-sheets/detail/measles",
         "type": "REFERENCE"

--- a/catalog/source/outbreaks.yml
+++ b/catalog/source/outbreaks.yml
@@ -433,6 +433,9 @@ outbreaks:
       - 3052599
       - 3052560
     resources:
+      - title: "hgPhyloPlace | Place you sequences in a global phylogenetic tree (Measles)"
+        url: "https://genome.ucsc.edu/cgi-bin/hgPhyloPlace?hgpp_org=hub_6572355_GCF_000854845.1"
+        type: HGPHYLOPLACE
       - title: "WHO | Measles"
         url: "https://www.who.int/news-room/fact-sheets/detail/measles"
         type: REFERENCE


### PR DESCRIPTION
## Description

adds hgPhyloPlace link for measles to the paramyxoviridae priority pathogen page

## Related Issue

closes #673 
