### PR TITLE
feat: change view workflow details button to learn more link (#952)

### DIFF
--- a/app/components/Entity/components/AnalysisMethod/components/Workflow/constants.ts
+++ b/app/components/Entity/components/AnalysisMethod/components/Workflow/constants.ts
@@ -12,11 +12,3 @@ export const BUTTON_PROPS = {
   color: MUI_BUTTON_PROPS.COLOR.PRIMARY,
   variant: MUI_BUTTON_PROPS.VARIANT.CONTAINED,
 } satisfies ButtonProps;
-
-export const OUTLINED_BUTTON_PROPS = {
-  color: MUI_BUTTON_PROPS.COLOR.PRIMARY,
-  sx: {
-    padding: "7px 15px", // Reduced by 1px on each side to compensate for border
-  },
-  variant: MUI_BUTTON_PROPS.VARIANT.OUTLINED,
-} satisfies ButtonProps;

--- a/app/components/Entity/components/AnalysisMethod/components/Workflow/workflow.tsx
+++ b/app/components/Entity/components/AnalysisMethod/components/Workflow/workflow.tsx
@@ -1,17 +1,16 @@
 import { Button, Grid, Typography } from "@mui/material";
 import { Props } from "./types";
+import { Link as DXLink } from "@databiosphere/findable-ui/lib/components/Links/components/Link/link";
 import { StyledGrid } from "./workflow.styles";
 import { TYPOGRAPHY_PROPS as COMPONENT_TYPOGRAPHY_PROPS } from "../../constants";
-import { BUTTON_PROPS, GRID_PROPS, OUTLINED_BUTTON_PROPS } from "./constants";
-import {
-  ANCHOR_TARGET,
-  REL_ATTRIBUTE,
-} from "@databiosphere/findable-ui/lib/components/Links/common/entities";
+import { BUTTON_PROPS, GRID_PROPS } from "./constants";
+import { REL_ATTRIBUTE } from "@databiosphere/findable-ui/lib/components/Links/common/entities";
 import Link from "next/link";
 import { ROUTES } from "../../../../../../../routes/constants";
 import { replaceParameters } from "@databiosphere/findable-ui/lib/utils/replaceParameters";
 import { formatTrsId } from "../../../AnalysisMethodsCatalog/utils";
 import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
+import { Fragment } from "react";
 
 export const Workflow = ({ entityId, workflow }: Props): JSX.Element => {
   const { iwcId, workflowDescription, workflowName } = workflow;
@@ -23,6 +22,16 @@ export const Workflow = ({ entityId, workflow }: Props): JSX.Element => {
         </Typography>
         <Typography {...COMPONENT_TYPOGRAPHY_PROPS}>
           {workflowDescription}
+          {iwcId && (
+            <Fragment>
+              {" "}
+              <DXLink
+                color="inherit"
+                label="Learn More"
+                url={`https://iwc.galaxyproject.org/workflow/${iwcId}`}
+              />
+            </Fragment>
+          )}
         </Typography>
       </Grid>
       <Grid container spacing={1}>
@@ -40,22 +49,6 @@ export const Workflow = ({ entityId, workflow }: Props): JSX.Element => {
             Configure Inputs
           </Button>
         </Grid>
-        {iwcId && (
-          <Grid>
-            <Button
-              {...OUTLINED_BUTTON_PROPS}
-              onClick={(): void => {
-                window.open(
-                  `https://iwc.galaxyproject.org/workflow/${iwcId}`,
-                  ANCHOR_TARGET.BLANK,
-                  REL_ATTRIBUTE.NO_OPENER_NO_REFERRER
-                );
-              }}
-            >
-              View Workflow Details
-            </Button>
-          </Grid>
-        )}
       </Grid>
     </StyledGrid>
   );


### PR DESCRIPTION
Closes #952.

This pull request refactors how workflow details are linked in the UI and simplifies button usage in the workflow component. The main changes involve replacing a custom "View Workflow Details" button with a standard link component and removing unused button props.

**UI Refactoring and Link Handling:**

* Replaced the custom "View Workflow Details" button with a `DXLink` component labeled "Learn More" that links to the workflow details page, improving consistency and accessibility. [[1]](diffhunk://#diff-e0b75ab8221e59e4a0d12e481c77dbab95b3376876f175cff03fd64ece76a56cR25-R34) [[2]](diffhunk://#diff-e0b75ab8221e59e4a0d12e481c77dbab95b3376876f175cff03fd64ece76a56cL43-L58)
* Removed the import and usage of `OUTLINED_BUTTON_PROPS` and related constants, as the outlined button is no longer needed. [[1]](diffhunk://#diff-c921a99bdb0573dbbbd91fb8a0b0c15aea3177c007b29fa6bd06f8f81b7a7ee4L15-L22) [[2]](diffhunk://#diff-e0b75ab8221e59e4a0d12e481c77dbab95b3376876f175cff03fd64ece76a56cR3-R13)

**Code Cleanup:**

* Updated imports to remove unused entities and improve clarity, such as removing `ANCHOR_TARGET` and consolidating link-related imports.

<img width="1418" height="1250" alt="image" src="https://github.com/user-attachments/assets/0f10d644-58eb-4598-a636-6e549fb86116" />
