### PR TITLE
feat: sort organism details assembly list by is_ref then accession number (#721)

### DIFF
--- a/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
@@ -19,7 +19,7 @@ import {
   NCBI_DATASETS_URL,
   NCBI_TAXONOMY,
 } from "./constants";
-import { ColumnDef } from "@tanstack/react-table";
+import { ColumnDef, getSortedRowModel } from "@tanstack/react-table";
 import {
   BRC_DATA_CATALOG_CATEGORY_KEY,
   BRC_DATA_CATALOG_CATEGORY_LABEL,
@@ -802,8 +802,14 @@ export function buildOrganismGenomesTable(
     noResultsTitle: "No Assemblies",
     tableOptions: {
       enableRowPosition: false,
+      enableSorting: true,
+      getSortedRowModel: getSortedRowModel(),
       initialState: {
         columnVisibility: { [COLUMN_IDENTIFIER.ROW_POSITION]: false },
+        sorting: [
+          { desc: true, id: BRC_DATA_CATALOG_CATEGORY_KEY.IS_REF },
+          { desc: false, id: BRC_DATA_CATALOG_CATEGORY_KEY.ACCESSION },
+        ],
       },
     },
   };


### PR DESCRIPTION
Closes #721.

This pull request enhances the sorting functionality of the organism genomes table in the BRC Analytics Catalog. The changes improve the user experience by enabling sorting and setting a default sort order for key columns.

Table sorting improvements:

* Enabled sorting in the organism genomes table and set up the `getSortedRowModel` function from `@tanstack/react-table` to manage sorted data. [[1]](diffhunk://#diff-c7a9aefa9288341532869ba9987b67c489fce1e3b9e10c08643d92d54691ee11L22-R22) [[2]](diffhunk://#diff-c7a9aefa9288341532869ba9987b67c489fce1e3b9e10c08643d92d54691ee11R805-R812)
* Defined an initial sort order: descending by `IS_REF` and ascending by `ACCESSION` columns, providing users with a more logical default view.

<img width="720" height="336" alt="image" src="https://github.com/user-attachments/assets/dee89f70-1456-4f77-84bd-9ae1ce72370f" />
