### PR TITLE
fix: use same-origin backend URLs for CloudFront proxy

### DIFF
--- a/site-config/brc-analytics/dev/.env
+++ b/site-config/brc-analytics/dev/.env
@@ -1,5 +1,5 @@
 NEXT_PUBLIC_ENA_PROXY_DOMAIN="https://brc-analytics.dev.clevercanary.com"
 NEXT_PUBLIC_SITE_CONFIG='brc-analytics-dev'
 NEXT_PUBLIC_GALAXY_INSTANCE_URL="https://test.galaxyproject.org"
-NEXT_PUBLIC_BACKEND_URL="https://platform-staging.brc-analytics.org"
+NEXT_PUBLIC_BACKEND_URL=""
 NEXT_PUBLIC_SENTRY_DSN="https://e9b62a8020d937bef98b86074281fd90@sentry.galaxyproject.org/23"

--- a/site-config/brc-analytics/prod/.env
+++ b/site-config/brc-analytics/prod/.env
@@ -1,6 +1,6 @@
 NEXT_PUBLIC_ENA_PROXY_DOMAIN="https://brc-analytics.org"
 NEXT_PUBLIC_SITE_CONFIG='brc-analytics-prod'
 NEXT_PUBLIC_GALAXY_INSTANCE_URL="https://usegalaxy.org"
-NEXT_PUBLIC_BACKEND_URL="https://platform-beta.brc-analytics.org"
+NEXT_PUBLIC_BACKEND_URL=""
 NEXT_PUBLIC_PLAUSIBLE_DOMAIN="brc-analytics.org"
 NEXT_PUBLIC_SENTRY_DSN="https://e9b62a8020d937bef98b86074281fd90@sentry.galaxyproject.org/23"


### PR DESCRIPTION
## Summary

- Clears `NEXT_PUBLIC_BACKEND_URL` in the dev and prod site configs so API calls use same-origin relative paths (`/api/v1/*`)
- With CloudFront proxying `/api/v1/*` to the backend, the frontend doesn't need to know the backend host — same-origin requests avoid CORS and CSP concerns entirely
- The docker config already worked this way

## Context

Companion to #1135 (moving FastAPI docs under `/api/v1/`). Together these two changes prepare for routing all `/api/v1/*` traffic through a CloudFront behavior to the backend origin, with everything else served as static files.

## Test plan

- [ ] Verify the dev build still fetches backend version correctly when served behind a proxy that routes `/api/v1/*` to the backend
- [ ] Verify the prod build behaves the same
- [ ] Verify local dev (`npm run dev`) still works (uses its own `.env` with `localhost:8000`, unchanged)

Closes #1122