### PR TITLE
content: custom analysis stepper tweak text (#954)

### DIFF
--- a/app/components/Entity/components/AnalysisMethod/components/CustomWorkflow/constants.ts
+++ b/app/components/Entity/components/AnalysisMethod/components/CustomWorkflow/constants.ts
@@ -16,6 +16,6 @@ export const CUSTOM_WORKFLOW: Workflow = {
   taxonomyId: null,
   trsId: "custom-workflow",
   workflowDescription:
-    "Select reads and tracks to send to a new Galaxy history with this assembly to analyze with your own tools or workflows.",
-  workflowName: "Custom Analysis",
+    "Send this assembly, its tracks, and ENA read runs to a new Galaxy history for analysis with your workflow.",
+  workflowName: "Send Data to a Galaxy History",
 };


### PR DESCRIPTION
Closes #954.

This pull request updates the workflow configuration for the custom analysis feature, focusing on clarifying its description and renaming the workflow for better user understanding.

Workflow configuration improvements:

* Updated the `workflowDescription` in `constants.ts` to clearly state that the assembly, tracks, and ENA read runs will be sent to a new Galaxy history for analysis with the user's workflow.
* Renamed the `workflowName` from "Custom Analysis" to "Send Data to a Galaxy History" for improved clarity and discoverability.

<img width="1416" height="1135" alt="image" src="https://github.com/user-attachments/assets/2bd89640-e884-4b5b-8eca-d0f7aa88b6d2" />
