### PR TITLE
feat: configure backend URLs for dev and prod environments

### DIFF
--- a/site-config/brc-analytics/dev/.env
+++ b/site-config/brc-analytics/dev/.env
@@ -1,4 +1,5 @@
 NEXT_PUBLIC_ENA_PROXY_DOMAIN="https://brc-analytics.dev.clevercanary.com"
 NEXT_PUBLIC_SITE_CONFIG='brc-analytics-dev'
 NEXT_PUBLIC_GALAXY_INSTANCE_URL="https://test.galaxyproject.org"
+NEXT_PUBLIC_BACKEND_URL="https://platform-staging.brc-analytics.org"
 NEXT_PUBLIC_SENTRY_DSN="https://e9b62a8020d937bef98b86074281fd90@sentry.galaxyproject.org/23"

--- a/site-config/brc-analytics/prod/.env
+++ b/site-config/brc-analytics/prod/.env
@@ -1,5 +1,6 @@
 NEXT_PUBLIC_ENA_PROXY_DOMAIN="https://brc-analytics.org"
 NEXT_PUBLIC_SITE_CONFIG='brc-analytics-prod'
 NEXT_PUBLIC_GALAXY_INSTANCE_URL="https://usegalaxy.org"
+NEXT_PUBLIC_BACKEND_URL="https://platform-beta.brc-analytics.org"
 NEXT_PUBLIC_PLAUSIBLE_DOMAIN="brc-analytics.org"
 NEXT_PUBLIC_SENTRY_DSN="https://e9b62a8020d937bef98b86074281fd90@sentry.galaxyproject.org/23"


### PR DESCRIPTION
Configures the frontend to use the new Jetstream-hosted backend APIs:

- **Dev** (main branch builds): `platform-staging.brc-analytics.org`
- **Prod** (production branch builds): `platform-beta.brc-analytics.org`

These backends are deployed via the brc-analytics-playbook and run the API endpoints needed for LLM search (#1106) and other backend features.