### PR TITLE
fix: fix GTF stepper for human accession (#679)

### DIFF
--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/GTFStep/hooks/UseUCSCFiles/hook.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/GTFStep/hooks/UseUCSCFiles/hook.ts
@@ -4,8 +4,13 @@ import { parseUCSCFilesResult } from "./utils";
 import { UCSC_FILES_ENDPOINT } from "./constants";
 import { UseUCSCFiles } from "./types";
 
+const SPECIAL_CASE_ASSEMBLY_LOOKUP: Record<string, string> = {
+  "GCF_000001405.40": "hg38",
+} as const;
+
 export const useUCSCFiles = (genome: BRCDataCatalogGenome): UseUCSCFiles => {
-  const assemblyId = genome.accession;
+  const assemblyId =
+    SPECIAL_CASE_ASSEMBLY_LOOKUP[genome.accession] ?? genome.accession;
   const [geneModelUrls, setGeneModelUrls] = useState<string[] | undefined>();
 
   useEffect(() => {


### PR DESCRIPTION
closes https://github.com/galaxyproject/brc-analytics/issues/679 ... for now. I could see human being a frequently used test case for anyone discovering the site, so important that we fix this in a timely fashion.

<img width="865" height="772" alt="Screenshot 2025-07-24 at 18 57 50" src="https://github.com/user-attachments/assets/61adbd70-73ab-4e76-b19e-7a77762f7986" />
