### PR TITLE
feat: configure sort by chooser (alpha or count) to filters (#732)

### DIFF
--- a/site-config/brc-analytics/local/config.ts
+++ b/site-config/brc-analytics/local/config.ts
@@ -13,6 +13,7 @@ import { genomeEntityConfig } from "./index/genomeEntityConfig";
 import { organismEntityConfig } from "./index/organismEntityConfig";
 import { priorityPathogensEntityConfig } from "./index/priorityPathogensEntityConfig";
 import { socialMedia } from "./socialMedia";
+import { FILTER_SORT } from "@databiosphere/findable-ui/lib/common/filters/sort/config/types";
 
 const LOCALHOST = "http://localhost:3000";
 const APP_TITLE = "BRC Analytics";
@@ -49,6 +50,7 @@ export function makeConfig(
       genomeEntityConfig as EntityConfig<BRCDataCatalogGenome>,
       priorityPathogensEntityConfig as EntityConfig<Outbreak>,
     ],
+    filterSort: { sortBy: FILTER_SORT.ALPHA },
     gitHubUrl,
     layout: {
       floating,


### PR DESCRIPTION
Closes #732.

This pull request introduces a new default sorting configuration for the BRC Analytics local site config. The main change is the addition of a filter sort option that sets the default sorting method to alphabetical order.

Configuration improvements:

* Added import of `FILTER_SORT` from the shared UI library to enable sorting configuration in `config.ts`.
* Set the default `filterSort` option to sort entities alphabetically by adding `filterSort: { sortBy: FILTER_SORT.ALPHA }` to the configuration object in `makeConfig`.

<img width="1921" height="1114" alt="image" src="https://github.com/user-attachments/assets/253227ce-e1fb-4fd5-b769-b68b163e128d" />

<img width="1920" height="976" alt="image" src="https://github.com/user-attachments/assets/c11fbea1-9d47-4e59-8d1b-fd0ad09966f8" />

<img width="1919" height="1106" alt="image" src="https://github.com/user-attachments/assets/73704c4f-f302-4892-b887-5ca9959d8ebb" />
