### PR TITLE
content: remove survey card for now (#1111)

### DIFF
--- a/app/components/Home/components/Section/components/SectionHero/components/Carousel/cards/constants.ts
+++ b/app/components/Home/components/Section/components/SectionHero/components/Carousel/cards/constants.ts
@@ -14,7 +14,4 @@ export const CAROUSEL_CARDS: Pick<CardProps, "text">[] = [
   {
     text: MDX.Webinar20250326({}),
   },
-  {
-    text: MDX.ShareUsageAndJoinAdvisoryPanel({}),
-  },
 ];


### PR DESCRIPTION
Closes #1111.

This pull request makes a minor change to the `CAROUSEL_CARDS` array by removing the "ShareUsageAndJoinAdvisoryPanel" card from the carousel.

- Removed the `ShareUsageAndJoinAdvisoryPanel` card from the `CAROUSEL_CARDS` array in `cards/constants.ts`