### PR TITLE
fix: remove analytics text from ga2 subhero text (#874)

### DIFF
--- a/app/components/Home/content/sectionSubHeroGA2.mdx
+++ b/app/components/Home/content/sectionSubHeroGA2.mdx
@@ -1,1 +1,1 @@
-GenomeArk analytics lets you run analyses directly on Phase I VGP genomes.
+GenomeArk lets you run analyses directly on Phase I VGP genomes.


### PR DESCRIPTION
Fixes #874.

This pull request makes a minor update to the `sectionSubHeroGA2.mdx` file, clarifying the description of GenomeArk by removing the word "analytics" from the introductory sentence.