### PR TITLE
chore: update findable-ui to latest v44.0.0 (#770)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "brc-analytics",
       "version": "0.15.0",
       "dependencies": {
-        "@databiosphere/findable-ui": "^43.0.0",
+        "@databiosphere/findable-ui": "^44.0.0",
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",
         "@mdx-js/loader": "^3.0.1",
@@ -2408,9 +2408,9 @@
       }
     },
     "node_modules/@databiosphere/findable-ui": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-43.0.0.tgz",
-      "integrity": "sha512-FjE2GUgrPrAwO9rFwrW7l8j8LdTHAPcwrZhyJU2e2WxY/N5zCRLyUs2QYGNndYM41pQTgKmJC8LVcVYSux9aWg==",
+      "version": "44.0.0",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-44.0.0.tgz",
+      "integrity": "sha512-E469rmfHci+tvhXC4jJ5VjoHHT6Ft95a7Sh5eOPHHrPBNgWEtbDez7Tanaxml/Hk9sW66lf3Xpzt1Ax0Pf9bVA==",
       "engines": {
         "node": "20.10.0"
       },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "validate-catalog": "./catalog/schema/scripts/validate-catalog.sh"
   },
   "dependencies": {
-    "@databiosphere/findable-ui": "^43.0.0",
+    "@databiosphere/findable-ui": "^44.0.0",
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@mdx-js/loader": "^3.0.1",


### PR DESCRIPTION
Closes #770.

This pull request makes a minor update to the project's dependencies by bumping the version of the `@databiosphere/findable-ui` package from `^43.0.0` to `^44.0.0` in `package.json`.