### PR TITLE
feat: enable ga2 roadmap w updated content

### DIFF
--- a/app/components/content/sectionRoadmapGA2.mdx
+++ b/app/components/content/sectionRoadmapGA2.mdx
@@ -13,22 +13,26 @@
           <AccordionDetails>
             Specific features planned for upcoming releases:
 
-            1. Natural language query interface for ENA with automatic Galaxy integration
-            2. Embedded Galaxy Pages (notebook-like documents containing workflow results) in relevant GenomeArk pages
-            3. Enhanced Galaxy workflows for comparative genomics and other analyses
-            4. Provide easy access to GenomeArk object storage for analysis in the Galaxy Platform
-            5. visualize downstream analysis items in GenomeArk, such as Pretext results
+            1. Highlight and provide streamlined access to VGP Phase 1 reference genomes
+            2. Enable users to leverage VGP workflows for building and annotating their own assemblies
+            3. Linked user accounts with Galaxy for tracking analysis tasks over time and sharing with collaborators
+            4. Tools to help users submit assemblies and annotations to NCBI
+            5. Natural language query interface for ENA with automatic Galaxy integration
+            6. Embedded Galaxy Pages (notebook-like documents containing workflow results) in relevant GenomeArk pages
+            7. Enhanced Galaxy workflows for comparative genomics and other analyses
+            8. Provide easy access to GenomeArk object storage for analysis in the Galaxy Platform
+            9. Visualize downstream analysis items in GenomeArk, such as Pretext results
+            10. Access to Galaxy's MCP server to provide a natural language interface to Galaxy itself
           </AccordionDetails>
         </Accordion>
         <Accordion>
-          <AccordionSummary>Community-driven knowledge platform</AccordionSummary>
+          <AccordionSummary>Collaborative research environment</AccordionSummary>
           <AccordionDetails>
-            In building a collaborative environment where researchers can share insights and analyses, we aim to:
+            To support collaborative research and knowledge sharing, we aim to:
 
             1. Embed results of Galaxy analyses directly in the GenomeArk site for community reference
-            2. Empower users to self-curate organism knowledge bases through peer review
-            3. Establish community forums for discussing research questions and methodologies
-            4. Enable contribution of custom workflows, analysis pipelines and visualizations tailored to specific organisms
+            2. Enable contribution of custom workflows, analysis pipelines and visualizations tailored to specific organisms
+            3. Support sharing of analysis results and workflows with collaborators through linked Galaxy accounts
           </AccordionDetails>
         </Accordion>
         <Accordion>
@@ -45,16 +49,18 @@
           </AccordionDetails>
         </Accordion>
         <Accordion>
-          <AccordionSummary>Seamless data integration</AccordionSummary>
+          <AccordionSummary>Extending the reach of the VGP project</AccordionSummary>
           <AccordionDetails>
-            We aim to create a unified experience that brings together diverse data sources and analysis capabilities. Our goals include:
+            We aim to maximize the impact of VGP assemblies by enabling downstream analysis and integration with diverse data sources. Our goals include:
 
-            1. Automatically manage reference genomes and annotations from NCBI
-            2. Provide an integrated and intuitive interface for ENA with automatic upload to Galaxy
-            3. Pre-build essential bioinformatics resources (indices, etc.) for supported organisms
-            4. Create a comprehensive resource that reduces the need to navigate between multiple platforms
-            5. Embed a wide range of analysis results from Galaxy as essential context for research on supported organisms
-            6. Build a flexible system that can be extended to support additional organisms, data sources and analysis tools quickly
+            1. Provide streamlined access to VGP Phase 1 reference genomes and assemblies
+            2. Enable researchers to perform downstream analyses on VGP assemblies using Galaxy workflows
+            3. Automatically manage reference genomes and annotations from NCBI
+            4. Provide an integrated and intuitive interface for ENA with automatic upload to Galaxy
+            5. Pre-build essential bioinformatics resources (indices, etc.) for VGP and other supported organisms
+            6. Create a comprehensive resource that reduces the need to navigate between multiple platforms
+            7. Embed a wide range of analysis results from Galaxy as essential context for research on supported organisms
+            8. Build a flexible system that can be extended to support additional organisms, data sources and analysis tools quickly
           </AccordionDetails>
         </Accordion>
         <Accordion>

--- a/app/views/RoadmapView/roadmapViewGA2.tsx
+++ b/app/views/RoadmapView/roadmapViewGA2.tsx
@@ -3,8 +3,6 @@ import { Fragment } from "react";
 import { SectionRoadmapGA2 } from "../../components/content";
 import { SectionHero } from "../../components/Layout/components/AppLayout/components/Section/components/SectionHero/sectionHero";
 import { BREADCRUMBS } from "./common/constants";
-import { Typography } from "@mui/material";
-import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
 
 export const RoadmapViewGA2 = (): JSX.Element => {
   return (
@@ -15,16 +13,12 @@ export const RoadmapViewGA2 = (): JSX.Element => {
         subHead={
           <>
             GenomeArk lets you combine VGP Phase 1, official NCBI, and your own
-            data using Galaxy Platform. It simplifies large-scale
-            bioinformatics, ensures reproducibility, and makes results easy to
-            share with other researchers. Our goal is to create a{" "}
-            <Typography
-              component="span"
-              variant={TYPOGRAPHY_PROPS.VARIANT.BODY_LARGE_500}
-            >
-              community-driven knowledge platform
-            </Typography>{" "}
-            that lowers barriers to entry for complex bioinformatics analyses.
+            data using the Galaxy Platform. We are extending the reach of the
+            VGP project by making it simple to analyze those assemblies,
+            generate new ones with proven workflows, and feed results back to
+            the community. By emphasizing reproducibility, collaboration, and
+            low-barrier access to large-scale bioinformatics, we help
+            researchers turn high-quality genomes into actionable science.
           </>
         }
       />

--- a/site-config/ga2/local/config.ts
+++ b/site-config/ga2/local/config.ts
@@ -18,7 +18,7 @@ const ALLOWED_PATHS = [
   ROUTES.ABOUT,
   ROUTES.ORGANISMS,
   ROUTES.GENOMES,
-  // ROUTES.ROADMAP,
+  ROUTES.ROADMAP,
 ];
 const LOCALHOST = "http://localhost:3000";
 const APP_TITLE = "Genome Ark 2";
@@ -78,7 +78,7 @@ export function makeConfig(
             { label: "About", url: ROUTES.ABOUT },
             { label: "Organisms", url: ROUTES.ORGANISMS },
             { label: "Assemblies", url: ROUTES.GENOMES },
-            // { label: "Roadmap", url: ROUTES.ROADMAP },
+            { label: "Roadmap", url: ROUTES.ROADMAP },
           ],
           undefined,
         ],


### PR DESCRIPTION
## Description

the bones of a roadmap were there, but needed enabled in config. so this does that, and updates the content a bit. 

<img width="1823" height="1058" alt="image" src="https://github.com/user-attachments/assets/fe76fc65-a2b2-46e9-b6ff-794fcce0346f" />

