### PR TITLE
feat: add codeathon and webinar series carousel entries

### DIFF
--- a/app/components/Home/components/Section/components/SectionHero/components/Carousel/cards/constants.ts
+++ b/app/components/Home/components/Section/components/SectionHero/components/Carousel/cards/constants.ts
@@ -2,9 +2,12 @@ import { CardProps } from "@databiosphere/findable-ui/lib/components/common/Card
 import * as MDX from "../content";
 
 export const CAROUSEL_CARDS: Pick<CardProps, "text">[] = [
-  // {
-  //   text: MDX.Webinars({}),
-  // },
+  {
+    text: MDX.Codeathon2025({}),
+  },
+  {
+    text: MDX.WebinarSeries({}),
+  },
   {
     text: MDX.Roadmap({}),
   },

--- a/app/components/Home/components/Section/components/SectionHero/components/Carousel/content/codeathon2025.mdx
+++ b/app/components/Home/components/Section/components/SectionHero/components/Carousel/content/codeathon2025.mdx
@@ -1,0 +1,5 @@
+### AI Codeathon 2025
+
+Join us for a three-day hands-on AI Codeathon uniting experts to tackle critical challenges in infectious disease research using artificial intelligence (AI) and large language models (LLMs), sponsored by the NIAID BRCs.
+
+[Register here!](https://www.bv-brc.org/brc-niaid-ai-codeathon-2025)

--- a/app/components/Home/components/Section/components/SectionHero/components/Carousel/content/index.tsx
+++ b/app/components/Home/components/Section/components/SectionHero/components/Carousel/content/index.tsx
@@ -2,3 +2,5 @@ export { default as ShareUsageAndJoinAdvisoryPanel } from "./shareUsageAndJoinAd
 export { default as Webinar20250326 } from "./webinar20250326.mdx";
 export { default as Webinars } from "./webinars.mdx";
 export { default as Roadmap } from "./roadmap.mdx";
+export { default as Codeathon2025 } from "./codeathon2025.mdx";
+export { default as WebinarSeries } from "./webinarSeries.mdx";

--- a/app/components/Home/components/Section/components/SectionHero/components/Carousel/content/webinarSeries.mdx
+++ b/app/components/Home/components/Section/components/SectionHero/components/Carousel/content/webinarSeries.mdx
@@ -1,0 +1,5 @@
+### Tools for Tomorrow Webinar Series
+
+Stay ahead in infectious disease research! Join the Tools for Tomorrow Webinar Series from the NIAID BRCs. Monthly updates, new tools, fresh insights. Starts Oct 10, 2 PM UTC.
+
+[Register here!](https://forms.office.com/pages/responsepage.aspx?id=8WfZJNg-SES6plYOxXKss8gM98-9jH9MgRdwq7CpaB5URVVKRFpaV0tCOUQxSFRQUzlGVEhFVjJHUi4u&route=shorturl)


### PR DESCRIPTION
## Description

adding the AI codeathon and the brc consortium webinar series to the carousel, based on text provided by @scottcain 

## Related Issue

closes #855 
