### PR TITLE
content: remove ai codeathon notice from the home carousel (#1019)

### DIFF
--- a/app/components/Home/components/Section/components/SectionHero/components/Carousel/cards/constants.ts
+++ b/app/components/Home/components/Section/components/SectionHero/components/Carousel/cards/constants.ts
@@ -3,9 +3,6 @@ import * as MDX from "../content";
 
 export const CAROUSEL_CARDS: Pick<CardProps, "text">[] = [
   {
-    text: MDX.Codeathon2025({}),
-  },
-  {
     text: MDX.EvolutionaryDynamicsOfCodingOverlapsInMeaslesVirus({}),
   },
   {

--- a/app/components/Home/components/Section/components/SectionHero/components/Carousel/content/codeathon2025.mdx
+++ b/app/components/Home/components/Section/components/SectionHero/components/Carousel/content/codeathon2025.mdx
@@ -1,5 +1,0 @@
-### AI Codeathon 2025
-
-Join us for a three-day hands-on AI Codeathon uniting experts to tackle critical challenges in infectious disease research using artificial intelligence (AI) and large language models (LLMs), sponsored by the NIAID BRCs.
-
-[Register here!](https://www.bv-brc.org/brc-niaid-ai-codeathon-2025)

--- a/app/components/Home/components/Section/components/SectionHero/components/Carousel/content/index.tsx
+++ b/app/components/Home/components/Section/components/SectionHero/components/Carousel/content/index.tsx
@@ -2,6 +2,5 @@ export { default as ShareUsageAndJoinAdvisoryPanel } from "./shareUsageAndJoinAd
 export { default as Webinar20250326 } from "./webinar20250326.mdx";
 export { default as Webinars } from "./webinars.mdx";
 export { default as Roadmap } from "./roadmap.mdx";
-export { default as Codeathon2025 } from "./codeathon2025.mdx";
 export { default as WebinarSeries } from "./webinarSeries.mdx";
 export { default as EvolutionaryDynamicsOfCodingOverlapsInMeaslesVirus } from "./evolutionary-dynamics-of-coding-overlaps-in-measles-virus.mdx";


### PR DESCRIPTION
Closes #1019.

This pull request removes all references and content related to the "AI Codeathon 2025" event from the carousel section on the home page. The changes ensure that the codeathon card and its associated content are no longer displayed or imported.

**Removal of AI Codeathon 2025 content:**

* Deleted the `codeathon2025.mdx` file, which contained the description and registration link for the event.
* Removed the import and export of `Codeathon2025` from the carousel content index (`index.tsx`).
* Removed the codeathon card from the `CAROUSEL_CARDS` array so it will not be shown in the carousel.

