### PR TITLE
feat: see how large we can make the read run count limit (#1012)

### DIFF
--- a/site-config/brc-analytics/local/config.ts
+++ b/site-config/brc-analytics/local/config.ts
@@ -113,7 +113,7 @@ export function makeConfig(
         socialMedia: socialMedia,
       },
     },
-    maxReadRunsForBrowseAll: 2000,
+    maxReadRunsForBrowseAll: 60000,
     redirectRootToPath: "/",
     taxTree: taxTreeData,
     themeOptions: THEME_OPTIONS,

--- a/site-config/ga2/local/config.ts
+++ b/site-config/ga2/local/config.ts
@@ -84,7 +84,7 @@ export function makeConfig(
         ],
       },
     },
-    maxReadRunsForBrowseAll: 4000,
+    maxReadRunsForBrowseAll: 60000,
     redirectRootToPath: "/",
     taxTree: taxTreeData,
     themeOptions: THEME_OPTIONS,


### PR DESCRIPTION
Closes #1012.

This pull request increases the limit for the `maxReadRunsForBrowseAll` configuration setting in two local site config files. This change will allow users to browse a much larger number of runs in the application.

Configuration updates:

* Increased `maxReadRunsForBrowseAll` from 2000 to 60000 in `site-config/brc-analytics/local/config.ts` to support browsing more runs.
* Increased `maxReadRunsForBrowseAll` from 4000 to 60000 in `site-config/ga2/local/config.ts` to support browsing more runs.