### PR TITLE
fix: use globus http url instead of ena ftp (1017)

### DIFF
--- a/app/utils/galaxy-api/galaxy-api.ts
+++ b/app/utils/galaxy-api/galaxy-api.ts
@@ -25,6 +25,8 @@ import {
 import { UcscTrack } from "../ucsc-tracks-api/entities";
 
 const DOCKSTORE_API_URL = "https://dockstore.org/api/ga4gh/trs/v2/tools";
+const FTP_HOST = "ftp.sra.ebi.ac.uk";
+const GLOBUS_HOST = "g-a8b222.dd271.03c0.data.globus.org";
 
 const galaxyInstanceUrl = process.env.NEXT_PUBLIC_GALAXY_INSTANCE_URL;
 
@@ -444,7 +446,7 @@ function getRunUrlsInfo(
   if (splitUrls.length === 1) {
     // Single read case
     return {
-      forward: { md5: splitMd5Hashes[0], url: `ftp://${splitUrls[0]}` },
+      forward: { md5: splitMd5Hashes[0], url: ftpToGlobusHttp(splitUrls[0]) },
       reverse: null,
     };
   }
@@ -457,13 +459,18 @@ function getRunUrlsInfo(
     const [, , readIndex] = urlMatch;
     const fileInfo: EnaFileInfo = {
       md5: splitMd5Hashes[i],
-      url: `ftp://${url}`,
+      url: ftpToGlobusHttp(url),
     };
     if (readIndex === "1") forward = fileInfo;
     else reverse = fileInfo;
   }
   if (forward === null) throw new Error("No URL for forward read found");
   return { forward, reverse };
+}
+
+function ftpToGlobusHttp(ftpUrl: string): string {
+  // should be more reliable than FTP download
+  return `https://${ftpUrl.replace(FTP_HOST, GLOBUS_HOST)}`;
 }
 
 function buildUcscTracksRequestValues(


### PR DESCRIPTION
## Description

Replaces FTP link with globus HTTP link. More details in https://github.com/galaxyproject/galaxy/issues/21321

Should get confirmation from ENA that this is indeed a / the sanctioned way to do this.

## Related Issue

https://github.com/galaxyproject/galaxy/issues/21321