### PR TITLE
fix: move FastAPI docs/openapi URLs under /api/v1/ prefix

### DIFF
--- a/backend/api/app/main.py
+++ b/backend/api/app/main.py
@@ -41,9 +41,9 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title="BRC Analytics API",
     version=settings.APP_VERSION,
-    openapi_url="/api/openapi.json",
-    docs_url="/api/docs",
-    redoc_url="/api/redoc",
+    openapi_url="/api/v1/openapi.json",
+    docs_url="/api/v1/docs",
+    redoc_url="/api/v1/redoc",
     lifespan=lifespan,
 )
 


### PR DESCRIPTION
## Summary

- Moves `/api/docs`, `/api/redoc`, and `/api/openapi.json` to `/api/v1/docs`, `/api/v1/redoc`, and `/api/v1/openapi.json`
- The nginx config routes `/api/v1*` to the FastAPI backend and everything else under `/api/` to static Next.js files, so the old paths were being handled by the static file location block and returning 404

## Test plan

- [ ] `docker compose up --build` and verify `/api/v1/docs` loads Swagger UI
- [ ] Verify `/api/v1/redoc` loads ReDoc
- [ ] Verify `/api/v1/openapi.json` returns the schema
- [ ] Verify existing endpoints (`/api/v1/health`, `/api/v1/version`) still work