### PR TITLE
fix: change UCSC_GENOME_BROWSE link to landing page of UCSC

### DIFF
--- a/app/components/Home/common/constants.ts
+++ b/app/components/Home/common/constants.ts
@@ -7,7 +7,6 @@ export const URLS = {
   NCBI_DATASETS: "https://www.ncbi.nlm.nih.gov/datasets",
   T2T_CONSORTIUM: "https://sites.google.com/ucsc.edu/t2tworkinggroup/home",
   TACC: "https://tacc.utexas.edu",
-  UCSC_GENOME_BROWSER:
-    "https://genome.ucsc.edu/cgi-bin/hgTracks?db=hub_3099159_GCF_000002765.5&lastVirtModeType=default&lastVirtModeExtraState=&virtModeType=default&virtMode=0&nonVirtPosition=&position=chr14%3A1097312%2D1107312&hgsid=2334740048_JURjoJTpdZ1arRgPWCUOn1kbfI2r",
+  UCSC_GENOME_BROWSER: "https://genome.ucsc.edu",
   VERTEBRATE_GENOMES_PROJECT: "https://vertebrategenomesproject.org",
 };


### PR DESCRIPTION
the current link for UCSC in constants are pointing to a view of GRCh38/hg38

## Description

Brief description of the changes made in this PR.

## Related Issue

If this addresses an existing GitHub issue, link it here (e.g., "Closes #123"). If no existing issue exists, consider creating one first to discuss the changes.
