### PR TITLE
feat: update column isref to display a chip (#716)

### DIFF
--- a/app/components/index.ts
+++ b/app/components/index.ts
@@ -15,6 +15,7 @@ export { FluidPaper } from "@databiosphere/findable-ui/lib/components/common/Pap
 export { SectionTitle } from "@databiosphere/findable-ui/lib/components/common/Section/components/SectionTitle/sectionTitle";
 export { Stack } from "@databiosphere/findable-ui/lib/components/common/Stack/stack";
 export { StaticImage } from "@databiosphere/findable-ui/lib/components/common/StaticImage/staticImage";
+export { ChipCell } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/ChipCell/chipCell";
 export {
   BackPageContentMainColumn,
   BackPageContentSideColumn,

--- a/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
@@ -279,14 +279,21 @@ export const buildGenomeTaxonomicLevelIsolate = (
 /**
  * Build props for the "is ref" cell.
  * @param genome - Genome entity.
- * @returns Props to be used for the cell.
+ * @returns Props to be used for the ChipCell component.
  */
 export const buildIsRef = (
   genome: BRCDataCatalogGenome
-): ComponentProps<typeof C.BasicCell> => {
+): ComponentProps<typeof C.ChipCell> => {
   return {
-    value: genome.isRef,
-  };
+    getValue: () => ({
+      color:
+        genome.isRef.toLowerCase() === "yes"
+          ? CHIP_PROPS.COLOR.SUCCESS
+          : CHIP_PROPS.COLOR.DEFAULT,
+      label: genome.isRef,
+      variant: CHIP_PROPS.VARIANT.STATUS,
+    }),
+  } as ComponentProps<typeof C.ChipCell>;
 };
 
 /**
@@ -844,7 +851,7 @@ function buildOrganismGenomesTableColumns(): ColumnDef<BRCDataCatalogGenome>[] {
     },
     {
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.IS_REF,
-      cell: ({ row }) => C.BasicCell(buildIsRef(row.original)),
+      cell: ({ row }) => C.ChipCell(buildIsRef(row.original)),
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.IS_REF,
     },
     {

--- a/site-config/brc-analytics/local/index/genomeEntityConfig.ts
+++ b/site-config/brc-analytics/local/index/genomeEntityConfig.ts
@@ -314,9 +314,9 @@ export const genomeEntityConfig: BRCEntityConfig<BRCDataCatalogGenome> = {
       },
       {
         componentConfig: {
-          component: C.BasicCell,
+          component: C.ChipCell,
           viewBuilder: V.buildIsRef,
-        } as ComponentConfig<typeof C.BasicCell, BRCDataCatalogGenome>,
+        } as ComponentConfig<typeof C.ChipCell, BRCDataCatalogGenome>,
         header: BRC_DATA_CATALOG_CATEGORY_LABEL.IS_REF,
         id: BRC_DATA_CATALOG_CATEGORY_KEY.IS_REF,
         width: { max: "0.5fr", min: "80px" },


### PR DESCRIPTION
Closes #716.

This pull request updates how the "is ref" property of genome entities is displayed in tables, switching from a basic cell to a chip-style cell for improved visual clarity. The changes involve updating both the component used for rendering and the supporting view model logic.

**UI Component Updates:**

* Changed the cell component for the "is ref" column in genome tables from `BasicCell` to `ChipCell`, providing a more visually distinct representation. [[1]](diffhunk://#diff-c7a9aefa9288341532869ba9987b67c489fce1e3b9e10c08643d92d54691ee11L847-R854) [[2]](diffhunk://#diff-4108318bbfd5edc450fb9ed3200ca627e0bbc349c5105d96d70235896d592037L317-R319)
* Added export for `ChipCell` in `app/components/index.ts` to make it available for use throughout the app.

**View Model Logic:**

* Updated the `buildIsRef` view model builder to return props compatible with `ChipCell`, including color and label logic based on the value of `isRef`.

<img width="1404" height="948" alt="image" src="https://github.com/user-attachments/assets/4003e32c-9991-4e55-91c8-27f3b801c3b9" />
