### PR TITLE
fix: fix sequencing step study accession link (#748)

### DIFF
--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/CollectionSelector/hooks/UseTable/viewBuilders.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/CollectionSelector/hooks/UseTable/viewBuilders.ts
@@ -39,12 +39,10 @@ export function buildStudyAccession(
   cellContext: CellContext<ReadRun, unknown>
 ): CellContext<ReadRun, LinkProps> {
   const value = cellContext.getValue() || "";
+  const href = value
+    ? `https://www.ncbi.nlm.nih.gov/bioproject/?term=${value}`
+    : "";
   return {
-    getValue: () => {
-      return {
-        children: value,
-        href: `value ? https://www.ncbi.nlm.nih.gov/bioproject/?term=${value} : ""`,
-      };
-    },
+    getValue: () => ({ children: value, href }),
   } as CellContext<ReadRun, LinkProps>;
 }


### PR DESCRIPTION
Closes #748.

This pull request simplifies and corrects the construction of the `href` property for study accession links in the ENA Sequencing Data table. The main change ensures that the link to the NCBI BioProject is only created when a value is present, and the URL is constructed correctly.

Improvements to link handling:

* Updated the `buildStudyAccession` function in `viewBuilders.ts` to construct the `href` property using a template string only when a value exists, ensuring accurate and conditional link generation.