### PR TITLE
feat: filter order updates for assembly and organism (#921)

### DIFF
--- a/site-config/brc-analytics/local/index/genomeEntityConfig.ts
+++ b/site-config/brc-analytics/local/index/genomeEntityConfig.ts
@@ -57,7 +57,6 @@ export const genomeEntityConfig: AppEntityConfig<BRCDataCatalogGenome> = {
         ],
         label: "Organism",
       },
-      CATEGORY_GROUPS.PRIORITY_PATHOGENS,
       {
         categoryConfigs: [
           {
@@ -95,6 +94,7 @@ export const genomeEntityConfig: AppEntityConfig<BRCDataCatalogGenome> = {
         ],
         label: "Taxonomic Lineage",
       },
+      CATEGORY_GROUPS.PRIORITY_PATHOGENS,
       {
         categoryConfigs: [
           {

--- a/site-config/brc-analytics/local/index/organismEntityConfig.ts
+++ b/site-config/brc-analytics/local/index/organismEntityConfig.ts
@@ -40,7 +40,6 @@ export const organismEntityConfig: AppEntityConfig<BRCDataCatalogOrganism> = {
           },
         ],
       },
-      CATEGORY_GROUPS.PRIORITY_PATHOGENS,
       {
         categoryConfigs: [
           {
@@ -78,6 +77,7 @@ export const organismEntityConfig: AppEntityConfig<BRCDataCatalogOrganism> = {
         ],
         label: "Taxonomic Lineage",
       },
+      CATEGORY_GROUPS.PRIORITY_PATHOGENS,
     ],
     key: "organisms",
   },

--- a/site-config/ga2/local/index/genome/categoryGroups.ts
+++ b/site-config/ga2/local/index/genome/categoryGroups.ts
@@ -11,16 +11,6 @@ export const CATEGORY_GROUPS: CategoryGroup[] = [
   },
   {
     categoryConfigs: [
-      CATEGORY_REGISTRY.ACCESSION,
-      CATEGORY_REGISTRY.IS_REF,
-      CATEGORY_REGISTRY.LEVEL,
-      CATEGORY_REGISTRY.COVERAGE,
-      CATEGORY_REGISTRY.ANNOTATION_STATUS,
-    ],
-    label: "Assembly",
-  },
-  {
-    categoryConfigs: [
       CATEGORY_REGISTRY.TAXONOMIC_LEVEL_DOMAIN,
       CATEGORY_REGISTRY.TAXONOMIC_LEVEL_KINGDOM,
       CATEGORY_REGISTRY.TAXONOMIC_LEVEL_PHYLUM,
@@ -30,5 +20,15 @@ export const CATEGORY_GROUPS: CategoryGroup[] = [
       CATEGORY_REGISTRY.TAXONOMIC_LEVEL_GENUS,
     ],
     label: "Taxonomic Lineage",
+  },
+  {
+    categoryConfigs: [
+      CATEGORY_REGISTRY.ACCESSION,
+      CATEGORY_REGISTRY.IS_REF,
+      CATEGORY_REGISTRY.LEVEL,
+      CATEGORY_REGISTRY.COVERAGE,
+      CATEGORY_REGISTRY.ANNOTATION_STATUS,
+    ],
+    label: "Assembly",
   },
 ];


### PR DESCRIPTION
Closes #921.

This pull request reorganizes the order of category groups in the configuration files for both the BRC Analytics and GA2 applications. The main change is to move the "Priority Pathogens" group to appear after the "Taxonomic Lineage" group, and to adjust the placement of the "Assembly" group in the GA2 genome category groups configuration.

**Category group reordering for improved logical grouping:**

* In `genomeEntityConfig.ts` and `organismEntityConfig.ts`, the `CATEGORY_GROUPS.PRIORITY_PATHOGENS` entry is moved to follow the "Taxonomic Lineage" group, improving the logical order of displayed groups. [[1]](diffhunk://#diff-4108318bbfd5edc450fb9ed3200ca627e0bbc349c5105d96d70235896d592037L60) [[2]](diffhunk://#diff-4108318bbfd5edc450fb9ed3200ca627e0bbc349c5105d96d70235896d592037R97) [[3]](diffhunk://#diff-7c6aca36be1e442bdd70577dca605ac48c3843b7dab490ac151be00b1cd33c5eL43) [[4]](diffhunk://#diff-7c6aca36be1e442bdd70577dca605ac48c3843b7dab490ac151be00b1cd33c5eR80)

**Category group placement adjustment in GA2 genome configuration:**

* In `categoryGroups.ts` for GA2, the "Assembly" group is moved to appear after the "Taxonomic Lineage" group instead of before it, aligning the order with the other configurations. [[1]](diffhunk://#diff-05ae4a7a56175c51b730f6334f2766a81de79340cc982707fb14c80b559e6166L12-L21) [[2]](diffhunk://#diff-05ae4a7a56175c51b730f6334f2766a81de79340cc982707fb14c80b559e6166R24-R33)

<img width="2559" height="1288" alt="image" src="https://github.com/user-attachments/assets/c284db81-83ce-466c-b327-59e6a83b2f83" />

<img width="2553" height="1289" alt="image" src="https://github.com/user-attachments/assets/6fb0d31b-8237-46fd-b4a6-8314b1de0dbf" />

<img width="2553" height="1287" alt="image" src="https://github.com/user-attachments/assets/d4860faa-588d-4253-b7b5-932d0ba6a3b5" />


<img width="2553" height="1290" alt="image" src="https://github.com/user-attachments/assets/7dc686c3-d1ea-4da6-984d-d83484c7e86b" />
