### PR TITLE
feat: add function to get data landing url (#825)

### DIFF
--- a/app/apis/catalog/brc-analytics-catalog/common/entities.ts
+++ b/app/apis/catalog/brc-analytics-catalog/common/entities.ts
@@ -1,5 +1,5 @@
 import { MDXRemoteSerializeResult } from "next-mdx-remote";
-import { WorkflowUrlParameter } from "../../../../utils/galaxy-api/entities";
+import { GalaxyUrlData } from "../../../../utils/galaxy-api/entities";
 import {
   ORGANISM_PLOIDY,
   OUTBREAK_PRIORITY,
@@ -133,6 +133,6 @@ export interface WorkflowDataRequirements {
 export interface WorkflowParameter {
   data_requirements?: WorkflowDataRequirements;
   key: string;
-  url_spec?: WorkflowUrlParameter;
+  url_spec?: GalaxyUrlData;
   variable?: WORKFLOW_PARAMETER_VARIABLE;
 }

--- a/app/utils/galaxy-api/entities.ts
+++ b/app/utils/galaxy-api/entities.ts
@@ -1,3 +1,5 @@
+//// ENA types
+
 export interface EnaSequencingReads {
   md5Hashes: string;
   runAccession: string;
@@ -8,6 +10,8 @@ export interface EnaFileInfo {
   md5: string;
   url: string;
 }
+
+//// Workflow landing types
 
 export interface WorkflowLandingsBody {
   public: true;
@@ -22,11 +26,44 @@ export type WorkflowLandingsBodyRequestState = {
 
 export type WorkflowParameterValue =
   | string
-  | WorkflowUrlParameter
-  | WorkflowListCollectionParameter
-  | WorkflowPairedCollectionParameter;
+  | GalaxyUrlData
+  | WorkflowCollectionParameter;
 
-export interface WorkflowUrlParameter {
+export type WorkflowCollectionParameter<
+  T extends GalaxyCollection = GalaxyCollection,
+> = {
+  class: "Collection";
+} & T;
+
+//// Data landing types
+
+export interface DataLandingsBody {
+  public: true;
+  request_state: DataLandingsBodyRequestState;
+}
+
+export interface DataLandingsBodyRequestState {
+  targets: DataLandingsTarget[];
+}
+
+export type DataLandingsTarget =
+  | DataLandingsDatasetTarget
+  | DataLandingsCollectionTarget;
+
+export interface DataLandingsDatasetTarget {
+  destination: { type: "hdas" };
+  items: GalaxyUrlData[];
+}
+
+export type DataLandingsCollectionTarget<
+  T extends GalaxyCollection = GalaxyCollection,
+> = {
+  destination: { type: "hdca" };
+} & T;
+
+//// Shared Galaxy types
+
+export interface GalaxyUrlData {
   dbkey?: string;
   ext: string;
   src: string;
@@ -35,8 +72,9 @@ export interface WorkflowUrlParameter {
 
 // Narrow type specific to the two kinds of collections we use -- might be worth defining a more general collection type if we need other kinds of collections
 
-interface WorkflowListCollectionParameter {
-  class: "Collection";
+export type GalaxyCollection = GalaxyListCollection | GalaxyPairedCollection;
+
+export interface GalaxyListCollection {
   collection_type: "list";
   elements: Array<{
     class: "File";
@@ -47,8 +85,7 @@ interface WorkflowListCollectionParameter {
   }>;
 }
 
-interface WorkflowPairedCollectionParameter {
-  class: "Collection";
+export interface GalaxyPairedCollection {
   collection_type: "list:paired";
   elements: Array<{
     class: "Collection";
@@ -78,6 +115,8 @@ interface WorkflowDatasetHash {
   hash_value: string;
 }
 
-export interface WorkflowLanding {
+//// Response type
+
+export interface GalaxyLandingResponseData {
   uuid: string;
 }


### PR DESCRIPTION
This pull request refactors and extends the Galaxy API integration code to support both workflow and data landing endpoints, introducing new types and utility functions for handling complex Galaxy parameter structures. The main changes include replacing legacy types with more general and reusable ones, adding support for data landings, and improving how request payloads are constructed for both workflows and data landings.

### API and Type Refactoring

* Replaced the legacy `WorkflowUrlParameter` and related collection parameter types with new, more general `GalaxyUrlData` and `GalaxyCollection` types in both `entities.ts` and API usage, making the codebase more flexible and maintainable. [[1]](diffhunk://#diff-2825763892393f6517a6e8db9e159e93b182c5149e0351bfd52ee5cd7319dd5dL2-R2) [[2]](diffhunk://#diff-2825763892393f6517a6e8db9e159e93b182c5149e0351bfd52ee5cd7319dd5dL128-R128) [[3]](diffhunk://#diff-0c44c22184ee91ae031dbf111c1bad9ad556a0ab2cfab8368ac2975f1e40c914L25-R66) [[4]](diffhunk://#diff-0c44c22184ee91ae031dbf111c1bad9ad556a0ab2cfab8368ac2975f1e40c914L38-R77) [[5]](diffhunk://#diff-0c44c22184ee91ae031dbf111c1bad9ad556a0ab2cfab8368ac2975f1e40c914L50-R88)
* Updated all API functions and request payload construction in `galaxy-api.ts` to use the new types, including changes to imports and function signatures. [[1]](diffhunk://#diff-f09dd2ccabdbe1c599a4a08db41d4d0c966091023e4c68ad5a128ede6c7014b4L7-R19) [[2]](diffhunk://#diff-f09dd2ccabdbe1c599a4a08db41d4d0c966091023e4c68ad5a128ede6c7014b4L54-R106) [[3]](diffhunk://#diff-f09dd2ccabdbe1c599a4a08db41d4d0c966091023e4c68ad5a128ede6c7014b4L122-L125)

### Data Landings Support

* Added new types and API endpoints for "data landings," including `DataLandingsBody`, `DataLandingsTarget`, and related utility functions for constructing request payloads for non-workflow data uploads. [[1]](diffhunk://#diff-0c44c22184ee91ae031dbf111c1bad9ad556a0ab2cfab8368ac2975f1e40c914L25-R66) [[2]](diffhunk://#diff-0c44c22184ee91ae031dbf111c1bad9ad556a0ab2cfab8368ac2975f1e40c914L81-R120) [[3]](diffhunk://#diff-f09dd2ccabdbe1c599a4a08db41d4d0c966091023e4c68ad5a128ede6c7014b4R32-R33) [[4]](diffhunk://#diff-f09dd2ccabdbe1c599a4a08db41d4d0c966091023e4c68ad5a128ede6c7014b4L54-R106) [[5]](diffhunk://#diff-f09dd2ccabdbe1c599a4a08db41d4d0c966091023e4c68ad5a128ede6c7014b4R122-R239)

### Utility Functions and Payload Construction

* Refactored and expanded utility functions for building request payloads, including new helpers for constructing dataset and collection targets, and for building specific parameter values (e.g., assembly FASTA, gene model URLs, single/paired read runs). [[1]](diffhunk://#diff-f09dd2ccabdbe1c599a4a08db41d4d0c966091023e4c68ad5a128ede6c7014b4R122-R239) [[2]](diffhunk://#diff-f09dd2ccabdbe1c599a4a08db41d4d0c966091023e4c68ad5a128ede6c7014b4L102-R258) [[3]](diffhunk://#diff-f09dd2ccabdbe1c599a4a08db41d4d0c966091023e4c68ad5a128ede6c7014b4L122-L125) [[4]](diffhunk://#diff-f09dd2ccabdbe1c599a4a08db41d4d0c966091023e4c68ad5a128ede6c7014b4L157-R314)
* Centralized the logic for generating landing URLs for both workflows and data landings into a single function, reducing code duplication.

### Cleanup

* Removed obsolete types, imports, and duplicated logic, consolidating all request state construction into new, clearer utility functions.

These changes make the Galaxy API integration code more robust, easier to extend, and better able to handle new use cases for both workflow and data landings.
