### PR TITLE
feat: virtualize ena picker list (#901)

### DIFF
--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/CollectionSelector/components/Table/table.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/CollectionSelector/components/Table/table.tsx
@@ -1,7 +1,7 @@
 import { GridTable } from "@databiosphere/findable-ui/lib/components/Table/table.styles";
 import { TableHead } from "@databiosphere/findable-ui/lib/components/Table/components/TableHead/tableHead";
 import { ROW_DIRECTION } from "@databiosphere/findable-ui/lib/components/Table/common/entities";
-import { TableBody } from "@databiosphere/findable-ui/lib/components/Detail/components/Table/components/TableBody/tableBody";
+import { TableBody } from "@databiosphere/findable-ui/lib/components/Table/components/TableBody/tableBody";
 import { StyledGrid } from "./table.styles";
 import { StyledRoundedPaper } from "./table.styles";
 import { TableContainer } from "@mui/material";
@@ -9,8 +9,13 @@ import { getColumnTrackSizing } from "@databiosphere/findable-ui/lib/components/
 import { Props } from "./types";
 import { NoResults } from "@databiosphere/findable-ui/lib/components/NoResults/noResults";
 import { TableToolbar2 } from "@databiosphere/findable-ui/lib/components/Table/components/TableToolbar2/tableToolbar2";
+import { useVirtualization } from "@databiosphere/findable-ui/lib/components/Table/hooks/UseVirtualization/hook";
 
 export const Table = ({ table }: Props): JSX.Element => {
+  const { rows, scrollElementRef, virtualizer } = useVirtualization({
+    rowDirection: ROW_DIRECTION.DEFAULT,
+    table,
+  });
   return (
     <StyledGrid container>
       <StyledRoundedPaper elevation={0}>
@@ -18,7 +23,7 @@ export const Table = ({ table }: Props): JSX.Element => {
         {table.getRowModel().rows.length === 0 ? (
           <NoResults Paper={null} title="No Results" />
         ) : (
-          <TableContainer>
+          <TableContainer ref={scrollElementRef}>
             <GridTable
               gridTemplateColumns={getColumnTrackSizing(
                 table.getVisibleFlatColumns()
@@ -28,7 +33,9 @@ export const Table = ({ table }: Props): JSX.Element => {
               <TableHead tableInstance={table} />
               <TableBody
                 rowDirection={ROW_DIRECTION.DEFAULT}
+                rows={rows}
                 tableInstance={table}
+                virtualizer={virtualizer}
               />
             </GridTable>
           </TableContainer>


### PR DESCRIPTION
Closes #901.

This pull request introduces virtualization to the `Table` component in the ENA Sequencing Data Collection Selector, improving performance when rendering large datasets. The main changes involve integrating a virtualization hook and updating the table body to use virtualized rows.

Performance improvements (virtualization):

* Integrated the `useVirtualization` hook from `@databiosphere/findable-ui` to manage row virtualization, reducing the rendering load for large tables (`table.tsx`).
* Updated the `TableContainer` to use a `ref` from the virtualization hook, enabling efficient scrolling and rendering (`table.tsx`).
* Modified the `TableBody` component props to accept `rows` and `virtualizer` from the virtualization hook, ensuring only visible rows are rendered (`table.tsx`).