### PR TITLE
feat: remove custom workflow feature flag (#997)

### DIFF
--- a/app/components/Entity/components/AnalysisMethodsCatalog/analysisMethodsCatalog.tsx
+++ b/app/components/Entity/components/AnalysisMethodsCatalog/analysisMethodsCatalog.tsx
@@ -2,7 +2,6 @@ import { AnalysisMethod } from "../AnalysisMethod/analysisMethod";
 import { Props } from "./types";
 import { useRouter } from "next/router";
 import { Fragment } from "react";
-import { useFeatureFlag } from "@databiosphere/findable-ui/lib/hooks/useFeatureFlag/useFeatureFlag";
 import { CustomWorkflow } from "../AnalysisMethod/components/CustomWorkflow/customWorkflow";
 import { AnalysisTypeHeader } from "./components/AnalysisTypeHeader/analysisTypeHeader";
 import { Stack } from "@mui/material";
@@ -14,7 +13,6 @@ export const AnalysisMethodsCatalog = ({ assembly }: Props): JSX.Element => {
     assembly,
     WORKFLOW_CATEGORIES
   );
-  const isFeatureEnabled = useFeatureFlag("custom-workflow");
 
   const {
     query: { entityId },
@@ -23,15 +21,13 @@ export const AnalysisMethodsCatalog = ({ assembly }: Props): JSX.Element => {
   return (
     <Stack gap={8} useFlexGap>
       {/* Custom Analysis */}
-      {isFeatureEnabled && (
-        <Stack gap={4} useFlexGap>
-          <AnalysisTypeHeader
-            description="Prefer to explore the data without a predefined workflow?"
-            title="Custom Analysis"
-          />
-          <CustomWorkflow entityId={entityId as string} />
-        </Stack>
-      )}
+      <Stack gap={4} useFlexGap>
+        <AnalysisTypeHeader
+          description="Prefer to explore the data without a predefined workflow?"
+          title="Custom Analysis"
+        />
+        <CustomWorkflow entityId={entityId as string} />
+      </Stack>
       <Stack gap={4} useFlexGap>
         {/* Workflow Analysis */}
         <AnalysisTypeHeader

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -21,12 +21,9 @@ import { config } from "../app/config/config";
 import { mergeAppTheme } from "../app/theme/theme";
 import { GoogleSignInAuthenticationProvider } from "@databiosphere/findable-ui/lib/providers/googleSignInAuthentication/provider";
 import { ServicesProvider } from "@databiosphere/findable-ui/lib/providers/services/provider";
-import { setFeatureFlags } from "@databiosphere/findable-ui/lib/hooks/useFeatureFlag/common/utils";
 
 const DEFAULT_ENTITY_LIST_TYPE = "organisms";
 import "../app/styles/fonts/fonts.css";
-
-setFeatureFlags(["custom-workflow"]);
 
 export interface PageProps extends AzulEntitiesStaticResponse {
   pageTitle?: string;

--- a/pages/data/[entityListType]/[entityId]/[trsId]/index.tsx
+++ b/pages/data/[entityListType]/[entityId]/[trsId]/index.tsx
@@ -22,8 +22,6 @@ import { getEntityConfig } from "@databiosphere/findable-ui/lib/config/utils";
 import { WorkflowInputsView } from "../../../../../app/views/WorkflowInputsView/workflowInputsView";
 import { GA2AssemblyEntity } from "../../../../../app/apis/catalog/ga2/entities";
 import { CUSTOM_WORKFLOW } from "../../../../../app/components/Entity/components/AnalysisMethod/components/CustomWorkflow/constants";
-import Error from "next/error";
-import { useFeatureFlag } from "@databiosphere/findable-ui/lib/hooks/useFeatureFlag/useFeatureFlag";
 
 interface StaticPath {
   params: PageUrlParams;
@@ -112,9 +110,6 @@ export const getStaticProps = async (
 };
 
 const ConfigureWorkflowInputs = (props: Props): JSX.Element => {
-  const isFeatureEnabled = useFeatureFlag("custom-workflow");
-  if (props.workflow.trsId === CUSTOM_WORKFLOW.trsId && !isFeatureEnabled)
-    return <Error statusCode={404} />;
   return <WorkflowInputsView {...props} />;
 };
 


### PR DESCRIPTION
Closes #997.

This pull request removes the use of the `custom-workflow` feature flag and its related logic from the codebase. The main impact is that the custom workflow functionality is now always enabled, simplifying the code and removing conditional rendering based on the feature flag.

Feature flag removal and code simplification:

* Removed all imports and usage of `useFeatureFlag` and `setFeatureFlags` related to the `custom-workflow` feature flag from `analysisMethodsCatalog.tsx`, `_app.tsx`, and dynamic workflow page files. [[1]](diffhunk://#diff-7b276a625e6dcd5e1d02b1b0b40d198e320da98cdaac244fb4b87fa7c543af0dL5) [[2]](diffhunk://#diff-a9827ce1be32c607c948881a89b99c592f752898f9c49e0dea0b7199eb151029L24-L30) [pages/data/[entityListType]/[entityId]/[trsId]/index.tsxL25-L26](diffhunk://#diff-e32d811d95d3263141f882b75b77b7e9a123e46e831de9ba327777b2d844cd17L25-L26))
* Eliminated conditional rendering and error handling logic that previously hid or blocked the custom workflow UI when the feature flag was disabled. Now, the custom workflow section and related routes are always available. [[1]](diffhunk://#diff-7b276a625e6dcd5e1d02b1b0b40d198e320da98cdaac244fb4b87fa7c543af0dL17) [[2]](diffhunk://#diff-7b276a625e6dcd5e1d02b1b0b40d198e320da98cdaac244fb4b87fa7c543af0dL26-L34) [pages/data/[entityListType]/[entityId]/[trsId]/index.tsxL115-L117](diffhunk://#diff-e32d811d95d3263141f882b75b77b7e9a123e46e831de9ba327777b2d844cd17L115-L117))