### PR TITLE
feat: warnings for failed automagical gtf files

### DIFF
--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/GTFStep/gtfStep.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/GTFStep/gtfStep.tsx
@@ -24,7 +24,7 @@ import { Optional } from "@databiosphere/findable-ui/lib/components/Stepper/comp
 import { getGeneModelLabel } from "./utils";
 import { BUTTON_PROPS } from "@databiosphere/findable-ui/lib/components/common/Button/constants";
 import { STEP } from "./step";
-import { StepError } from "../components/StepError/stepError";
+import { StepWarning } from "../components/StepWarning/stepWarning";
 import { getStepActiveState, getButtonDisabledState } from "../utils/stepUtils";
 
 export const GTFStep = ({
@@ -45,6 +45,14 @@ export const GTFStep = ({
   useEffect(() => {
     configureGTFStep(geneModelUrls, onConfigure, onValueChange);
   }, [geneModelUrls, onConfigure, onValueChange]);
+
+  // Auto-configure step with empty string if there's an error
+  // Empty string represents "user will provide in Galaxy" similar to how sequencing steps use empty arrays
+  useEffect(() => {
+    if (error && active) {
+      onConfigure(STEP.key, ""); // Use empty string instead of null
+    }
+  }, [error, active, onConfigure]);
 
   return (
     <Step
@@ -76,7 +84,7 @@ export const GTFStep = ({
           >
             Genes and Gene Predictions
           </Typography>
-          <StepError error={error} />
+          <StepWarning error={error} />
           {!error && controls.length > 0 ? (
             <RadioGroup onChange={onChange} value={value}>
               {controls.map(({ label, value }, i) => (
@@ -98,10 +106,10 @@ export const GTFStep = ({
           )}
           <Button
             {...BUTTON_PROPS.PRIMARY_CONTAINED}
-            disabled={getButtonDisabledState(!value, false, !!error)}
+            disabled={getButtonDisabledState(!value && !error, isLoading)}
             onClick={() => onContinue()}
           >
-            Continue
+            {error ? "Skip This Step" : "Continue"}
           </Button>
         </StyledGrid>
       </StepContent>

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/GTFStep/step.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/GTFStep/step.ts
@@ -9,6 +9,7 @@ export const STEP = {
   label: "GTF Files",
   renderValue({ geneModelUrl }): string | undefined {
     if (geneModelUrl === null) return LABEL.NONE;
+    if (geneModelUrl === "") return "User upload to Galaxy";
     if (geneModelUrl !== undefined) return getGeneModelLabel(geneModelUrl);
   },
 } satisfies StepConfig;

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/LaunchStep/launchStep.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/LaunchStep/launchStep.tsx
@@ -4,7 +4,7 @@ import { StepLabel } from "@databiosphere/findable-ui/lib/components/Stepper/com
 import { StepProps } from "../types";
 import { Button } from "@mui/material";
 import { BUTTON_PROPS } from "@databiosphere/findable-ui/lib/components/common/Button/constants";
-import { StepError } from "../components/StepError/stepError";
+import { StepWarning } from "../components/StepWarning/stepWarning";
 import { getStepActiveState, getButtonDisabledState } from "../utils/stepUtils";
 
 export const LaunchStep = ({
@@ -12,9 +12,12 @@ export const LaunchStep = ({
   completed,
   entryLabel,
   index,
+  onContinue,
   onLaunchGalaxy,
   status,
 }: StepProps): JSX.Element => {
+  // This step doesn't auto-skip on error - user should see the warning
+
   return (
     <Step
       active={getStepActiveState(active, status.loading)}
@@ -23,17 +26,16 @@ export const LaunchStep = ({
     >
       <StepLabel>{entryLabel}</StepLabel>
       <StepContent>
-        <StepError error={status.error} />
+        <StepWarning error={status.error} />
         <Button
           {...BUTTON_PROPS.PRIMARY_CONTAINED}
           disabled={getButtonDisabledState(
-            status.disabled,
-            status.loading,
-            !!status.error
+            status.disabled && !status.error,
+            status.loading
           )}
-          onClick={onLaunchGalaxy}
+          onClick={status.error ? onContinue : onLaunchGalaxy}
         >
-          Launch In Galaxy
+          {status.error ? "Skip This Step" : "Launch In Galaxy"}
         </Button>
       </StepContent>
     </Step>

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/components/StepWarning/stepWarning.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/components/StepWarning/stepWarning.tsx
@@ -1,0 +1,22 @@
+import { Typography } from "@mui/material";
+import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
+
+export interface StepWarningProps {
+  error: string | null;
+}
+
+export const StepWarning = ({
+  error,
+}: StepWarningProps): JSX.Element | null => {
+  if (!error) return null;
+
+  return (
+    <Typography
+      variant={TYPOGRAPHY_PROPS.VARIANT.TEXT_BODY_400}
+      color="warning.main"
+    >
+      Warning: Unable to automatically configure this step. You will need to
+      provide this data manually. ({error})
+    </Typography>
+  );
+};

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/hooks/UseLaunchGalaxy/utils.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/hooks/UseLaunchGalaxy/utils.ts
@@ -37,7 +37,8 @@ export function getConfiguredValues(
 
   // Only check for required values
   if (requiredParams.ASSEMBLY_FASTA_URL && !referenceAssembly) return;
-  if (requiredParams.GENE_MODEL_URL && !geneModelUrl) return;
+  // For geneModelUrl, treat empty string as valid (user skipped or will upload manually)
+  if (requiredParams.GENE_MODEL_URL && geneModelUrl === null) return;
   if (requiredParams.SANGER_READ_RUN_SINGLE && !readRunsSingle) return;
   if (requiredParams.SANGER_READ_RUN_PAIRED && !readRunsPaired) return;
 

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/utils/stepUtils.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/utils/stepUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Determines if a step should be active based on loading and error states
+ * Determines if a step should be active based on loading states
  * @param active - Whether the step should be active
  * @param isLoading - Whether the step is currently loading
  * @returns Whether the step should be active
@@ -15,13 +15,11 @@ export const getStepActiveState = (
  * Determines if a button should be disabled based on various states
  * @param baseDisabled - Base disabled state
  * @param isLoading - Whether currently loading
- * @param hasError - Whether there is an error
  * @returns Whether the button should be disabled
  */
 export const getButtonDisabledState = (
   baseDisabled: boolean,
-  isLoading: boolean,
-  hasError?: boolean
+  isLoading: boolean
 ): boolean => {
-  return baseDisabled || isLoading || !!hasError;
+  return baseDisabled || isLoading;
 };


### PR DESCRIPTION
## Description

we prev had #680 merged. id like to iterate on that, so that the behavior for missing GTFs is no worse than it was pre-stepper. we also have outstanding issue #682 but i dont want to close that w this, bc this should be revisited. i see this as an interim measure until we have ux for this properly sorted.

## Related Issue

related to #682
