### PR TITLE
feat: update stepper ui for large number of sequences in the final step (#852)

### DIFF
--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/CollectionSummary/collectionSummary.styles.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/CollectionSummary/collectionSummary.styles.ts
@@ -7,12 +7,4 @@ export const StyledRoundedPaper = styled(RoundedPaper)`
   display: grid;
   gap: 1px;
   width: 100%;
-
-  .MuiToolbar-table {
-    background-color: ${PALETTE.COMMON_WHITE};
-    display: flex;
-    gap: 8px;
-    justify-content: space-between;
-    padding: 16px;
-  }
 `;

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/CollectionSummary/collectionSummary.styles.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/CollectionSummary/collectionSummary.styles.ts
@@ -1,10 +1,12 @@
 import styled from "@emotion/styled";
 import { RoundedPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/components/RoundedPaper/roundedPaper";
-import { PALETTE } from "@databiosphere/findable-ui/lib/styles/common/constants/palette";
 
 export const StyledRoundedPaper = styled(RoundedPaper)`
-  background-color: ${PALETTE.SMOKE_MAIN};
-  display: grid;
-  gap: 1px;
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  justify-content: space-between;
+  padding: 16px;
   width: 100%;
 `;

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/CollectionSummary/collectionSummary.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/CollectionSummary/collectionSummary.tsx
@@ -1,18 +1,6 @@
-import {
-  Button,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Typography,
-  Grid,
-} from "@mui/material";
-import { GridTable } from "@databiosphere/findable-ui/lib/components/Table/table.styles";
-import { getColumnTrackSizing } from "@databiosphere/findable-ui/lib/components/TableCreator/options/columnTrackSizing/utils";
+import { Button, Typography, Grid } from "@mui/material";
 import { StyledRoundedPaper } from "./collectionSummary.styles";
 import { Props } from "./types";
-import { flexRender } from "@tanstack/react-table";
 import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
 import { BUTTON_PROPS } from "@databiosphere/findable-ui/lib/components/common/Button/constants";
 import { StyledToolbar } from "@databiosphere/findable-ui/lib/components/Table/components/TableToolbar/tableToolbar.styles";
@@ -40,51 +28,6 @@ export const CollectionSummary = ({
           </Button>
         </Grid>
       </StyledToolbar>
-      <TableContainer>
-        <GridTable
-          gridTemplateColumns={getColumnTrackSizing(
-            table
-              .getVisibleFlatColumns()
-              .filter((column) => column.id === "run_accession")
-          )}
-        >
-          {table.getHeaderGroups().map((headerGroup) => (
-            <TableHead key={headerGroup.id}>
-              <TableRow>
-                {headerGroup.headers
-                  .filter((header) => header.column.id === "run_accession")
-                  .map((header) => (
-                    <TableCell key={header.id}>
-                      {flexRender(
-                        header.column.columnDef.header,
-                        header.getContext()
-                      )}
-                    </TableCell>
-                  ))}
-              </TableRow>
-            </TableHead>
-          ))}
-          <TableBody>
-            {table.getSelectedRowModel().rows.map((row) => (
-              <TableRow key={row.id}>
-                {row
-                  .getVisibleCells()
-                  .filter((cell) => cell.column.id === "run_accession")
-                  .map((cell) => {
-                    return (
-                      <TableCell key={cell.id}>
-                        {flexRender(
-                          cell.column.columnDef.cell,
-                          cell.getContext()
-                        )}
-                      </TableCell>
-                    );
-                  })}
-              </TableRow>
-            ))}
-          </TableBody>
-        </GridTable>
-      </TableContainer>
     </StyledRoundedPaper>
   );
 };

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/CollectionSummary/collectionSummary.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/CollectionSummary/collectionSummary.tsx
@@ -3,7 +3,6 @@ import { StyledRoundedPaper } from "./collectionSummary.styles";
 import { Props } from "./types";
 import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
 import { BUTTON_PROPS } from "@databiosphere/findable-ui/lib/components/common/Button/constants";
-import { StyledToolbar } from "@databiosphere/findable-ui/lib/components/Table/components/TableToolbar/tableToolbar.styles";
 
 export const CollectionSummary = ({
   onClear,
@@ -15,19 +14,17 @@ export const CollectionSummary = ({
   if (selectedCount === 0) return null;
   return (
     <StyledRoundedPaper elevation={0}>
-      <StyledToolbar>
-        <Typography variant={TYPOGRAPHY_PROPS.VARIANT.BODY_400}>
-          {count} Collection{count > 1 ? "s" : ""} Selected
-        </Typography>
-        <Grid container gap={2}>
-          <Button {...BUTTON_PROPS.SECONDARY_CONTAINED} onClick={onEdit}>
-            Edit list
-          </Button>
-          <Button {...BUTTON_PROPS.SECONDARY_CONTAINED} onClick={onClear}>
-            Clear all
-          </Button>
-        </Grid>
-      </StyledToolbar>
+      <Typography variant={TYPOGRAPHY_PROPS.VARIANT.BODY_400}>
+        {count} Collection{count > 1 ? "s" : ""} Selected
+      </Typography>
+      <Grid container gap={2}>
+        <Button {...BUTTON_PROPS.SECONDARY_CONTAINED} onClick={onEdit}>
+          Edit list
+        </Button>
+        <Button {...BUTTON_PROPS.SECONDARY_CONTAINED} onClick={onClear}>
+          Clear all
+        </Button>
+      </Grid>
     </StyledRoundedPaper>
   );
 };


### PR DESCRIPTION
Closes #852.

This pull request simplifies the `CollectionSummary` component by removing the use of Material-UI Table components and related table rendering logic. The changes focus on cleaning up unused imports and removing the table display from the component, likely in preparation for a different UI approach or to reduce complexity.

**Component simplification and cleanup:**

* Removed all Material-UI Table components and related logic (such as `TableContainer`, `GridTable`, `TableHead`, `TableRow`, `TableCell`, `TableBody`, and the use of `flexRender`) from the `CollectionSummary` component, resulting in a much simpler JSX structure.
* Cleaned up imports in `collectionSummary.tsx` by removing unused table-related components and utilities.

**Styling cleanup:**

* Removed the `.MuiToolbar-table` CSS rules from the `StyledRoundedPaper` styled component, as the related toolbar/table styling is no longer needed.

<img width="1639" height="1291" alt="image" src="https://github.com/user-attachments/assets/5e70d5b3-d297-4635-bfaf-c92a614bcc35" />
