### PR TITLE
chore: update findable-ui to v45.0.0 (#800)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "brc-analytics",
       "version": "0.15.0",
       "dependencies": {
-        "@databiosphere/findable-ui": "^44.0.0",
+        "@databiosphere/findable-ui": "^45.0.0",
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",
         "@mdx-js/loader": "^3.0.1",
@@ -2408,9 +2408,9 @@
       }
     },
     "node_modules/@databiosphere/findable-ui": {
-      "version": "44.0.0",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-44.0.0.tgz",
-      "integrity": "sha512-E469rmfHci+tvhXC4jJ5VjoHHT6Ft95a7Sh5eOPHHrPBNgWEtbDez7Tanaxml/Hk9sW66lf3Xpzt1Ax0Pf9bVA==",
+      "version": "45.0.0",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-45.0.0.tgz",
+      "integrity": "sha512-sHomAwY9eTv6CuugbL7Nc87LU/GR64cVSeUuZ0rHKEEy8X5pQ2T3JlWBdy7wy72B9WJqDFhhKUNxUyInwT5tRw==",
       "engines": {
         "node": "20.10.0"
       },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "validate-ga2-catalog": "./catalog/ga2/schema/scripts/validate-catalog.sh"
   },
   "dependencies": {
-    "@databiosphere/findable-ui": "^44.0.0",
+    "@databiosphere/findable-ui": "^45.0.0",
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@mdx-js/loader": "^3.0.1",

--- a/site-config/brc-analytics/local/index/genomeEntityConfig.ts
+++ b/site-config/brc-analytics/local/index/genomeEntityConfig.ts
@@ -148,6 +148,7 @@ export const genomeEntityConfig: AppEntityConfig<BRCDataCatalogGenome> = {
           viewBuilder: V.buildAnalyzeGenome,
         } as ComponentConfig<typeof C.AnalyzeGenome, BRCDataCatalogGenome>,
         enableSorting: false,
+        enableTableDownload: false,
         header: BRC_DATA_CATALOG_CATEGORY_LABEL.ANALYZE_GENOME,
         id: BRC_DATA_CATALOG_CATEGORY_KEY.ANALYZE_GENOME,
         width: "auto",
@@ -405,6 +406,8 @@ export const genomeEntityConfig: AppEntityConfig<BRCDataCatalogGenome> = {
       COLUMN_REGISTRY.PRIORITY,
     ],
     tableOptions: {
+      downloadFilename: "assemblies",
+      enableTableDownload: true,
       initialState: {
         columnVisibility: {
           [BRC_DATA_CATALOG_CATEGORY_KEY.PRIORITY]: false,
@@ -429,7 +432,6 @@ export const genomeEntityConfig: AppEntityConfig<BRCDataCatalogGenome> = {
   } as ListConfig<BRCDataCatalogGenome>,
   listView: {
     disablePagination: true,
-    enableDownload: true,
   },
   route: "assemblies",
   staticLoadFile: "catalog/output/assemblies.json",

--- a/site-config/brc-analytics/local/index/organismEntityConfig.ts
+++ b/site-config/brc-analytics/local/index/organismEntityConfig.ts
@@ -261,6 +261,8 @@ export const organismEntityConfig: AppEntityConfig<BRCDataCatalogOrganism> = {
       COLUMN_REGISTRY.PRIORITY,
     ],
     tableOptions: {
+      downloadFilename: "organisms",
+      enableTableDownload: true,
       initialState: {
         columnVisibility: {
           [BRC_DATA_CATALOG_CATEGORY_KEY.PRIORITY]: false,
@@ -288,7 +290,6 @@ export const organismEntityConfig: AppEntityConfig<BRCDataCatalogOrganism> = {
   } as ListConfig<BRCDataCatalogOrganism>,
   listView: {
     disablePagination: true,
-    enableDownload: true,
   },
   route: "organisms",
   staticLoadFile: "catalog/output/organisms.json",

--- a/site-config/ga2/local/index/genome/columnDefs.ts
+++ b/site-config/ga2/local/index/genome/columnDefs.ts
@@ -39,6 +39,7 @@ export const ANALYZE_GENOME: ColumnConfig<GA2AssemblyEntity> = {
     viewBuilder: buildAnalyzeGenome,
   } as ComponentConfig<typeof C.AnalyzeGenome, GA2AssemblyEntity>,
   enableSorting: false,
+  enableTableDownload: false,
   header: GA2_CATEGORY_LABEL.ANALYZE_GENOME,
   id: GA2_CATEGORY_KEY.ANALYZE_GENOME,
   width: "auto",

--- a/site-config/ga2/local/index/genome/genomeEntityConfig.ts
+++ b/site-config/ga2/local/index/genome/genomeEntityConfig.ts
@@ -44,6 +44,8 @@ export const genomeEntityConfig: AppEntityConfig<GA2AssemblyEntity> = {
   list: {
     columns: COLUMNS,
     tableOptions: {
+      downloadFilename: "assemblies",
+      enableTableDownload: true,
       initialState: {
         sorting: [
           {
@@ -56,7 +58,6 @@ export const genomeEntityConfig: AppEntityConfig<GA2AssemblyEntity> = {
   } as ListConfig<GA2AssemblyEntity>,
   listView: {
     disablePagination: true,
-    enableDownload: true,
   },
   route: "assemblies",
   staticLoadFile: "catalog/ga2/output/assemblies.json",

--- a/site-config/ga2/local/index/organism/organismEntityConfig.ts
+++ b/site-config/ga2/local/index/organism/organismEntityConfig.ts
@@ -38,6 +38,8 @@ export const organismEntityConfig: AppEntityConfig<GA2OrganismEntity> = {
   list: {
     columns: COLUMNS,
     tableOptions: {
+      downloadFilename: "organisms",
+      enableTableDownload: true,
       initialState: {
         sorting: [
           {
@@ -50,7 +52,6 @@ export const organismEntityConfig: AppEntityConfig<GA2OrganismEntity> = {
   } as ListConfig<GA2OrganismEntity>,
   listView: {
     disablePagination: true,
-    enableDownload: true,
   },
   route: "organisms",
   staticLoadFile: "catalog/ga2/output/organisms.json",


### PR DESCRIPTION
Closes #800.

This pull request updates the table download configuration for both genome and organism entity tables across the BRC Analytics and GA2 sites. The main focus is to standardize how table downloads are enabled and configured, moving from the deprecated or less flexible `enableDownload` property in `listView` to the newer `enableTableDownload` and `downloadFilename` options in `tableOptions`. Additionally, it updates the `@databiosphere/findable-ui` dependency to the latest version.

**Table Download Configuration Updates**

* BRC Analytics site:
  - For both `genomeEntityConfig.ts` and `organismEntityConfig.ts`, removed the `enableDownload` property from `listView` and added `enableTableDownload: true` and a specific `downloadFilename` ("assemblies" or "organisms") to `tableOptions` for improved download handling. [[1]](diffhunk://#diff-4108318bbfd5edc450fb9ed3200ca627e0bbc349c5105d96d70235896d592037R409-R410) [[2]](diffhunk://#diff-7c6aca36be1e442bdd70577dca605ac48c3843b7dab490ac151be00b1cd33c5eR264-R265) [[3]](diffhunk://#diff-4108318bbfd5edc450fb9ed3200ca627e0bbc349c5105d96d70235896d592037L432) [[4]](diffhunk://#diff-7c6aca36be1e442bdd70577dca605ac48c3843b7dab490ac151be00b1cd33c5eL291)
  - Set `enableTableDownload: false` for the `ANALYZE_GENOME` column config to explicitly disable downloads for that column. [[1]](diffhunk://#diff-4108318bbfd5edc450fb9ed3200ca627e0bbc349c5105d96d70235896d592037R151) [[2]](diffhunk://#diff-2059102af3ba8b2cf06883c20828f14210cd2dff4d14cbf97867aaf713459876R42)

* GA2 site:
  - For both `genomeEntityConfig.ts` and `organismEntityConfig.ts`, removed `enableDownload` from `listView` and added `enableTableDownload: true` and the appropriate `downloadFilename` in `tableOptions`. [[1]](diffhunk://#diff-8ed20e59d1cb870ccd8fc0deffaa4f6eb539cd08a4c9f2a872c7a1439bdf02c3R47-R48) [[2]](diffhunk://#diff-74a7c5e39f59e17e16a7b0803d299e1c5ba7fe00f9f91b7dea154dd9a06b523cR41-R42) [[3]](diffhunk://#diff-8ed20e59d1cb870ccd8fc0deffaa4f6eb539cd08a4c9f2a872c7a1439bdf02c3L59) [[4]](diffhunk://#diff-74a7c5e39f59e17e16a7b0803d299e1c5ba7fe00f9f91b7dea154dd9a06b523cL53)
  - Set `enableTableDownload: false` for the `ANALYZE_GENOME` column config to match the new pattern.

**Dependency Update**

* Upgraded `@databiosphere/findable-ui` from version 44.0.0 to 45.0.0 in `package.json` to ensure compatibility with the new table download features.