### PR TITLE
feat: don't clear pre-filters when no matches on sequencing runs (#973)

### DIFF
--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/CollectionSelector/utils.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/CollectionSelector/utils.ts
@@ -8,65 +8,6 @@ import {
 import { WORKFLOW_PARAMETER_BY_STEP_KEY } from "./constants";
 
 /**
- * Builds column filters from preselected values only if they are valid for the current data.
- * A set of preselected filters is considered valid if at least one row of data satisfies all column filters (AND across columns),
- * where each column filter matches if the row contains at least one of the desired values for that column (OR within a column).
- * If no rows satisfy the filters, an empty list is returned.
- *
- * Note: This does not mutate or filter out individual values; it validates the combination overall.
- *
- * @param rows - Rows (read runs).
- * @param preselectedFilters - Record of column IDs to arrays of desired filter values.
- * @returns Column filters state.
- */
-function buildValidatedColumnFilters<T>(
-  rows: T[],
-  preselectedFilters: Record<string, string[]>
-): ColumnFiltersState {
-  // We need to ensure that the combined column filters are valid for the given data.
-  // A row must have at least one of the desired values (OR-join) for each column filter (AND-join).
-  for (const row of rows) {
-    let isRowValid = true;
-
-    for (const [id, value] of Object.entries(preselectedFilters)) {
-      // Determine the filter set (we can safely assert the value as string array).
-      const filterValueSet = new Set(value as string[]);
-
-      // Determine the column values.
-      const columnValues = toStringArray(row[id as keyof T]);
-
-      // At least one of the desired values must be present in the column "OR".
-      let hasAny = false;
-      for (const v of columnValues) {
-        if (filterValueSet.has(v)) {
-          hasAny = true;
-          break;
-        }
-      }
-
-      // If the row is not valid, break (no need to check the rest of the columns).
-      if (!hasAny) {
-        isRowValid = false;
-        break;
-      }
-    }
-
-    // If the row is not valid, continue to the next row.
-    if (!isRowValid) continue;
-
-    // Found a valid row i.e. we know the pre-selected column filters will be a valid
-    // combination for the data. There is no need to continue checking the rest of the rows.
-    return Object.entries(preselectedFilters).map(([id, value]) => ({
-      id,
-      value,
-    }));
-  }
-
-  // No valid rows found, return empty column filters.
-  return [];
-}
-
-/**
  * Gets library strategy requirements from a workflow parameter.
  * @param parameter - The workflow parameter.
  * @returns Array of library strategy values or null if not specified.
@@ -195,29 +136,16 @@ export function buildFilters(
 /**
  * Pre-selects column filters based on the given step key for ENA query method by taxonomy ID.
  * @param workflow - Workflow.
- * @param rows - Rows (read runs).
  * @param stepKey - Step key.
  * @returns Column filters for the given ENA data.
  */
-export function preSelectColumnFilters<T>(
+export function preSelectColumnFilters(
   workflow: Workflow,
-  rows: T[],
   stepKey:
     | SEQUENCING_DATA_TYPE.READ_RUNS_PAIRED
     | SEQUENCING_DATA_TYPE.READ_RUNS_SINGLE
 ): ColumnFiltersState {
   const workflowParameter = getWorkflowParameter(workflow, stepKey);
   const filters = buildFilters(stepKey, workflowParameter);
-  return buildValidatedColumnFilters(rows, filters);
-}
-
-/**
- * Converts a value to an array of strings.
- * @param value - The value to convert.
- * @returns An array of strings.
- */
-function toStringArray(value: unknown): string[] {
-  if (value === null) return [];
-  if (Array.isArray(value)) return value.map(String);
-  return [String(value)];
+  return Object.entries(filters).map(([id, value]) => ({ id, value }));
 }

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/hooks/UseENADataByTaxonomyId/hook.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/hooks/UseENADataByTaxonomyId/hook.ts
@@ -33,13 +33,11 @@ export const useENADataByTaxonomyId = <T>(
             setErrors({ taxonomyId: e.message });
             setLoading(false);
           },
-          onSuccess: (readRuns) => {
+          onSuccess: () => {
             setLoading(false);
             // If the step key is READ_RUNS_ANY, do not pre-select column filters.
             if (stepKey === SEQUENCING_DATA_TYPE.READ_RUNS_ANY) return;
-            setColumnFilters(
-              preSelectColumnFilters(workflow, readRuns, stepKey)
-            );
+            setColumnFilters(preSelectColumnFilters(workflow, stepKey));
           },
         },
         taxonomyId,


### PR DESCRIPTION
Closes #973.

This pull request refactors how column filters are pre-selected for ENA sequencing data in the workflow configuration UI. The main change is the removal of validation logic that checked if preselected filters matched any data rows, simplifying filter selection to always use workflow-defined defaults. This streamlines the filter selection process and reduces complexity in both the utility and hook files.

**Refactoring and simplification of filter selection:**

* Removed the `buildValidatedColumnFilters` function from `CollectionSelector/utils.ts`, eliminating the logic that validated preselected filters against actual data rows. Now, filters are always pre-selected based on workflow parameters without checking if they match the data.
* Simplified the `preSelectColumnFilters` function in `CollectionSelector/utils.ts` by removing the `rows` parameter and returning workflow-defined filters directly.
* Updated the `useENADataByTaxonomyId` hook in `UseENADataByTaxonomyId/hook.ts` to use the new simplified `preSelectColumnFilters` function, no longer passing data rows to it.

<img width="1563" height="1141" alt="image" src="https://github.com/user-attachments/assets/2ef8e7e0-b788-4642-b64a-3f19449c0031" />
