### PR TITLE
refactor: limit column width for organism image, in assembly list page

### DIFF
--- a/site-config/ga2/local/index/genome/columnDefs.ts
+++ b/site-config/ga2/local/index/genome/columnDefs.ts
@@ -269,5 +269,5 @@ export const ORGANISM_IMAGE: ColumnConfig<GA2AssemblyEntity> = {
   } as ComponentConfig<typeof C.OrganismAvatar, GA2AssemblyEntity>,
   header: GA2_CATEGORY_LABEL.ORGANISM_AVATAR,
   id: GA2_CATEGORY_KEY.ORGANISM_AVATAR,
-  width: { max: "1fr", min: "auto" },
+  width: { max: "100px", min: "100px" },
 };


### PR DESCRIPTION
## Description

This will limit the column width for the assembly image in the assembly list from

<img width="2315" height="494" alt="Screenshot from 2025-12-05 09-18-46" src="https://github.com/user-attachments/assets/e66f24bb-fc99-4f57-aa67-fe3f7bb7a3c7" />

to 

<img width="2315" height="494" alt="Screenshot from 2025-12-05 09-19-00" src="https://github.com/user-attachments/assets/85b3d3c8-2d1a-4e7e-950b-7fa55fe5b6b3" />


## Related Issue

If this addresses an existing GitHub issue, link it here (e.g., "Closes #123"). If no existing issue exists, consider creating one first to discuss the changes.
