### PR TITLE
feat: update covid priority pathogen ranking

### DIFF
--- a/catalog/output/assemblies.json
+++ b/catalog/output/assemblies.json
@@ -49109,7 +49109,7 @@
     "ploidy": [
       "HAPLOID"
     ],
-    "priority": "HIGHEST",
+    "priority": "CRITICAL",
     "priorityPathogenName": "SARS-CoV-2",
     "scaffoldCount": 1,
     "scaffoldL50": 1,
@@ -78325,7 +78325,7 @@
     "ploidy": [
       "HAPLOID"
     ],
-    "priority": "HIGHEST",
+    "priority": "CRITICAL",
     "priorityPathogenName": "SARS-CoV-2",
     "scaffoldCount": 1,
     "scaffoldL50": 1,

--- a/catalog/output/organisms.json
+++ b/catalog/output/organisms.json
@@ -66845,7 +66845,7 @@
         "ploidy": [
           "HAPLOID"
         ],
-        "priority": "HIGHEST",
+        "priority": "CRITICAL",
         "priorityPathogenName": "SARS-CoV-2",
         "scaffoldCount": 1,
         "scaffoldL50": 1,
@@ -66901,7 +66901,7 @@
         "ploidy": [
           "HAPLOID"
         ],
-        "priority": "HIGHEST",
+        "priority": "CRITICAL",
         "priorityPathogenName": "SARS-CoV-2",
         "scaffoldCount": 1,
         "scaffoldL50": 1,
@@ -66928,7 +66928,7 @@
     ],
     "ncbiTaxonomyId": "3418604",
     "otherTaxa": null,
-    "priority": "HIGHEST",
+    "priority": "CRITICAL",
     "priorityPathogenName": "SARS-CoV-2",
     "taxonomicGroup": [
       "Viruses"

--- a/catalog/output/outbreaks.json
+++ b/catalog/output/outbreaks.json
@@ -62,7 +62,7 @@
     },
     "highlight_descendant_taxonomy_ids": null,
     "name": "SARS-CoV-2",
-    "priority": "HIGHEST",
+    "priority": "CRITICAL",
     "resources": [
       {
         "title": "WHO: Coronavirus disease (COVID-19) situation reports",

--- a/catalog/source/outbreaks.yml
+++ b/catalog/source/outbreaks.yml
@@ -33,7 +33,7 @@ outbreaks:
 
   - name: SARS-CoV-2
     taxonomy_id: 3418604
-    priority: HIGHEST
+    priority: CRITICAL
     active: true
     description:
       path: outbreaks/covid19.md
@@ -434,7 +434,7 @@ outbreaks:
       - 3052560
     resources:
       - title: "hgPhyloPlace | Place you sequences in a global phylogenetic tree (Measles)"
-        url: "https://genome.ucsc.edu/cgi-bin/hgPhyloPlace?hgpp_org=hub_6572355_GCF_000854845.1"
+        url: "https://genome.ucsc.edu/cgi-bin/hgPhyloPlace?hgpp_org=hub_3526175_GCF_000854845.1"
         type: HGPHYLOPLACE
       - title: "WHO | Measles"
         url: "https://www.who.int/news-room/fact-sheets/detail/measles"


### PR DESCRIPTION
## Description

talking w anton fri and he didnt love covid being highest priority. there was talk of removing the rankings entirely, but in the meantime of that i figure we can just change it from highest to critical, and have no highest priority pathogen. hopefully thats less potentially controversial.

while i was doing that i noticed a discrepancy w the measles hgphyloplace link url and fixed it.

## Related Issue

na
