### PR TITLE
feat: change MAX_READ_RUNS_FOR_BROWSE_ALL from hard coded to configurable

### DIFF
--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/DataSelector/dataSelector.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/DataSelector/dataSelector.tsx
@@ -6,19 +6,22 @@ import { BUTTON_PROPS } from "@databiosphere/findable-ui/lib/components/common/B
 import { LoadingIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/LoadingIcon/loadingIcon";
 import { SVG_ICON_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/svgIcon";
 import { Props } from "./types";
-import { MAX_READ_RUNS_FOR_BROWSE_ALL } from "../../hooks/UseENADataByTaxonomyId/constants";
 import { ENA_QUERY_METHOD } from "../../../../types";
 import { Fragment } from "react";
+import { config } from "../../../../../../../../../../../../../../../../app/config/config";
 
 export const DataSelector = ({
   loading,
   onContinue,
   onOpen,
-  readCount = MAX_READ_RUNS_FOR_BROWSE_ALL,
+  readCount,
   selectedCount,
   setEnaQueryMethod,
   taxonomicLevelSpecies,
 }: Props): JSX.Element | null => {
+  const { maxReadRunsForBrowseAll } = config();
+  const readCountValue =
+    readCount === undefined ? maxReadRunsForBrowseAll : readCount;
   if (selectedCount > 0) return null;
   return (
     <StyledPaper {...PAPER_PROPS}>
@@ -43,7 +46,7 @@ export const DataSelector = ({
         />
       ) : (
         <StyledGrid {...GRID_PROPS}>
-          {readCount < MAX_READ_RUNS_FOR_BROWSE_ALL && (
+          {readCountValue < maxReadRunsForBrowseAll && (
             <Fragment>
               <Stack alignItems="center" spacing={1}>
                 <Button
@@ -53,7 +56,7 @@ export const DataSelector = ({
                     onContinue();
                   }}
                 >
-                  {renderButtonText(readCount)}
+                  {renderButtonText(readCountValue)}
                 </Button>
                 <Typography
                   color={TYPOGRAPHY_PROPS.COLOR.INK_LIGHT}

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/hooks/UseENADataByTaxonomyId/constants.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/hooks/UseENADataByTaxonomyId/constants.ts
@@ -1,1 +1,0 @@
-export const MAX_READ_RUNS_FOR_BROWSE_ALL = 2000;

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/hooks/UseENADataByTaxonomyId/hook.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/hooks/UseENADataByTaxonomyId/hook.ts
@@ -5,6 +5,7 @@ import { useAsync } from "@databiosphere/findable-ui/lib/hooks/useAsync";
 import { shouldFetch } from "./utils";
 import { BRCDataCatalogGenome } from "../../../../../../../../../../../../../../../apis/catalog/brc-analytics-catalog/common/entities";
 import { GA2AssemblyEntity } from "../../../../../../../../../../../../../../../apis/catalog/ga2/entities";
+import { config } from "../../../../../../../../../../../../../../../../app/config/config";
 
 export const useENADataByTaxonomyId = <T>(
   genome: BRCDataCatalogGenome | GA2AssemblyEntity
@@ -13,7 +14,7 @@ export const useENADataByTaxonomyId = <T>(
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [loading, setLoading] = useState<boolean>(true);
   const { ncbiTaxonomyId: taxonomyId } = genome;
-
+  const { maxReadRunsForBrowseAll } = config();
   const onRequestData = useCallback(async (): Promise<void> => {
     run(
       fetchENAData({
@@ -32,7 +33,7 @@ export const useENADataByTaxonomyId = <T>(
   }, [run, taxonomyId]);
 
   useEffect(() => {
-    if (shouldFetch(taxonomyId)) {
+    if (shouldFetch(taxonomyId, maxReadRunsForBrowseAll)) {
       // Request sequencing data by taxonomy ID and configured filters.
       onRequestData();
     } else {
@@ -40,7 +41,7 @@ export const useENADataByTaxonomyId = <T>(
       // the user should not be able to browse all sequences.
       setLoading(false);
     }
-  }, [onRequestData, taxonomyId]);
+  }, [onRequestData, taxonomyId, maxReadRunsForBrowseAll]);
 
   return { data, status: { errors, loading } };
 };

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/hooks/UseENADataByTaxonomyId/utils.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/hooks/UseENADataByTaxonomyId/utils.ts
@@ -1,4 +1,3 @@
-import { MAX_READ_RUNS_FOR_BROWSE_ALL } from "./constants";
 import taxonomyReadCounts from "./taxonomy_read_counts.json";
 
 /**
@@ -6,16 +5,19 @@ import taxonomyReadCounts from "./taxonomy_read_counts.json";
  * Pre-fetching occurs when the read count is less than the maximum allowable count.
  * A 0 read count is not a valid value and should not be pre-fetched; the user will only be able to browse data by accession.
  * @param taxonomyId - Taxonomy ID.
+ * @param maxReadRuns - Maximum allowable read runs for pre-fetching (default is 2000).
  * @returns True if ENA data by taxonomy ID should be pre-fetched.
  */
-export function shouldFetch(taxonomyId: string): boolean {
+export function shouldFetch(
+  taxonomyId: string,
+  maxReadRuns: number = 2000
+): boolean {
   if (!taxonomyId) return false;
-
   const taxonomyIdReadCounts = new Map(Object.entries(taxonomyReadCounts));
   const readCount = taxonomyIdReadCounts.get(taxonomyId);
 
   // If the read count is not found -- or is 0, we should not pre-fetch ENA data by taxonomy ID.
   if (!readCount) return false;
 
-  return readCount < MAX_READ_RUNS_FOR_BROWSE_ALL;
+  return readCount < maxReadRuns;
 }

--- a/site-config/brc-analytics/local/config.ts
+++ b/site-config/brc-analytics/local/config.ts
@@ -107,6 +107,7 @@ export function makeConfig(
         socialMedia: socialMedia,
       },
     },
+    maxReadRunsForBrowseAll: 2000,
     redirectRootToPath: "/",
     themeOptions: {},
   };

--- a/site-config/common/entities.ts
+++ b/site-config/common/entities.ts
@@ -25,4 +25,5 @@ export interface AppEntityConfig<R>
 export interface AppSiteConfig extends BaseSiteConfig {
   allowedPaths?: string[];
   appKey?: (typeof APP_KEYS)[keyof typeof APP_KEYS];
+  maxReadRunsForBrowseAll: number;
 }

--- a/site-config/ga2/local/config.ts
+++ b/site-config/ga2/local/config.ts
@@ -1,4 +1,3 @@
-import { SiteConfig } from "@databiosphere/findable-ui/lib/config/entities";
 import { EntityConfig } from "@databiosphere/findable-ui/lib/config/entities";
 import * as C from "../../../app/components";
 import { ROUTES } from "../../../routes/constants";
@@ -77,11 +76,12 @@ export function makeConfig(
         ],
       },
     },
+    maxReadRunsForBrowseAll: 4000,
     redirectRootToPath: "/",
     themeOptions: {},
   };
 }
 
-const config: SiteConfig = makeConfig(BROWSER_URL);
+const config: AppSiteConfig = makeConfig(BROWSER_URL);
 
 export default config;


### PR DESCRIPTION
## Description

For GA2 we would like to have a value for MAX_READ_RUNS_FOR_BROWSE_ALL that's different from the one used by BRC Analytics.

## Related Issue

#868 