### PR TITLE
fix: add missing dependency for fetch organism image step

### DIFF
--- a/catalog/ga2/build/py/requirements.txt
+++ b/catalog/ga2/build/py/requirements.txt
@@ -3,6 +3,8 @@ antlr4-python3-runtime==4.9.3
 arrow==1.3.0
 attrs==25.1.0
 beautifulsoup4==4.13.3
+boto3==1.40.57
+botocore==1.40.76
 certifi==2024.8.30
 CFGraph==0.2.1
 chardet==5.2.0


### PR DESCRIPTION
Added boto3 and botocore dependencies to requirements.

## Description

Brief description of the changes made in this PR.

## Related Issue

If this addresses an existing GitHub issue, link it here (e.g., "Closes #123"). If no existing issue exists, consider creating one first to discuss the changes.
