### PR TITLE
feat: create the all v all option in the primary contrasts stepper step (#1078)

### DIFF
--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PrimaryContrastsStep/components/RadioGroup/constants.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PrimaryContrastsStep/components/RadioGroup/constants.ts
@@ -4,7 +4,7 @@ import { RadioGroupOption } from "./types";
 export const OPTIONS: RadioGroupOption[] = [
   {
     description: "Generate all pairwise comparisons between levels",
-    disabled: true,
+    disabled: false,
     label: "Compare All Against All",
     value: CONTRAST_MODE.ALL_AGAINST_ALL,
   },

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PrimaryContrastsStep/primaryContrastsStep.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PrimaryContrastsStep/primaryContrastsStep.tsx
@@ -9,7 +9,11 @@ import { STEP } from "./step";
 import { RadioGroup } from "./components/RadioGroup/radioGroup";
 import { ExplicitPairs } from "./components/ExplicitPairs/explicitPairs";
 import { useExplicitContrasts } from "./hooks/UseExplicitContrasts/hook";
-import { getUniqueFactorValues } from "./utils";
+import {
+  buildPrimaryContrasts,
+  getUniqueFactorValues,
+  isDisabled,
+} from "./utils";
 import { getValidPairs } from "./hooks/UseExplicitContrasts/utils";
 import { useRadioGroup } from "../hooks/UseRadioGroup/hook";
 import { CONTRAST_MODE } from "./hooks/UseRadioGroup/types";
@@ -25,7 +29,7 @@ export const PrimaryContrastsStep = ({
   onContinue,
   onEdit,
 }: StepProps): JSX.Element => {
-  const radioGroup = useRadioGroup(CONTRAST_MODE.EXPLICIT);
+  const radioGroup = useRadioGroup(CONTRAST_MODE.ALL_AGAINST_ALL);
 
   const factorValues = useMemo(
     () => getUniqueFactorValues(configuredInput),
@@ -61,13 +65,13 @@ export const PrimaryContrastsStep = ({
         <StyledStack>
           <Button
             {...BUTTON_PROPS.PRIMARY_CONTAINED}
-            disabled={!valid}
+            disabled={isDisabled(radioGroup.value, valid)}
             onClick={() => {
               onConfigure({
-                [STEP.key]: {
-                  pairs: getValidPairs(pairs),
-                  type: radioGroup.value,
-                },
+                [STEP.key]: buildPrimaryContrasts(
+                  radioGroup.value,
+                  getValidPairs(pairs)
+                ),
               });
               onContinue();
             }}

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PrimaryContrastsStep/utils.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PrimaryContrastsStep/utils.ts
@@ -1,4 +1,39 @@
-import { ConfiguredInput } from "../../../../../../../../../../../views/WorkflowInputsView/hooks/UseConfigureInputs/types";
+import {
+  ConfiguredInput,
+  PrimaryContrasts,
+} from "../../../../../../../../../../../views/WorkflowInputsView/hooks/UseConfigureInputs/types";
+import { CONTRAST_MODE } from "./hooks/UseRadioGroup/types";
+import { ContrastPair } from "./hooks/UseExplicitContrasts/types";
+
+/**
+ * Builds the primary contrasts configuration based on mode and pairs.
+ * @param mode - The selected contrast mode.
+ * @param pairs - Valid pairs for explicit mode.
+ * @returns PrimaryContrasts configuration object.
+ */
+export function buildPrimaryContrasts(
+  mode: CONTRAST_MODE,
+  pairs: ContrastPair[]
+): PrimaryContrasts {
+  if (mode === CONTRAST_MODE.EXPLICIT) return { pairs, type: mode };
+
+  return { type: mode as CONTRAST_MODE.ALL_AGAINST_ALL };
+}
+
+/**
+ * Determines if the continue button should be disabled based on mode and validation state.
+ * @param mode - The selected contrast mode.
+ * @param isExplicitValid - Whether explicit pairs are valid.
+ * @returns True if the button should be disabled.
+ */
+export function isDisabled(
+  mode: CONTRAST_MODE,
+  isExplicitValid: boolean
+): boolean {
+  if (mode === CONTRAST_MODE.EXPLICIT) return !isExplicitValid;
+
+  return false;
+}
 
 /**
  * Extracts unique values from the primary factor column in the sample sheet.

--- a/app/views/WorkflowInputsView/hooks/UseConfigureInputs/types.ts
+++ b/app/views/WorkflowInputsView/hooks/UseConfigureInputs/types.ts
@@ -2,6 +2,10 @@ import { EnaSequencingReads } from "app/utils/galaxy-api/entities";
 import { UcscTrack } from "../../../../utils/ucsc-tracks-api/entities";
 import { COLUMN_TYPE } from "../../../../components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SampleSheetClassificationStep/types";
 
+export interface AllVAllContrasts {
+  type: "ALL_AGAINST_ALL";
+}
+
 export interface ConfiguredInput {
   designFormula?: string | null;
   geneModelUrl?: string | null;
@@ -22,7 +26,7 @@ export interface ExplicitContrasts {
 
 export type OnConfigure = (configuredInput: Partial<ConfiguredInput>) => void;
 
-export type PrimaryContrasts = ExplicitContrasts;
+export type PrimaryContrasts = AllVAllContrasts | ExplicitContrasts;
 
 export interface UseConfigureInputs {
   configuredInput: ConfiguredInput;

--- a/tests/configureWorkflow/primaryContrastsStep/utils.test.ts
+++ b/tests/configureWorkflow/primaryContrastsStep/utils.test.ts
@@ -1,4 +1,53 @@
-import { getUniqueFactorValues } from "../../../app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PrimaryContrastsStep/utils";
+import {
+  buildPrimaryContrasts,
+  getUniqueFactorValues,
+  isDisabled,
+} from "../../../app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PrimaryContrastsStep/utils";
+import { CONTRAST_MODE } from "../../../app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PrimaryContrastsStep/hooks/UseRadioGroup/types";
+
+describe("buildPrimaryContrasts", () => {
+  test("returns type only for ALL_AGAINST_ALL mode", () => {
+    const result = buildPrimaryContrasts(CONTRAST_MODE.ALL_AGAINST_ALL, [
+      ["control", "treated"],
+    ]);
+
+    expect(result).toEqual({ type: "ALL_AGAINST_ALL" });
+  });
+
+  test("returns type and pairs for EXPLICIT mode", () => {
+    const pairs: [string, string][] = [
+      ["control", "treated"],
+      ["baseline", "experiment"],
+    ];
+
+    const result = buildPrimaryContrasts(CONTRAST_MODE.EXPLICIT, pairs);
+
+    expect(result).toEqual({ pairs, type: "EXPLICIT" });
+  });
+
+  test("returns empty pairs array for EXPLICIT mode with no pairs", () => {
+    const result = buildPrimaryContrasts(CONTRAST_MODE.EXPLICIT, []);
+
+    expect(result).toEqual({ pairs: [], type: "EXPLICIT" });
+  });
+});
+
+describe("isDisabled", () => {
+  test("returns false for ALL_AGAINST_ALL mode regardless of validation", () => {
+    expect(isDisabled(CONTRAST_MODE.ALL_AGAINST_ALL, false)).toBe(false);
+    expect(isDisabled(CONTRAST_MODE.ALL_AGAINST_ALL, true)).toBe(false);
+  });
+
+  test("returns inverse of validation state for EXPLICIT mode", () => {
+    expect(isDisabled(CONTRAST_MODE.EXPLICIT, false)).toBe(true);
+    expect(isDisabled(CONTRAST_MODE.EXPLICIT, true)).toBe(false);
+  });
+
+  test("returns false for BASELINE mode regardless of validation", () => {
+    expect(isDisabled(CONTRAST_MODE.BASELINE, false)).toBe(false);
+    expect(isDisabled(CONTRAST_MODE.BASELINE, true)).toBe(false);
+  });
+});
 
 describe("getUniqueFactorValues", () => {
   test("extracts unique values from primary factor column", () => {


### PR DESCRIPTION
Closes #1078.

This pull request updates the logic for configuring primary contrasts in the workflow input step, mainly to support and enable the "All Against All" comparison mode. It introduces new utility functions for handling contrast configuration, updates the UI to default to and allow "All Against All" selection, and extends type definitions and tests to support these changes.

**Primary Contrasts Logic and UI:**
- The "Compare All Against All" option in the radio group is now enabled, allowing users to select this mode for contrasts.
- The contrast selection UI now defaults to "ALL_AGAINST_ALL" mode instead of "EXPLICIT".
- The continue button's enabled/disabled state is determined by the new `isDisabled` utility, which accounts for the selected contrast mode and validation state. [[1]](diffhunk://#diff-98ba5da4516898b3ebc467d437920d81203dbe5ec9f3087a4ed8abda573fb6d3L64-R74) [[2]](diffhunk://#diff-ebc72f92003801eabc94608db93c593964e6fed6a64917fd9c9f62c01e148661L1-R36)
- When continuing, the configuration is constructed using the new `buildPrimaryContrasts` function, which builds the correct object shape depending on the selected mode. [[1]](diffhunk://#diff-98ba5da4516898b3ebc467d437920d81203dbe5ec9f3087a4ed8abda573fb6d3L64-R74) [[2]](diffhunk://#diff-ebc72f92003801eabc94608db93c593964e6fed6a64917fd9c9f62c01e148661L1-R36)

**Type Definitions:**
- Added the `AllVAllContrasts` interface and updated the `PrimaryContrasts` type to support both "ALL_AGAINST_ALL" and "EXPLICIT" modes. [[1]](diffhunk://#diff-175e93b754fcc9596961cf44fa358200087ffdb8e4b384537da97e5adb6b56baR5-R8) [[2]](diffhunk://#diff-175e93b754fcc9596961cf44fa358200087ffdb8e4b384537da97e5adb6b56baL25-R29)

**Utilities and Testing:**
- Introduced `buildPrimaryContrasts` and `isDisabled` utility functions to encapsulate logic for constructing contrast configurations and determining button state.
- Added comprehensive tests for the new utility functions to ensure correct behavior for all contrast modes.

**Imports and Code Organization:**
- Updated imports in the main step component to include new utilities.

<img width="1452" height="1189" alt="image" src="https://github.com/user-attachments/assets/5a1a96f1-4b56-41b2-844e-5197d154df02" />
