### PR TITLE
fix: dedup veupath gtf and improve display name

### DIFF
--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/GTFStep/hooks/UseUCSCFiles/utils.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/GTFStep/hooks/UseUCSCFiles/utils.ts
@@ -20,5 +20,5 @@ export function parseUCSCFilesResult(response: Result): string[] {
  * @returns True if the URL ends with ".gtf.gz".
  */
 function filterGFTFile(url: string): boolean {
-  return url.endsWith(".gtf.gz");
+  return url.includes("/genes/") && url.endsWith(".gtf.gz");
 }

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/GTFStep/hooks/UseUCSCFiles/utils.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/GTFStep/hooks/UseUCSCFiles/utils.ts
@@ -17,7 +17,7 @@ export function parseUCSCFilesResult(response: Result): string[] {
 /**
  * Filters the GTF file URLs from the UCSC files API response.
  * @param url - URL.
- * @returns True if the URL ends with ".gtf.gz".
+ * @returns True if the URL lives under the UCSC genes directory and ends with ".gtf.gz".
  */
 function filterGFTFile(url: string): boolean {
   return url.includes("/genes/") && url.endsWith(".gtf.gz");

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/GTFStep/utils.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/GTFStep/utils.ts
@@ -48,6 +48,7 @@ export const getGeneModelLabel = (url: string): string => {
     [/\.ncbiRefSeq\./, "NCBI RefSeq"],
     [/\.ncbiGene\./, "NCBI Gene"],
     [/\.xenoRefGene\./, "UCSC Xeno RefGene"],
+    [/veupathGenes\./i, "VEuPathDB"],
   ];
 
   for (const [pattern, label] of labelPatterns) {


### PR DESCRIPTION
## Description

this does two things:
1. adds display name for veupath gtf files
2. makes sure we only pull gtf from the /genes path, not the contributor path. this will ensure when we display options that were contributed to ucsc, we only show them once.