### PR TITLE
feat: change UCSC assembly file to one pointing at VGP assemblies (#779)

### DIFF
--- a/catalog/ga2/build/py/build_files_from_ncbi.py
+++ b/catalog/ga2/build/py/build_files_from_ncbi.py
@@ -2,7 +2,7 @@ from ....py_package.catalog_build import build_files
 
 ASSEMBLIES_PATH = "catalog/ga2/source/assemblies.yml"
 
-UCSC_ASSEMBLIES_URL = "https://hgdownload.soe.ucsc.edu/hubs/BRC/assemblyList.json"
+UCSC_ASSEMBLIES_URL = "https://hgdownload.soe.ucsc.edu/hubs/VGP/assemblyList.json"
 
 GENOMES_OUTPUT_PATH = "catalog/ga2/build/intermediate/genomes-from-ncbi.tsv"
 


### PR DESCRIPTION
## Description

Brief description of the changes made in this PR.

## Related Issue

If this addresses an existing GitHub issue, link it here (e.g., "Closes #123"). If no existing issue exists, consider creating one first to discuss the changes.
