### PR TITLE
feat: configure export as tsv to select sequencing runs table (#731)

### DIFF
--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/CollectionSelector/components/Table/table.styles.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/CollectionSelector/components/Table/table.styles.ts
@@ -14,7 +14,9 @@ export const StyledGrid = styled(Grid)`
 
 export const StyledRoundedPaper = styled(RoundedPaper)`
   background-color: ${PALETTE.SMOKE_MAIN};
+  display: grid;
   flex: 1;
+  gap: 1px;
   max-height: 100%;
 
   .MuiTableContainer-root {

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/CollectionSelector/components/Table/table.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/CollectionSelector/components/Table/table.tsx
@@ -8,11 +8,13 @@ import { TableContainer } from "@mui/material";
 import { getColumnTrackSizing } from "@databiosphere/findable-ui/lib/components/TableCreator/options/columnTrackSizing/utils";
 import { Props } from "./types";
 import { NoResults } from "@databiosphere/findable-ui/lib/components/NoResults/noResults";
+import { TableToolbar2 } from "@databiosphere/findable-ui/lib/components/Table/components/TableToolbar2/tableToolbar2";
 
 export const Table = ({ table }: Props): JSX.Element => {
   return (
     <StyledGrid container>
       <StyledRoundedPaper elevation={0}>
+        <TableToolbar2 table={table} />
         {table.getRowModel().rows.length === 0 ? (
           <NoResults Paper={null} title="No Results" />
         ) : (

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/CollectionSelector/hooks/UseTable/hook.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/CollectionSelector/hooks/UseTable/hook.ts
@@ -22,6 +22,7 @@ import { getSortedRowModel } from "@tanstack/react-table";
 import { CATEGORY_GROUPS } from "./categoryGroups";
 import { getFacetedMinMaxValues } from "@databiosphere/findable-ui/lib/components/Table/featureOptions/facetedColumn/getFacetedMinMaxValues";
 import { FILTER_SORT } from "@databiosphere/findable-ui/lib/common/filters/sort/config/types";
+import { TABLE_DOWNLOAD } from "@databiosphere/findable-ui/lib/components/Table/features/TableDownload/constants";
 
 export const useTable = (
   enaQueryMethod: ENA_QUERY_METHOD,
@@ -62,9 +63,10 @@ export const useTable = (
   const state = { columnFilters: columnFiltersByMethod[enaQueryMethod] };
 
   return useReactTable<ReadRun>({
-    _features: [ROW_POSITION, ROW_PREVIEW],
+    _features: [ROW_POSITION, ROW_PREVIEW, TABLE_DOWNLOAD],
     columns,
     data,
+    downloadFilename: "read-runs",
     enableColumnFilters: true,
     enableFilters: true,
     enableMultiSort: true,
@@ -72,6 +74,7 @@ export const useTable = (
     enableSorting: true,
     enableSortingInteraction: true,
     enableSortingRemoval: false,
+    enableTableDownload: true,
     filterFns: { arrIncludesSome },
     getCoreRowModel: getCoreRowModel(),
     getFacetedMinMaxValues: getFacetedMinMaxValues(),


### PR DESCRIPTION
Closes #731.

This pull request enhances the sequencing data table component by improving its layout and adding table download functionality. The main changes include updating the table's styling, introducing a toolbar, and enabling users to download table data.

**UI and Layout Improvements:**

* Updated `StyledRoundedPaper` in `table.styles.ts` to use a CSS grid layout and added a gap between elements for improved visual structure.
* Added the `TableToolbar2` component to the table UI for additional table controls and actions.

**Table Download Feature:**

* Imported the `TABLE_DOWNLOAD` constant to support table download capabilities.
* Enabled the table download feature in the `useTable` hook by adding `TABLE_DOWNLOAD` to the features array, setting a default download filename, and enabling the `enableTableDownload` flag.

<img width="1647" height="1224" alt="image" src="https://github.com/user-attachments/assets/2f6956bc-bcff-46c1-bb04-db1be5a1b965" />

<img width="989" height="248" alt="image" src="https://github.com/user-attachments/assets/5e3e1c5f-c5d7-4541-9572-19558cc2d193" />
