### PR TITLE
feat: add sectionwhitepapers component to homepage (#1108)

### DIFF
--- a/app/components/Home/components/Section/components/SectionSubHero/sectionSubHero.styles.ts
+++ b/app/components/Home/components/Section/components/SectionSubHero/sectionSubHero.styles.ts
@@ -10,7 +10,6 @@ import { FONT } from "@databiosphere/findable-ui/lib/styles/common/constants/fon
 
 export const Section = styled.section`
   background-color: ${PALETTE.COMMON_WHITE};
-  border-top: 1px solid ${PALETTE.SMOKE_MAIN};
   width: 100%;
 `;
 
@@ -18,7 +17,7 @@ export const SectionLayout = styled.div`
   display: grid;
   gap: 48px 16px;
   grid-template-columns: 1fr 1fr;
-  padding: 72px 0 104px;
+  padding: 80px 0 104px;
 
   ${bpDownSm} {
     grid-template-columns: repeat(12, 1fr);

--- a/app/components/Home/components/Section/components/SectionWhitePapers/constants.ts
+++ b/app/components/Home/components/Section/components/SectionWhitePapers/constants.ts
@@ -1,0 +1,19 @@
+import { WhitePaper } from "./types";
+
+export const WHITE_PAPERS: WhitePaper[] = [
+  {
+    date: "2025-10-29",
+    href: "/learn/featured-analyses/evolutionary-dynamics-of-coding-overlaps-in-measles",
+    imageSrc:
+      "/learn/featured-analyses/evolutionary-dynamics-of-coding-overlaps-in-measles/hero.webp",
+    title:
+      "From data to publication in a browser with BRC-Analytics: Evolutionary dynamics of coding overlaps in measles virus",
+  },
+  {
+    date: "2026-01-13",
+    href: "/learn/featured-analyses/standardizing-rnaseq-candidozyma-auris",
+    imageSrc: "/learn/featured-analyses/expression-analysis-scatter.webp",
+    title:
+      "Standardizing RNA-seq Analysis of Fungal Pathogens Using BRC-Analytics and Agentic AI: A Candidozyma auris Case Study",
+  },
+];

--- a/app/components/Home/components/Section/components/SectionWhitePapers/sectionWhitePapers.styles.ts
+++ b/app/components/Home/components/Section/components/SectionWhitePapers/sectionWhitePapers.styles.ts
@@ -1,0 +1,59 @@
+import { bpUpSm } from "@databiosphere/findable-ui/lib/styles/common/mixins/breakpoints";
+import { PALETTE } from "@databiosphere/findable-ui/lib/styles/common/constants/palette";
+import styled from "@emotion/styled";
+import { sectionLayout } from "../../../../../Layout/components/AppLayout/components/Section/section.styles";
+import { Card, Divider } from "@mui/material";
+
+export const Section = styled.section`
+  background-color: ${PALETTE.COMMON_WHITE};
+  border-top: 1px solid ${PALETTE.SMOKE_MAIN};
+  width: 100%;
+`;
+
+export const SectionLayout = styled.div`
+  ${sectionLayout};
+  display: flex;
+  flex-direction: column;
+  gap: 48px 16px;
+  padding: 64px 16px 60px;
+`;
+
+export const StyledGrid = styled.div`
+  display: grid;
+  gap: 48px 16px;
+
+  ${bpUpSm} {
+    grid-template-columns: repeat(2, 1fr);
+  }
+`;
+
+export const StyledCard = styled(Card)`
+  .MuiCardActionArea-root {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    text-decoration: none;
+
+    &:hover {
+      .MuiCardActionArea-focusHighlight {
+        opacity: 0;
+      }
+    }
+  }
+
+  .MuiCardContent-root {
+    align-self: flex-start;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 0;
+
+    .MuiTypography-heading-small {
+      max-width: 504px;
+    }
+  }
+`;
+
+export const StyledDivider = styled(Divider)`
+  ${sectionLayout};
+`;

--- a/app/components/Home/components/Section/components/SectionWhitePapers/sectionWhitePapers.tsx
+++ b/app/components/Home/components/Section/components/SectionWhitePapers/sectionWhitePapers.tsx
@@ -1,0 +1,50 @@
+import { JSX } from "react";
+import Link from "next/link";
+import { formatDate } from "../../../../../../utils/date-fns";
+import { WHITE_PAPERS } from "./constants";
+import {
+  Section,
+  SectionLayout,
+  StyledCard,
+  StyledDivider,
+  StyledGrid,
+} from "./sectionWhitePapers.styles";
+import { SectionTitle } from "../../section.styles";
+import {
+  CardActionArea,
+  CardContent,
+  CardMedia,
+  Typography,
+} from "@mui/material";
+import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
+
+export const SectionWhitePapers = (): JSX.Element => {
+  return (
+    <Section>
+      <SectionLayout>
+        <SectionTitle>Analyzed on BRC Analytics</SectionTitle>
+        <StyledGrid>
+          {WHITE_PAPERS.map(({ date, href, imageSrc, title }) => (
+            <StyledCard key={title} elevation={0}>
+              <CardActionArea component={Link} href={href}>
+                <CardMedia alt={title} component="img" src={imageSrc} />
+                <CardContent>
+                  <Typography variant={TYPOGRAPHY_PROPS.VARIANT.HEADING_SMALL}>
+                    {title}
+                  </Typography>
+                  <Typography
+                    color={TYPOGRAPHY_PROPS.COLOR.INK_LIGHT}
+                    variant={TYPOGRAPHY_PROPS.VARIANT.BODY_LARGE_400}
+                  >
+                    {formatDate(new Date(date))}
+                  </Typography>
+                </CardContent>
+              </CardActionArea>
+            </StyledCard>
+          ))}
+        </StyledGrid>
+      </SectionLayout>
+      <StyledDivider />
+    </Section>
+  );
+};

--- a/app/components/Home/components/Section/components/SectionWhitePapers/types.ts
+++ b/app/components/Home/components/Section/components/SectionWhitePapers/types.ts
@@ -1,0 +1,6 @@
+export interface WhitePaper {
+  date: string;
+  href: string;
+  imageSrc: string;
+  title: string;
+}

--- a/app/docs/learn/featured-analyses/evolutionary-dynamics-of-coding-overlaps-in-measles.mdx
+++ b/app/docs/learn/featured-analyses/evolutionary-dynamics-of-coding-overlaps-in-measles.mdx
@@ -5,6 +5,7 @@ breadcrumbs:
   - path: "/learn/featured-analyses"
     text: "Featured Analyses"
 contentType: "ARTICLE"
+date: "2025-10-29"
 description: ""
 heroImage:
   alt: "Evolutionary dynamics of coding overlaps in measles virus"

--- a/app/docs/learn/featured-analyses/standardizing-rnaseq-candidozyma-auris.mdx
+++ b/app/docs/learn/featured-analyses/standardizing-rnaseq-candidozyma-auris.mdx
@@ -4,6 +4,7 @@ breadcrumbs:
     text: "Learn"
   - path: "/learn/featured-analyses"
     text: "Featured Analyses"
+date: "2026-01-13"
 contentType: "ARTICLE"
 description: "Re-analyzing C. auris RNA-seq data using BRC-Analytics and agentic AI for reproducible fungal pathogen genomics"
 heroImage:

--- a/app/views/HomeView/homeView.tsx
+++ b/app/views/HomeView/homeView.tsx
@@ -5,11 +5,13 @@ import { SectionAssemblies } from "../../components/Home/components/Section/comp
 import { SectionHelp } from "../../components/Home/components/Section/components/SectionHelp/sectionHelp";
 import { SectionHero } from "../../components/Home/components/Section/components/SectionHero/sectionHero";
 import { SectionSubHero } from "../../components/Home/components/Section/components/SectionSubHero/sectionSubHero";
+import { SectionWhitePapers } from "../../components/Home/components/Section/components/SectionWhitePapers/sectionWhitePapers";
 
 export const HomeView = (): JSX.Element => {
   return (
     <Fragment>
       <SectionHero />
+      <SectionWhitePapers />
       <SectionSubHero />
       <SectionAssemblies />
       <SectionAnalytics />


### PR DESCRIPTION
Closes #1108.

This pull request introduces a new "Analyzed on BRC Analytics" section to the home page, showcasing featured white papers with improved styling and structure. It also includes minor updates to existing section paddings and adds publication dates to relevant articles.

**New "White Papers" Section:**

* Added a new `SectionWhitePapers` component to the home page, displaying featured analyses with images, titles, and formatted publication dates using data from a new `WHITE_PAPERS` constant. [[1]](diffhunk://#diff-6d73055f916b81e9d48bcd443363b7408ef8d50f45778a3276d03a794ee1ba25R1-R50) [[2]](diffhunk://#diff-46005a45875c17901e956a6114c2b72af0fc3bae200a9db0fa1888a231f89c85R1-R19) [[3]](diffhunk://#diff-f0933ad10e37eb16167f655ed898d70ddd4ca62bd5b92d5e955496f4184d39e3R1-R6) [[4]](diffhunk://#diff-6a4c7cf3a3a864c4cdbc3bc6e5eec942b7e2628bb7ee3d2c7d73fcb4b40fdf75R8-R14)
* Implemented custom styles for the new section and its cards, including responsive grid layout and consistent design with other sections.

**Content and Metadata Updates:**

* Added publication dates to the metadata of the two featured analysis articles for consistency and accurate display in the new section. [[1]](diffhunk://#diff-76ff6a2ebe6fc35dffbedc032f271ef05c9888187f9045db882243afb461494bR8) [[2]](diffhunk://#diff-2c77392b23c02edc0972c2c778d9a61a9d65d1b7f53f746f47520cbb48d72b0fR7)

**UI/UX Improvements:**

* Adjusted the top padding of the existing `SectionSubHero` component for better spacing and alignment with the new section.

<img width="1381" height="1253" alt="image" src="https://github.com/user-attachments/assets/00672082-55a6-4913-9c70-1d9638728bf8" />

