### PR TITLE
feat: add socials to header navigation menu for mid-sized viewports (#842)

### DIFF
--- a/site-config/brc-analytics/local/config.ts
+++ b/site-config/brc-analytics/local/config.ts
@@ -11,7 +11,7 @@ import { floating } from "./floating/floating";
 import { genomeEntityConfig } from "./index/genomeEntityConfig";
 import { organismEntityConfig } from "./index/organismEntityConfig";
 import { priorityPathogensEntityConfig } from "./index/priorityPathogensEntityConfig";
-import { socialMedia } from "./socialMedia";
+import { socialMenuItems, socialMedia } from "./socialMedia";
 import { FILTER_SORT } from "@databiosphere/findable-ui/lib/common/filters/sort/config/types";
 import { AppSiteConfig } from "../../common/entities";
 import { APP_KEYS } from "../../common/constants";
@@ -87,7 +87,20 @@ export function makeConfig(
             { label: "Organisms", url: ROUTES.ORGANISMS },
             { label: "Assemblies", url: ROUTES.GENOMES },
             { label: "Priority Pathogens", url: ROUTES.PRIORITY_PATHOGENS },
-            { label: "Roadmap", url: ROUTES.ROADMAP },
+            {
+              flatten: { lg: true, md: true, sm: false, xs: true },
+              label: "More",
+              menuItems: [
+                { label: "Roadmap", url: ROUTES.ROADMAP },
+                {
+                  label: "Join Us",
+                  menuItems: socialMenuItems,
+                  url: "",
+                  visible: { lg: false, xs: false },
+                },
+              ],
+              url: "",
+            },
           ],
           undefined,
         ],

--- a/site-config/brc-analytics/local/socialMedia.ts
+++ b/site-config/brc-analytics/local/socialMedia.ts
@@ -1,6 +1,11 @@
 import { SocialMedia } from "@databiosphere/findable-ui/lib/components/Layout/components/Header/common/entities";
 import * as C from "../../../app/components";
 import { ROUTES } from "../../../routes/constants";
+import {
+  REL_ATTRIBUTE,
+  ANCHOR_TARGET,
+} from "@databiosphere/findable-ui/lib/components/Links/common/entities";
+import { MenuItem } from "@databiosphere/findable-ui/lib/components/Layout/components/Header/components/Content/components/Navigation/components/NavigationMenuItems/navigationMenuItems";
 
 export const SOCIALS = {
   CALENDAR: {
@@ -9,13 +14,32 @@ export const SOCIALS = {
   },
   DISCOURSE: {
     label: "Discourse",
+    rel: REL_ATTRIBUTE.NO_OPENER_NO_REFERRER,
+    target: ANCHOR_TARGET.BLANK,
     url: "https://help.brc-analytics.org/",
   },
   GITHUB: {
     label: "GitHub",
+    rel: REL_ATTRIBUTE.NO_OPENER_NO_REFERRER,
+    target: ANCHOR_TARGET.BLANK,
     url: "https://github.com/galaxyproject/brc-analytics",
   },
 };
+
+export const socialMenuItems: MenuItem[] = [
+  {
+    ...SOCIALS.CALENDAR,
+    icon: C.CalendarIcon({ fontSize: "small" }),
+  },
+  {
+    ...SOCIALS.DISCOURSE,
+    icon: C.DiscourseIcon({ fontSize: "small" }),
+  },
+  {
+    ...SOCIALS.GITHUB,
+    icon: C.GitHubIcon({ fontSize: "small" }),
+  },
+];
 
 export const socialMedia: SocialMedia = {
   socials: [


### PR DESCRIPTION
Closes #842.

This pull request enhances the navigation and social media integration in the BRC Analytics site configuration. The main improvements include adding a "More" dropdown to the navigation menu, grouping social media links under a "Join Us" submenu, and standardizing social media link attributes for security and consistency.

Navigation menu improvements:
* Added a "More" dropdown to the main navigation, which contains links to "Roadmap" and a "Join Us" submenu. The "Join Us" submenu displays social media links and is conditionally visible based on screen size.
* Imported and used the new `socialMenuItems` array to populate the "Join Us" submenu, grouping social links with their respective icons. [[1]](diffhunk://#diff-d8a05cfdd5e948c0abdb37e8934842bce48a70d4dc011e7a3ebf253daf9528fdL14-R14) [[2]](diffhunk://#diff-e11ca0325a3597fb86abea3cba98d5ae5b85e9723c327a6f84c2296d1599331aR17-R43)

Social media integration:
* Introduced the `socialMenuItems` array in `socialMedia.ts`, which combines social media definitions with appropriate icons for use in menus.
* Updated social media link definitions to include `rel` and `target` attributes, improving security (using `noopener noreferrer`) and ensuring links open in new tabs.
* Added necessary imports for menu item types and link attributes to support the new structure and improve type safety.

<img width="1288" height="452" alt="image" src="https://github.com/user-attachments/assets/bfc24f06-2f75-42e8-83a5-5ccf5219af2a" />

----

<img width="777" height="457" alt="image" src="https://github.com/user-attachments/assets/68c1ea6e-80eb-421a-93a0-8852ab8c5f10" />

----

<img width="501" height="460" alt="image" src="https://github.com/user-attachments/assets/516792e7-8bf4-4c18-92bb-861b33f5cccb" />
