### PR TITLE
feat: create range filter (#382)

### DIFF
--- a/site-config/brc-analytics/local/index/genomeEntityConfig.ts
+++ b/site-config/brc-analytics/local/index/genomeEntityConfig.ts
@@ -21,6 +21,7 @@ import { sideColumn as analysisMethodsSideColumn } from "../entity/genome/analys
 import { top as analysisMethodsTop } from "../entity/genome/analysisMethodsTop";
 import { CATEGORY_GROUPS } from "./common/category/categories";
 import { COLUMN_REGISTRY } from "./common/column/columnRegistry";
+import { VIEW_KIND } from "@databiosphere/findable-ui/lib/common/categories/views/types";
 
 /**
  * Entity config object responsible to config anything related to the /assemblies route.
@@ -112,6 +113,7 @@ export const genomeEntityConfig: BRCEntityConfig<BRCDataCatalogGenome> = {
           {
             key: BRC_DATA_CATALOG_CATEGORY_KEY.COVERAGE,
             label: BRC_DATA_CATALOG_CATEGORY_LABEL.COVERAGE,
+            viewKind: VIEW_KIND.RANGE,
           },
           {
             key: BRC_DATA_CATALOG_CATEGORY_KEY.ANNOTATION_STATUS,
@@ -380,6 +382,7 @@ export const genomeEntityConfig: BRCEntityConfig<BRCDataCatalogGenome> = {
           component: C.BasicCell,
           viewBuilder: V.buildCoverage,
         } as ComponentConfig<typeof C.BasicCell, BRCDataCatalogGenome>,
+        filterFn: "inNumberRange",
         header: BRC_DATA_CATALOG_CATEGORY_LABEL.COVERAGE,
         id: BRC_DATA_CATALOG_CATEGORY_KEY.COVERAGE,
         width: { max: "0.5fr", min: "80px" },


### PR DESCRIPTION
Closes #382.

This pull request updates the genome entity configuration to improve how the "coverage" field is displayed and filtered in the UI. The main changes introduce a range-based view and filtering for coverage, enhancing the user experience when working with this data.

**Improvements to coverage field display and filtering:**

* Added a `viewKind` property with the value `VIEW_KIND.RANGE` to the coverage category, enabling a range-based UI for displaying coverage values.
* Added a `filterFn` property with the value `"inNumberRange"` to the coverage column, allowing users to filter coverage values within a specified numeric range.

**Dependency update:**

* Imported `VIEW_KIND` from the UI library to support the new range view for categories.

<img width="873" height="1253" alt="image" src="https://github.com/user-attachments/assets/b881ae28-a412-4521-9e99-202ed31193f0" />
