### PR TITLE
fix: fix warnings  (#970)

### DIFF
--- a/app/components/Docs/components/SectionContent/sectionContent.styles.ts
+++ b/app/components/Docs/components/SectionContent/sectionContent.styles.ts
@@ -20,7 +20,10 @@ import { Outline } from "@databiosphere/findable-ui/lib/components/Layout/compon
 export const PADDING_Y = 64;
 
 export const StyledContentLayout = styled(ContentLayout, {
-  shouldForwardProp: (propName) => propName !== "contentType",
+  shouldForwardProp: (propName) =>
+    propName !== "contentType" &&
+    propName !== "hasNavigation" &&
+    propName !== "panelColor",
 })<Pick<FrontmatterProps, "contentType">>`
   ${(props) =>
     props.contentType !== CONTENT_TYPE.ARTICLE &&
@@ -59,7 +62,10 @@ export const StyledContent = styled(Content, {
 `;
 
 export const StyledOutlineGrid = styled(OutlineGrid, {
-  shouldForwardProp: (propName) => propName !== "contentType",
+  shouldForwardProp: (propName) =>
+    propName !== "contentType" &&
+    propName !== "headerHeight" &&
+    propName !== "panelColor",
 })<Pick<FrontmatterProps, "contentType">>`
   ${(props) =>
     props.contentType !== CONTENT_TYPE.ARTICLE &&


### PR DESCRIPTION
Closes #970.

This pull request makes minor updates to the prop forwarding logic in styled components within `sectionContent.styles.ts`. The changes ensure that certain props are not forwarded to underlying DOM elements, which helps prevent React warnings and potential styling issues.

Prop forwarding improvements:

* Updated `StyledContentLayout` to exclude `hasNavigation` and `panelColor` props from being forwarded, in addition to `contentType`.
* Updated `StyledOutlineGrid` to exclude `headerHeight` and `panelColor` props from being forwarded, in addition to `contentType`.