### PR TITLE
feat: provide names for collections sent to galaxy landing apis (#994)

### DIFF
--- a/app/utils/galaxy-api/galaxy-api.ts
+++ b/app/utils/galaxy-api/galaxy-api.ts
@@ -341,6 +341,7 @@ function buildSingleReadRunsRequestValue(
         url: forward.url,
       };
     }),
+    identifier: "Single reads",
   };
 }
 
@@ -375,6 +376,7 @@ function buildPairedReadRunsRequestValue(
         identifier: runAccession,
       };
     }),
+    identifier: "Paired reads",
   };
 }
 


### PR DESCRIPTION
## Description

Added `identifier` fields to the abstract models generated for paired and single collections, which are translated to `name` fields when sent to the workflow and data landing APIs

## Related Issue

Closes #994
