### PR TITLE
feat: add number formatting to numeric columns (#511)

### DIFF
--- a/app/viewModelBuilders/catalog/ga2/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/ga2/viewModelBuilders.ts
@@ -17,6 +17,7 @@ import {
   buildAnalyzeGenome,
   buildGenomeTaxonomicLevelStrain,
   buildIsRef,
+  formatNumber,
 } from "../brc-analytics-catalog/common/viewModelBuilders";
 
 /**
@@ -125,18 +126,22 @@ function buildOrganismGenomesTableColumns(): ColumnDef<GA2AssemblyEntity>[] {
     },
     {
       accessorKey: GA2_CATEGORY_KEY.LENGTH,
+      cell: ({ getValue }) => formatNumber(getValue()),
       header: GA2_CATEGORY_LABEL.LENGTH,
     },
     {
       accessorKey: GA2_CATEGORY_KEY.SCAFFOLD_COUNT,
+      cell: ({ getValue }) => formatNumber(getValue()),
       header: GA2_CATEGORY_LABEL.SCAFFOLD_COUNT,
     },
     {
       accessorKey: GA2_CATEGORY_KEY.SCAFFOLD_N50,
+      cell: ({ getValue }) => formatNumber(getValue()),
       header: GA2_CATEGORY_LABEL.SCAFFOLD_N50,
     },
     {
       accessorKey: GA2_CATEGORY_KEY.SCAFFOLD_L50,
+      cell: ({ getValue }) => formatNumber(getValue()),
       header: GA2_CATEGORY_LABEL.SCAFFOLD_L50,
     },
     {


### PR DESCRIPTION
Closes #511.

This pull request updates the genome table columns in the GA2 catalog to improve the display of numeric data. The main change is the addition of number formatting for several columns, ensuring that values like length, scaffold count, scaffold N50, and scaffold L50 are presented in a more readable format.

Enhancements to table column rendering:

* Imported `formatNumber` from `common/viewModelBuilders` to enable consistent number formatting in the table columns.
* Updated the `buildOrganismGenomesTableColumns` function so that the `LENGTH`, `SCAFFOLD_COUNT`, `SCAFFOLD_N50`, and `SCAFFOLD_L50` columns now use `formatNumber` to format their cell values.

<img width="1346" height="508" alt="image" src="https://github.com/user-attachments/assets/ad53fd5e-0a52-491a-9ef6-94f2fff905c8" />
