### PR TITLE
feat: [ga2] configure site to use plausible (#880)

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,5 +1,11 @@
 import Document, { Head, Html, Main, NextScript } from "next/document";
 
+const plausibleDomain = process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN;
+
+if (!plausibleDomain) {
+  throw new Error("NEXT_PUBLIC_PLAUSIBLE_DOMAIN is not defined");
+}
+
 class MyDocument extends Document {
   render(): JSX.Element {
     return (
@@ -14,7 +20,7 @@ class MyDocument extends Document {
             rel="stylesheet"
           />
           <script
-            data-domain="brc-analytics.org"
+            data-domain={plausibleDomain}
             defer
             src="https://plausible.galaxyproject.eu/js/script.js"
           />

--- a/site-config/brc-analytics/dev/.env
+++ b/site-config/brc-analytics/dev/.env
@@ -1,3 +1,4 @@
 NEXT_PUBLIC_ENA_PROXY_DOMAIN="https://brc-analytics.dev.clevercanary.com"
 NEXT_PUBLIC_SITE_CONFIG='brc-analytics-dev'
 NEXT_PUBLIC_GALAXY_INSTANCE_URL="https://test.galaxyproject.org"
+NEXT_PUBLIC_PLAUSIBLE_DOMAIN="brc-analytics.org"

--- a/site-config/brc-analytics/local/.env
+++ b/site-config/brc-analytics/local/.env
@@ -1,3 +1,4 @@
 NEXT_PUBLIC_ENA_PROXY_DOMAIN="https://brc-analytics.dev.clevercanary.com"
 NEXT_PUBLIC_SITE_CONFIG='brc-analytics-local'
 NEXT_PUBLIC_GALAXY_INSTANCE_URL="https://test.galaxyproject.org"
+NEXT_PUBLIC_PLAUSIBLE_DOMAIN="brc-analytics.org"

--- a/site-config/brc-analytics/prod/.env
+++ b/site-config/brc-analytics/prod/.env
@@ -1,3 +1,4 @@
 NEXT_PUBLIC_ENA_PROXY_DOMAIN="https://brc-analytics.org"
 NEXT_PUBLIC_SITE_CONFIG='brc-analytics-prod'
 NEXT_PUBLIC_GALAXY_INSTANCE_URL="https://usegalaxy.org"
+NEXT_PUBLIC_PLAUSIBLE_DOMAIN="brc-analytics.org"

--- a/site-config/ga2/dev/.env
+++ b/site-config/ga2/dev/.env
@@ -1,3 +1,4 @@
 NEXT_PUBLIC_ENA_PROXY_DOMAIN="https://brc-analytics.dev.clevercanary.com"
 NEXT_PUBLIC_SITE_CONFIG='ga2-dev'
 NEXT_PUBLIC_GALAXY_INSTANCE_URL="https://test.galaxyproject.org"
+NEXT_PUBLIC_PLAUSIBLE_DOMAIN="genomeark2.org"

--- a/site-config/ga2/local/.env
+++ b/site-config/ga2/local/.env
@@ -1,3 +1,4 @@
 NEXT_PUBLIC_ENA_PROXY_DOMAIN="https://brc-analytics.dev.clevercanary.com"
 NEXT_PUBLIC_SITE_CONFIG='ga2-local'
 NEXT_PUBLIC_GALAXY_INSTANCE_URL="https://test.galaxyproject.org"
+NEXT_PUBLIC_PLAUSIBLE_DOMAIN="genomeark2.org"

--- a/site-config/ga2/prod/.env
+++ b/site-config/ga2/prod/.env
@@ -1,3 +1,4 @@
 NEXT_PUBLIC_ENA_PROXY_DOMAIN="https://brc-analytics.org"
 NEXT_PUBLIC_SITE_CONFIG='ga2-prod'
 NEXT_PUBLIC_GALAXY_INSTANCE_URL="https://vgp.usegalaxy.org"
+NEXT_PUBLIC_PLAUSIBLE_DOMAIN="genomeark2.org"


### PR DESCRIPTION
Closes #880.

This pull request introduces environment-based configuration for the Plausible analytics domain, improving flexibility and maintainability across different deployments. The main changes include reading the analytics domain from environment variables and updating configuration files for all environments to support this.

**Analytics configuration improvements:**

* Updated `pages/_document.tsx` to read the Plausible analytics domain from the `NEXT_PUBLIC_PLAUSIBLE_DOMAIN` environment variable and throw an error if it is not set, ensuring correct configuration at runtime.
* Modified the Plausible script tag in `pages/_document.tsx` to use the dynamic domain from the environment variable instead of a hardcoded value.

**Environment variable additions:**

* Added `NEXT_PUBLIC_PLAUSIBLE_DOMAIN` to all environment configuration files for both `brc-analytics` and `ga2` sites, specifying the correct domain for each deployment (`brc-analytics.org` or `genomeark2.org`). [[1]](diffhunk://#diff-5e71c75e3954c624c1f1d10a91b933aa44e30052085ed06ce7009d7fa35b430dR4) [[2]](diffhunk://#diff-753fc6a37f415b4cfabcc7ff5b62f8785c0ebf8535f02680f4a7b856824d492aR4) [[3]](diffhunk://#diff-b854a8d26855d29a18b84d2791995d66f7e665bf589573e33ad730f059ebaa63R4) [[4]](diffhunk://#diff-986f7dd4992cfbb8bc149c0e6b35015480df496f70837af9243410f9b3b5a942R4) [[5]](diffhunk://#diff-b6955061ab9c4b1cef967880db643e11bfb214478472e1a902324b7f2b141f44R4) [[6]](diffhunk://#diff-975227fd9d2797a1da96175f806a24eb8527eb890bc971411538c0dcab662d20R4)