### PR TITLE
feat: show filtered count versus total count in workflow table toolbar (#909)

### DIFF
--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/CollectionSelector/components/Table/components/TableToolbar/components/ResultsSummary/resultsSummary.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/CollectionSelector/components/Table/components/TableToolbar/components/ResultsSummary/resultsSummary.tsx
@@ -1,0 +1,14 @@
+import { Typography } from "@mui/material";
+import { Props } from "../../../../types";
+import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
+
+export const ResultsSummary = ({ table }: Props): JSX.Element => {
+  const { getPreFilteredRowModel, getRowCount } = table;
+  const { rows } = getPreFilteredRowModel();
+  const rowCount = getRowCount();
+  return (
+    <Typography variant={TYPOGRAPHY_PROPS.VARIANT.BODY_400}>
+      {rowCount} matching run{rowCount === 1 ? "" : "s"} of {rows.length}
+    </Typography>
+  );
+};

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/CollectionSelector/components/Table/components/TableToolbar/tableToolbar.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/CollectionSelector/components/Table/components/TableToolbar/tableToolbar.tsx
@@ -1,0 +1,18 @@
+import { Props } from "../../types";
+import {
+  StyledToolbar,
+  StyledStack,
+} from "@databiosphere/findable-ui/lib/components/Table/components/TableToolbar2/tableToolbar2.styles";
+import { TableDownload } from "@databiosphere/findable-ui/lib/components/Table/components/TableFeatures/TableDownload/tableDownload";
+import { ResultsSummary } from "./components/ResultsSummary/resultsSummary";
+
+export const TableToolbar = ({ table }: Props): JSX.Element => {
+  return (
+    <StyledToolbar>
+      <ResultsSummary table={table} />
+      <StyledStack>
+        <TableDownload table={table} />
+      </StyledStack>
+    </StyledToolbar>
+  );
+};

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/CollectionSelector/components/Table/table.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/CollectionSelector/components/Table/table.tsx
@@ -8,8 +8,8 @@ import { TableContainer } from "@mui/material";
 import { getColumnTrackSizing } from "@databiosphere/findable-ui/lib/components/TableCreator/options/columnTrackSizing/utils";
 import { Props } from "./types";
 import { NoResults } from "@databiosphere/findable-ui/lib/components/NoResults/noResults";
-import { TableToolbar2 } from "@databiosphere/findable-ui/lib/components/Table/components/TableToolbar2/tableToolbar2";
 import { useVirtualization } from "@databiosphere/findable-ui/lib/components/Table/hooks/UseVirtualization/hook";
+import { TableToolbar } from "./components/TableToolbar/tableToolbar";
 
 export const Table = ({ table }: Props): JSX.Element => {
   const { rows, scrollElementRef, virtualizer } = useVirtualization({
@@ -19,7 +19,7 @@ export const Table = ({ table }: Props): JSX.Element => {
   return (
     <StyledGrid container>
       <StyledRoundedPaper elevation={0}>
-        <TableToolbar2 table={table} />
+        <TableToolbar table={table} />
         {table.getRowModel().rows.length === 0 ? (
           <NoResults Paper={null} title="No Results" />
         ) : (


### PR DESCRIPTION
Closes #909.

This pull request refactors the table toolbar component in the ENA Sequencing Data workflow to use a custom `TableToolbar` instead of the generic `TableToolbar2`. The new toolbar displays a summary of matching rows and integrates the download feature, improving clarity and user experience.

**Table toolbar refactor and UI improvements:**

* Replaced usage of the generic `TableToolbar2` with a new custom `TableToolbar` component in `table.tsx`, enhancing maintainability and customization. [[1]](diffhunk://#diff-0b4f3928b6305106e56af0a3250a545f30e9c9fa28157b12195b80ee0ab9930dL11-R12) [[2]](diffhunk://#diff-0b4f3928b6305106e56af0a3250a545f30e9c9fa28157b12195b80ee0ab9930dL22-R22)
* Added a new `ResultsSummary` component to the toolbar, which clearly displays the number of matching runs out of the total, providing users with immediate feedback on their search/filter results. [[1]](diffhunk://#diff-d39875c8ab9211936b57ef2ad7606b9853193eb079924e6ad2b86b2cc0161aebR1-R14) [[2]](diffhunk://#diff-3a104d27d0993e853476bade9de1285ade41f9f17977c4245f6bfbf8fce37275R1-R18)
* Incorporated the existing `TableDownload` feature into the new toolbar, ensuring users retain the ability to download table data.

<img width="1153" height="963" alt="image" src="https://github.com/user-attachments/assets/b8020a83-685e-46a0-b4f4-a62541c318c8" />
