### PR TITLE
feat: indicate browsing n sequences is specific to the selected organism (#728)

### DIFF
--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/DataSelector/constants.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/DataSelector/constants.ts
@@ -3,7 +3,7 @@ import { GridProps, PaperProps } from "@mui/material";
 export const GRID_PROPS: GridProps = {
   alignItems: "center",
   container: true,
-  gap: 4,
+  gap: 6,
 };
 
 export const PAPER_PROPS: PaperProps = {

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/DataSelector/dataSelector.styles.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/DataSelector/dataSelector.styles.ts
@@ -1,11 +1,12 @@
 import { PALETTE } from "@databiosphere/findable-ui/lib/styles/common/constants/palette";
+import { bpDown820 } from "@databiosphere/findable-ui/src/styles/common/mixins/breakpoints";
 import styled from "@emotion/styled";
-import { Paper } from "@mui/material";
+import { Grid, Paper } from "@mui/material";
 
 export const StyledPaper = styled(Paper)`
   background-color: ${PALETTE.SMOKE_LIGHT};
   display: grid;
-  gap: 8px;
+  gap: 24px;
   justify-items: center;
   padding: 24px;
   text-align: center;
@@ -13,5 +14,25 @@ export const StyledPaper = styled(Paper)`
 
   .MuiButton-root {
     text-transform: none;
+  }
+`;
+
+export const StyledGrid = styled(Grid)`
+  justify-content: center;
+
+  ${bpDown820} {
+    flex-direction: column;
+  }
+
+  .MuiButton-root {
+    width: fit-content;
+  }
+
+  .MuiDivider-root {
+    min-height: 60px;
+
+    .MuiDivider-wrapper {
+      padding: 4px 0;
+    }
   }
 `;

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/DataSelector/dataSelector.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/DataSelector/dataSelector.tsx
@@ -1,5 +1,5 @@
-import { Button, Grid, Typography } from "@mui/material";
-import { StyledPaper } from "./dataSelector.styles";
+import { Button, Divider, Stack, Typography } from "@mui/material";
+import { StyledPaper, StyledGrid } from "./dataSelector.styles";
 import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
 import { GRID_PROPS, PAPER_PROPS } from "./constants";
 import { BUTTON_PROPS } from "@databiosphere/findable-ui/lib/components/common/Button/constants";
@@ -8,6 +8,7 @@ import { SVG_ICON_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui
 import { Props } from "./types";
 import { MAX_READ_RUNS_FOR_BROWSE_ALL } from "../../hooks/UseENADataByTaxonomyId/constants";
 import { ENA_QUERY_METHOD } from "../../../../types";
+import { Fragment } from "react";
 
 export const DataSelector = ({
   loading,
@@ -16,50 +17,82 @@ export const DataSelector = ({
   readCount = MAX_READ_RUNS_FOR_BROWSE_ALL,
   selectedCount,
   setEnaQueryMethod,
+  taxonomicLevelSpecies,
 }: Props): JSX.Element | null => {
   if (selectedCount > 0) return null;
   return (
     <StyledPaper {...PAPER_PROPS}>
-      <Typography
-        component="div"
-        variant={TYPOGRAPHY_PROPS.VARIANT.HEADING_XSMALL}
-      >
-        No Sequencing Data Selected
-      </Typography>
-      <Typography
-        color={TYPOGRAPHY_PROPS.COLOR.INK_LIGHT}
-        variant={TYPOGRAPHY_PROPS.VARIANT.BODY_400}
-      >
-        Browse ENA to find and select sequences
-      </Typography>
+      <Stack spacing={2}>
+        <Typography
+          component="div"
+          variant={TYPOGRAPHY_PROPS.VARIANT.HEADING_XSMALL}
+        >
+          Select sequences from ENA
+        </Typography>
+        <Typography
+          color={TYPOGRAPHY_PROPS.COLOR.INK_LIGHT}
+          variant={TYPOGRAPHY_PROPS.VARIANT.BODY_400}
+        >
+          Browse ENA to find and select sequences
+        </Typography>
+      </Stack>
       {loading ? (
         <LoadingIcon
           color={SVG_ICON_PROPS.COLOR.PRIMARY}
           fontSize={SVG_ICON_PROPS.FONT_SIZE.SMALL}
         />
       ) : (
-        <Grid {...GRID_PROPS}>
-          <Button
-            {...BUTTON_PROPS.PRIMARY_CONTAINED}
-            onClick={() => {
-              setEnaQueryMethod(ENA_QUERY_METHOD.ACCESSION);
-              onOpen();
-            }}
-          >
-            Enter Accession(s)
-          </Button>
+        <StyledGrid {...GRID_PROPS}>
           {readCount < MAX_READ_RUNS_FOR_BROWSE_ALL && (
+            <Fragment>
+              <Stack alignItems="center" spacing={1}>
+                <Button
+                  {...BUTTON_PROPS.PRIMARY_CONTAINED}
+                  onClick={() => {
+                    setEnaQueryMethod(ENA_QUERY_METHOD.TAXONOMY_ID);
+                    onContinue();
+                  }}
+                >
+                  {renderButtonText(readCount)}
+                </Button>
+                <Typography
+                  color={TYPOGRAPHY_PROPS.COLOR.INK_LIGHT}
+                  noWrap
+                  maxWidth={200}
+                  variant={TYPOGRAPHY_PROPS.VARIANT.BODY_400}
+                >
+                  {taxonomicLevelSpecies}
+                </Typography>
+              </Stack>
+              <Divider flexItem orientation="vertical">
+                <Typography
+                  component="div"
+                  color={TYPOGRAPHY_PROPS.COLOR.INK_LIGHT}
+                  variant={TYPOGRAPHY_PROPS.VARIANT.BODY_400}
+                >
+                  <i>OR</i>
+                </Typography>
+              </Divider>
+            </Fragment>
+          )}
+          <Stack alignItems="center" spacing={1}>
             <Button
               {...BUTTON_PROPS.PRIMARY_CONTAINED}
               onClick={() => {
-                setEnaQueryMethod(ENA_QUERY_METHOD.TAXONOMY_ID);
-                onContinue();
+                setEnaQueryMethod(ENA_QUERY_METHOD.ACCESSION);
+                onOpen();
               }}
             >
-              {renderButtonText(readCount)}
+              Enter Accession(s)
             </Button>
-          )}
-        </Grid>
+            <Typography
+              color={TYPOGRAPHY_PROPS.COLOR.INK_LIGHT}
+              variant={TYPOGRAPHY_PROPS.VARIANT.BODY_400}
+            >
+              Any organism
+            </Typography>
+          </Stack>
+        </StyledGrid>
       )}
     </StyledPaper>
   );
@@ -72,5 +105,5 @@ export const DataSelector = ({
  */
 function renderButtonText(readCount: number): string {
   if (readCount === 1) return "Browse 1 Sequence";
-  return `Browse All ${readCount} Sequences`;
+  return `Browse ${readCount} Sequences`;
 }

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/DataSelector/types.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/DataSelector/types.ts
@@ -8,4 +8,5 @@ export interface Props {
   readCount?: number;
   selectedCount: number;
   setEnaQueryMethod: Dispatch<SetStateAction<ENA_QUERY_METHOD>>;
+  taxonomicLevelSpecies: string;
 }

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/enaSequencingData.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/enaSequencingData.tsx
@@ -14,6 +14,7 @@ export const ENASequencingData = ({
   setEnaQueryMethod,
   stepKey,
   table,
+  taxonomicLevelSpecies,
 }: Props): JSX.Element => {
   const accessionDialog = useDialog();
   const collectionDialog = useDialog();
@@ -34,6 +35,7 @@ export const ENASequencingData = ({
         readCount={enaTaxonomyId.data?.length}
         selectedCount={selectedCount}
         setEnaQueryMethod={setEnaQueryMethod}
+        taxonomicLevelSpecies={taxonomicLevelSpecies}
       />
       <AccessionSelector
         clearErrors={enaAccession.clearErrors}

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/types.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/types.ts
@@ -31,4 +31,5 @@ export interface Props {
   setEnaQueryMethod: Dispatch<SetStateAction<ENA_QUERY_METHOD>>;
   stepKey: SEQUENCING_DATA_TYPE;
   table: Table<ReadRun>;
+  taxonomicLevelSpecies: string;
 }

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/sequencingStep.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/sequencingStep.tsx
@@ -43,6 +43,7 @@ export const SequencingStep = ({
             setEnaQueryMethod={setEnaQueryMethod}
             stepKey={stepKey as SEQUENCING_DATA_TYPE}
             table={table}
+            taxonomicLevelSpecies={genome.taxonomicLevelSpecies}
           />
         ) : (
           <UploadMyData


### PR DESCRIPTION
Closes #728.

This pull request updates the ENA sequencing data selection UI to improve clarity, usability, and responsiveness. The main changes include redesigning the data selection interface to better distinguish between browsing by taxonomy and entering accessions, updating layout and spacing for improved readability, and passing additional context about the selected species to the UI components.

**UI/UX Improvements:**

* Redesigned the `DataSelector` component to clearly separate the options for browsing ENA sequences by taxonomy or entering accessions, including updated button labels, explanatory text, and a visual divider with an "OR" label. Also, now displays the selected species and "Any organism" context for each option. [[1]](diffhunk://#diff-4fff3a49d0638f307078d17a714962f3736a5f7916f2913880b492ae1815a88dR20-R95) [[2]](diffhunk://#diff-4fff3a49d0638f307078d17a714962f3736a5f7916f2913880b492ae1815a88dL75-R108)
* Changed the main heading in the selector from "No Sequencing Data Selected" to "Select sequences from ENA" for clarity.
* Updated the button label to show "Browse {readCount} Sequences" instead of "Browse All {readCount} Sequences" for improved accuracy.

**Styling and Layout Enhancements:**

* Increased spacing in `StyledPaper` and `GRID_PROPS` for better visual separation, and introduced a new `StyledGrid` component for responsive layout, including vertical stacking on smaller screens and improved alignment of buttons and dividers. [[1]](diffhunk://#diff-745d6a1da7bc4214cf3d0be77ed57ff770ee213865860f8d0aa294871bae24f4R2-R9) [[2]](diffhunk://#diff-745d6a1da7bc4214cf3d0be77ed57ff770ee213865860f8d0aa294871bae24f4R19-R38) [[3]](diffhunk://#diff-ca244e1fe1132ea18335223b5a8f92565e37b89f04b08c6641feda194bd1512fL6-R6)
* Refactored to use `Stack`, `Divider`, and new styled components for more consistent and maintainable layout in the data selector. [[1]](diffhunk://#diff-4fff3a49d0638f307078d17a714962f3736a5f7916f2913880b492ae1815a88dR20-R95) [[2]](diffhunk://#diff-4fff3a49d0638f307078d17a714962f3736a5f7916f2913880b492ae1815a88dR11)

**Prop and Type Updates:**

* Added a new `taxonomicLevelSpecies` prop to the relevant components and types, allowing the UI to display the current species context in the selector. [[1]](diffhunk://#diff-6ab8e6185c845d46875a94921854ca872a2c5bc81d5e1b8d9de8e49977e8968eR11) [[2]](diffhunk://#diff-b819bc78312d56593ca3910c7ceb5fdb575696aa28d9b61bebde6cdc85accdb3R34) [[3]](diffhunk://#diff-9df56d95545404d5d056a20480bc9dd97a725893959e77831b81eb5370a73c0eR17) [[4]](diffhunk://#diff-9df56d95545404d5d056a20480bc9dd97a725893959e77831b81eb5370a73c0eR38) [[5]](diffhunk://#diff-e5885a24016d716fbdcf8b5de89aa24e749f17806a105b809da5947cfc990f19R46)

<img width="1717" height="948" alt="image" src="https://github.com/user-attachments/assets/a5f7e5f0-760e-47a7-8b12-56bbdbad5b17" />
