### PR TITLE
feat: add strandedness support to de workflow form (#1127)

### DIFF
--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/GTFStep/gtfStep.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/GTFStep/gtfStep.tsx
@@ -1,4 +1,6 @@
 import { BUTTON_PROPS } from "@databiosphere/findable-ui/lib/components/common/Button/constants";
+import { RadioCheckedIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/RadioCheckedIcon/radioCheckedIcon";
+import { RadioUncheckedIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/RadioUncheckedIcon/radioUncheckedIcon";
 import {
   Loading,
   LOADING_PANEL_STYLE,
@@ -8,6 +10,7 @@ import { Icon } from "@databiosphere/findable-ui/lib/components/Stepper/componen
 import { Optional } from "@databiosphere/findable-ui/lib/components/Stepper/components/Step/components/StepLabel/components/Optional/optional";
 import { StepLabel } from "@databiosphere/findable-ui/lib/components/Stepper/components/Step/components/StepLabel/stepLabel";
 import { Step } from "@databiosphere/findable-ui/lib/components/Stepper/components/Step/step";
+import { SVG_ICON_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/svgIcon";
 import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
 import {
   Button,
@@ -88,7 +91,21 @@ export const GTFStep = ({
             <RadioGroup onChange={onChange} value={value}>
               {controls.map(({ label, value }, i) => (
                 <FormControlLabel
-                  control={<Radio />}
+                  control={
+                    <Radio
+                      checkedIcon={
+                        <RadioCheckedIcon
+                          fontSize={SVG_ICON_PROPS.FONT_SIZE.XSMALL}
+                        />
+                      }
+                      icon={
+                        <RadioUncheckedIcon
+                          fontSize={SVG_ICON_PROPS.FONT_SIZE.XSMALL}
+                        />
+                      }
+                      size="small"
+                    />
+                  }
                   key={i}
                   onChange={() => onConfigure({ [STEP.key]: value })}
                   label={label}

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/StrandednessStep/constants.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/StrandednessStep/constants.ts
@@ -1,0 +1,31 @@
+import { FormControlLabelProps } from "@mui/material";
+import { STRANDEDNESS } from "./types";
+
+export const STRANDEDNESS_LABELS: Record<STRANDEDNESS, string> = {
+  [STRANDEDNESS.UNSTRANDED]: "Unstranded",
+  [STRANDEDNESS.FORWARD]: "Forward (FR / second-strand)",
+  [STRANDEDNESS.REVERSE]: "Reverse (RF / first-strand)",
+};
+
+export const CONTROLS: (Pick<FormControlLabelProps, "label" | "value"> & {
+  description: string;
+})[] = [
+  {
+    description:
+      "Reads come from either strand (e.g. TruSeq RNA Sample Prep Kit). Most common for older datasets.",
+    label: STRANDEDNESS_LABELS[STRANDEDNESS.UNSTRANDED],
+    value: STRANDEDNESS.UNSTRANDED,
+  },
+  {
+    description:
+      "Read 1 is in the same orientation as the transcript (e.g. ligation-based kits like ScriptSeq, SMARTer Stranded).",
+    label: STRANDEDNESS_LABELS[STRANDEDNESS.FORWARD],
+    value: STRANDEDNESS.FORWARD,
+  },
+  {
+    description:
+      "Read 1 is the reverse complement of the transcript (e.g. dUTP-based kits like TruSeq Stranded, NEBNext Directional). Most common for modern stranded data.",
+    label: STRANDEDNESS_LABELS[STRANDEDNESS.REVERSE],
+    value: STRANDEDNESS.REVERSE,
+  },
+];

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/StrandednessStep/step.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/StrandednessStep/step.ts
@@ -1,0 +1,12 @@
+import { StepConfig } from "../types";
+import { StrandednessStep } from "./strandednessStep";
+import { getStepLabel } from "./utils";
+
+export const STEP = {
+  Step: StrandednessStep,
+  key: "strandedness",
+  label: "Specify Strandedness",
+  renderValue({ strandedness }): string {
+    return getStepLabel(strandedness);
+  },
+} satisfies StepConfig;

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/StrandednessStep/strandednessStep.styles.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/StrandednessStep/strandednessStep.styles.ts
@@ -1,0 +1,12 @@
+import { StepContent } from "@databiosphere/findable-ui/lib/components/Stepper/components/Step/components/StepContent/stepContent";
+import styled from "@emotion/styled";
+
+export const StyledStepContent = styled(StepContent)`
+  .MuiFormControlLabel-root {
+    align-items: flex-start;
+
+    .MuiRadio-root {
+      margin: 1px 0;
+    }
+  }
+`;

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/StrandednessStep/strandednessStep.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/StrandednessStep/strandednessStep.tsx
@@ -59,7 +59,7 @@ export const StrandednessStep = ({
       </StepLabel>
       <StyledStepContent>
         <RadioGroup onChange={onChange} value={value}>
-          {CONTROLS.map(({ description, label, value }, i) => (
+          {CONTROLS.map((control, i) => (
             <FormControlLabel
               control={
                 <Radio
@@ -79,16 +79,16 @@ export const StrandednessStep = ({
               key={i}
               label={
                 <Stack useFlexGap>
-                  <span>{label}</span>
+                  <span>{control.label}</span>
                   <Typography
                     color={TYPOGRAPHY_PROPS.COLOR.INK_LIGHT}
                     variant={TYPOGRAPHY_PROPS.VARIANT.BODY_SMALL_400}
                   >
-                    {description}
+                    {control.description}
                   </Typography>
                 </Stack>
               }
-              value={value}
+              value={control.value}
             />
           ))}
         </RadioGroup>

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/StrandednessStep/strandednessStep.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/StrandednessStep/strandednessStep.tsx
@@ -1,0 +1,101 @@
+import { BUTTON_PROPS } from "@databiosphere/findable-ui/lib/components/common/Button/constants";
+import { RadioCheckedIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/RadioCheckedIcon/radioCheckedIcon";
+import { RadioUncheckedIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/RadioUncheckedIcon/radioUncheckedIcon";
+import { Optional } from "@databiosphere/findable-ui/lib/components/Stepper/components/Step/components/StepLabel/components/Optional/optional";
+import { StepLabel } from "@databiosphere/findable-ui/lib/components/Stepper/components/Step/components/StepLabel/stepLabel";
+import { Step } from "@databiosphere/findable-ui/lib/components/Stepper/components/Step/step";
+import { SVG_ICON_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/svgIcon";
+import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
+import {
+  Button,
+  FormControlLabel,
+  Radio,
+  RadioGroup,
+  Stack,
+  Typography,
+} from "@mui/material";
+import { Fragment, JSX, useEffect } from "react";
+import { useRadioGroup } from "../hooks/UseRadioGroup/hook";
+import { StepProps } from "../types";
+import { CONTROLS } from "./constants";
+import { StyledStepContent } from "./strandednessStep.styles";
+import { STRANDEDNESS } from "./types";
+import { getStepLabel } from "./utils";
+
+export const StrandednessStep = ({
+  active,
+  completed,
+  configuredInput,
+  entryLabel,
+  index,
+  onConfigure,
+  onContinue,
+  onEdit,
+  stepKey,
+}: StepProps): JSX.Element => {
+  const { strandedness } = configuredInput;
+  const { onChange, value } = useRadioGroup(
+    strandedness ?? STRANDEDNESS.UNSTRANDED
+  );
+
+  useEffect(() => {
+    if (!active) return;
+    onConfigure({ [stepKey]: value });
+  }, [active, onConfigure, stepKey, value]);
+
+  return (
+    <Step active={active} completed={completed} index={index}>
+      <StepLabel
+        optional={
+          completed && (
+            <Fragment>
+              <Optional>{getStepLabel(strandedness)}</Optional>
+              <Button onClick={() => onEdit(index)}>Edit</Button>
+            </Fragment>
+          )
+        }
+      >
+        {entryLabel}
+      </StepLabel>
+      <StyledStepContent>
+        <RadioGroup onChange={onChange} value={value}>
+          {CONTROLS.map(({ description, label, value }, i) => (
+            <FormControlLabel
+              control={
+                <Radio
+                  checkedIcon={
+                    <RadioCheckedIcon
+                      fontSize={SVG_ICON_PROPS.FONT_SIZE.XSMALL}
+                    />
+                  }
+                  icon={
+                    <RadioUncheckedIcon
+                      fontSize={SVG_ICON_PROPS.FONT_SIZE.XSMALL}
+                    />
+                  }
+                  size="small"
+                />
+              }
+              key={i}
+              label={
+                <Stack useFlexGap>
+                  <span>{label}</span>
+                  <Typography
+                    color={TYPOGRAPHY_PROPS.COLOR.INK_LIGHT}
+                    variant={TYPOGRAPHY_PROPS.VARIANT.BODY_SMALL_400}
+                  >
+                    {description}
+                  </Typography>
+                </Stack>
+              }
+              value={value}
+            />
+          ))}
+        </RadioGroup>
+        <Button {...BUTTON_PROPS.PRIMARY_CONTAINED} onClick={onContinue}>
+          Continue
+        </Button>
+      </StyledStepContent>
+    </Step>
+  );
+};

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/StrandednessStep/strandednessStep.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/StrandednessStep/strandednessStep.tsx
@@ -14,7 +14,7 @@ import {
   Stack,
   Typography,
 } from "@mui/material";
-import { Fragment, JSX, useEffect } from "react";
+import { Fragment, JSX, useEffect, useRef } from "react";
 import { useRadioGroup } from "../hooks/UseRadioGroup/hook";
 import { StepProps } from "../types";
 import { CONTROLS } from "./constants";
@@ -34,14 +34,18 @@ export const StrandednessStep = ({
   stepKey,
 }: StepProps): JSX.Element => {
   const { strandedness } = configuredInput;
-  const { onChange, value } = useRadioGroup(
-    strandedness ?? STRANDEDNESS.UNSTRANDED
-  );
+
+  const initialValue = useRef<STRANDEDNESS>(STRANDEDNESS.UNSTRANDED);
+
+  const { onChange, value } = useRadioGroup(initialValue.current);
 
   useEffect(() => {
+    // Wait until step is active to pre-configure the initial value.
     if (!active) return;
-    onConfigure({ [stepKey]: value });
-  }, [active, onConfigure, stepKey, value]);
+    // Don't overwrite existing configuration. This allows users to navigate back to the step without losing their selection.
+    if (strandedness) return;
+    onConfigure({ [stepKey]: initialValue.current });
+  }, [active, onConfigure, strandedness, stepKey]);
 
   return (
     <Step active={active} completed={completed} index={index}>
@@ -58,7 +62,13 @@ export const StrandednessStep = ({
         {entryLabel}
       </StepLabel>
       <StyledStepContent>
-        <RadioGroup onChange={onChange} value={value}>
+        <RadioGroup
+          onChange={(e, v) => {
+            onChange?.(e, v);
+            onConfigure({ [stepKey]: v });
+          }}
+          value={value}
+        >
           {CONTROLS.map((control, i) => (
             <FormControlLabel
               control={
@@ -92,7 +102,11 @@ export const StrandednessStep = ({
             />
           ))}
         </RadioGroup>
-        <Button {...BUTTON_PROPS.PRIMARY_CONTAINED} onClick={onContinue}>
+        <Button
+          {...BUTTON_PROPS.PRIMARY_CONTAINED}
+          disabled={!strandedness}
+          onClick={onContinue}
+        >
           Continue
         </Button>
       </StyledStepContent>

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/StrandednessStep/strandednessStep.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/StrandednessStep/strandednessStep.tsx
@@ -14,12 +14,11 @@ import {
   Stack,
   Typography,
 } from "@mui/material";
-import { Fragment, JSX, useEffect, useRef } from "react";
+import { Fragment, JSX } from "react";
 import { useRadioGroup } from "../hooks/UseRadioGroup/hook";
 import { StepProps } from "../types";
 import { CONTROLS } from "./constants";
 import { StyledStepContent } from "./strandednessStep.styles";
-import { STRANDEDNESS } from "./types";
 import { getStepLabel } from "./utils";
 
 export const StrandednessStep = ({
@@ -34,19 +33,7 @@ export const StrandednessStep = ({
   stepKey,
 }: StepProps): JSX.Element => {
   const { strandedness } = configuredInput;
-
-  const initialValue = useRef<STRANDEDNESS>(STRANDEDNESS.UNSTRANDED);
-
-  const { onChange, value } = useRadioGroup(initialValue.current);
-
-  useEffect(() => {
-    // Wait until step is active to pre-configure the initial value.
-    if (!active) return;
-    // Don't overwrite existing configuration. This allows users to navigate back to the step without losing their selection.
-    if (strandedness) return;
-    onConfigure({ [stepKey]: initialValue.current });
-  }, [active, onConfigure, strandedness, stepKey]);
-
+  const { onChange, value } = useRadioGroup(strandedness ?? "");
   return (
     <Step active={active} completed={completed} index={index}>
       <StepLabel

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/StrandednessStep/types.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/StrandednessStep/types.ts
@@ -1,0 +1,7 @@
+export enum STRANDEDNESS {
+  FORWARD = "forward",
+  REVERSE = "reverse",
+  UNSTRANDED = "unstranded",
+}
+
+export type Strandedness = STRANDEDNESS | null;

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/StrandednessStep/types.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/StrandednessStep/types.ts
@@ -1,6 +1,6 @@
 export enum STRANDEDNESS {
-  FORWARD = "forward",
-  REVERSE = "reverse",
+  FORWARD = "stranded - forward",
+  REVERSE = "stranded - reverse",
   UNSTRANDED = "unstranded",
 }
 

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/StrandednessStep/types.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/StrandednessStep/types.ts
@@ -4,4 +4,4 @@ export enum STRANDEDNESS {
   UNSTRANDED = "unstranded",
 }
 
-export type Strandedness = STRANDEDNESS | null;
+export type Strandedness = STRANDEDNESS;

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/StrandednessStep/utils.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/StrandednessStep/utils.ts
@@ -1,0 +1,13 @@
+import { STRANDEDNESS_LABELS } from "./constants";
+import { Strandedness } from "./types";
+
+/**
+ * Get the label to display for a given strandedness value.
+ * @param strandedness - Strandedness.
+ * @returns Label for the strandedness value.
+ */
+export function getStepLabel(strandedness?: Strandedness): string {
+  if (!strandedness) return "None";
+
+  return STRANDEDNESS_LABELS[strandedness];
+}

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/hooks/UseLaunchGalaxy/types.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/hooks/UseLaunchGalaxy/types.ts
@@ -6,6 +6,7 @@ import {
 } from "../../../../../../../../../../../../views/WorkflowInputsView/hooks/UseConfigureInputs/types";
 import { UcscTrack } from "../../../../../../../../../../../../utils/ucsc-tracks-api/entities";
 import { COLUMN_TYPE } from "../../SampleSheetClassificationStep/types";
+import { Strandedness } from "../../StrandednessStep/types";
 
 export interface ConfiguredValue {
   designFormula: string | null;
@@ -16,6 +17,7 @@ export interface ConfiguredValue {
   referenceAssembly: string;
   sampleSheet: Record<string, string>[] | null;
   sampleSheetClassification: Record<string, COLUMN_TYPE | null> | null;
+  strandedness: Strandedness | undefined;
   tracks: UcscTrack[] | null;
 }
 

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/hooks/UseLaunchGalaxy/useLaunchGalaxy.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/hooks/UseLaunchGalaxy/useLaunchGalaxy.ts
@@ -57,6 +57,7 @@ export const useLaunchGalaxy = ({
           configuredValue.sampleSheetClassification,
           configuredValue.designFormula,
           configuredValue.primaryContrasts,
+          configuredValue.strandedness,
           origin
         )
       );

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/hooks/UseLaunchGalaxy/utils.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/hooks/UseLaunchGalaxy/utils.ts
@@ -37,6 +37,7 @@ function getDEConfiguredValues(
     referenceAssembly,
     sampleSheet,
     sampleSheetClassification,
+    strandedness,
   } = configuredInput;
 
   // Validate required fields for DE workflow
@@ -59,6 +60,7 @@ function getDEConfiguredValues(
     referenceAssembly,
     sampleSheet,
     sampleSheetClassification,
+    strandedness,
     tracks: null,
   };
 }
@@ -99,6 +101,7 @@ function getStandardConfiguredValues(
     referenceAssembly: referenceAssembly!,
     sampleSheet: null,
     sampleSheetClassification: null,
+    strandedness: undefined,
     tracks: configuredInput.tracks ?? null,
   };
 }

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/steps/constants.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/steps/constants.ts
@@ -1,17 +1,18 @@
-import { StepConfig } from "../components/Step/types";
-import { STEP as REFERENCE_ASSEMBLY_STEP } from "../components/Step/ReferenceAssemblyStep/step";
+import { WORKFLOW_PARAMETER_VARIABLE } from "../../../../../../../../../apis/catalog/brc-analytics-catalog/common/schema-entities";
+import { STEP as DESEQ2_FORMULA_STEP } from "../components/Step/DESeq2FormulaStep/step";
 import { STEP as GTF_STEP } from "../components/Step/GTFStep/step";
+import { STEP as PRIMARY_CONTRASTS_STEP } from "../components/Step/PrimaryContrastsStep/step";
+import { STEP as REFERENCE_ASSEMBLY_STEP } from "../components/Step/ReferenceAssemblyStep/step";
+import { RELATED_TRACKS_STEP } from "../components/Step/RelatedTracksStep/step";
+import { STEP as SAMPLE_SHEET_CLASSIFICATION_STEP } from "../components/Step/SampleSheetClassificationStep/step";
+import { STEP as SAMPLE_SHEET_STEP } from "../components/Step/SampleSheetStep/step";
 import {
   ANY_END_STEP,
   PAIRED_END_STEP,
   SINGLE_END_STEP,
 } from "../components/Step/SequencingStep/step";
-import { WORKFLOW_PARAMETER_VARIABLE } from "../../../../../../../../../apis/catalog/brc-analytics-catalog/common/schema-entities";
-import { RELATED_TRACKS_STEP } from "../components/Step/RelatedTracksStep/step";
-import { STEP as SAMPLE_SHEET_STEP } from "../components/Step/SampleSheetStep/step";
-import { STEP as SAMPLE_SHEET_CLASSIFICATION_STEP } from "../components/Step/SampleSheetClassificationStep/step";
-import { STEP as DESEQ2_FORMULA_STEP } from "../components/Step/DESeq2FormulaStep/step";
-import { STEP as PRIMARY_CONTRASTS_STEP } from "../components/Step/PrimaryContrastsStep/step";
+import { STEP as STRANDEDNESS_STEP } from "../components/Step/StrandednessStep/step";
+import { StepConfig } from "../components/Step/types";
 
 export const SEQUENCING_STEPS: Record<string, StepConfig> = {
   readRunsPaired: PAIRED_END_STEP,
@@ -25,7 +26,8 @@ export const STEP: Record<
   | "READ_RUN_ANY"
   | "RELATED_TRACKS"
   | "SAMPLE_SHEET"
-  | "SAMPLE_SHEET_CLASSIFICATION",
+  | "SAMPLE_SHEET_CLASSIFICATION"
+  | "STRANDEDNESS",
   StepConfig | null
 > = {
   [WORKFLOW_PARAMETER_VARIABLE.ASSEMBLY_FASTA_URL]: null,
@@ -39,4 +41,5 @@ export const STEP: Record<
   RELATED_TRACKS: RELATED_TRACKS_STEP,
   SAMPLE_SHEET: SAMPLE_SHEET_STEP,
   SAMPLE_SHEET_CLASSIFICATION: SAMPLE_SHEET_CLASSIFICATION_STEP,
+  STRANDEDNESS: STRANDEDNESS_STEP,
 };

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/steps/utils.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/steps/utils.ts
@@ -1,10 +1,10 @@
 import { Workflow } from "../../../../../../../../../apis/catalog/brc-analytics-catalog/common/entities";
 import { WORKFLOW_PARAMETER_VARIABLE } from "../../../../../../../../../apis/catalog/brc-analytics-catalog/common/schema-entities";
-import { StepConfig } from "../components/Step/types";
-import { STEP } from "./constants";
 import { CUSTOM_WORKFLOW } from "../../../../../../../../../components/Entity/components/AnalysisMethod/components/CustomWorkflow/constants";
 import { ConfiguredInput } from "../../../../../../../../../views/WorkflowInputsView/hooks/UseConfigureInputs/types";
 import { DIFFERENTIAL_EXPRESSION_ANALYSIS } from "../../../../../../AnalysisMethod/components/DifferentialExpressionAnalysis/constants";
+import { StepConfig } from "../components/Step/types";
+import { STEP } from "./constants";
 
 /**
  * Augment the configured steps with two additional sequencing steps "READ_RUNS_PAIRED" and "READ_RUNS_SINGLE".
@@ -49,6 +49,7 @@ export function buildSteps(workflow: Workflow): StepConfig[] {
       STEP.ASSEMBLY_ID,
       STEP.GENE_MODEL_URL,
       STEP.SAMPLE_SHEET,
+      STEP.STRANDEDNESS,
       STEP.SAMPLE_SHEET_CLASSIFICATION,
       STEP.DESEQ2_FORMULA,
       STEP.PRIMARY_CONTRASTS,

--- a/app/utils/galaxy-api/entities.ts
+++ b/app/utils/galaxy-api/entities.ts
@@ -168,6 +168,7 @@ export interface DeSeq2RequestState {
   "Reference genome": string;
   "Reference level"?: string;
   "Sample sheet of sequencing reads": DeSeq2SampleSheetCollection;
+  Strandedness?: string;
   "Use featurecounts for generating count tables": boolean;
 }
 

--- a/app/utils/galaxy-api/galaxy-api.ts
+++ b/app/utils/galaxy-api/galaxy-api.ts
@@ -757,6 +757,7 @@ function buildSampleSheetCollection(
  * @param sampleSheetClassification - Classification of sample sheet columns.
  * @param designFormula - DESeq2 design formula.
  * @param primaryContrasts - Primary contrasts configuration (baseline, explicit pairs, or all-vs-all).
+ * @param strandedness - Library strandedness value.
  * @param origin - Origin URL of the site making the request.
  * @returns DESeq2 workflow landing URL.
  */
@@ -768,6 +769,7 @@ export async function getDeSeq2LandingUrl(
   sampleSheetClassification: Record<string, COLUMN_TYPE | null>,
   designFormula: string,
   primaryContrasts: PrimaryContrasts | null,
+  strandedness: string | undefined,
   origin: string
 ): Promise<string> {
   const md5Checksums = await fetchUcscMd5Checksums(referenceAssembly);
@@ -803,6 +805,7 @@ export async function getDeSeq2LandingUrl(
       },
       "Reference genome": referenceAssembly,
       ...(referenceLevel && { "Reference level": referenceLevel }),
+      ...(strandedness && { Strandedness: strandedness }),
       "Sample sheet of sequencing reads": sampleSheetCollection,
       "Use featurecounts for generating count tables": true,
     },

--- a/app/views/WorkflowInputsView/hooks/UseConfigureInputs/types.ts
+++ b/app/views/WorkflowInputsView/hooks/UseConfigureInputs/types.ts
@@ -1,6 +1,7 @@
-import { EnaSequencingReads } from "app/utils/galaxy-api/entities";
-import { UcscTrack } from "../../../../utils/ucsc-tracks-api/entities";
 import { COLUMN_TYPE } from "../../../../components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SampleSheetClassificationStep/types";
+import { Strandedness } from "../../../../components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/StrandednessStep/types";
+import { EnaSequencingReads } from "../../../../utils/galaxy-api/entities";
+import { UcscTrack } from "../../../../utils/ucsc-tracks-api/entities";
 
 export interface AllVAllContrasts {
   type: "ALL_AGAINST_ALL";
@@ -22,6 +23,7 @@ export interface ConfiguredInput {
   referenceAssembly?: string;
   sampleSheet?: Record<string, string>[];
   sampleSheetClassification?: Record<string, COLUMN_TYPE | null>;
+  strandedness?: Strandedness;
   tracks?: UcscTrack[] | null;
 }
 


### PR DESCRIPTION
Closes #1127.

This pull request introduces a new "Strandedness" step to the workflow configuration UI, allowing users to specify the strandedness of sequencing reads. It updates both the UI components and the workflow logic to support this new step, including custom radio icons and descriptive labels for each strandedness option.

**Addition of Strandedness Step:**

* Added a new `StrandednessStep` component with custom radio icons and detailed descriptions for each strandedness option, improving user clarity and workflow customization. [[1]](diffhunk://#diff-7c4b874f0de36efa19a973774043dcad1fffb8478e328deceea540c6b7d2a1a5R1-R101) [[2]](diffhunk://#diff-ab497e102ce360031472573dbede5dd2457ecd5791cb002c52f8bf19d3a3ceaaR2-R3) [[3]](diffhunk://#diff-ab497e102ce360031472573dbede5dd2457ecd5791cb002c52f8bf19d3a3ceaaR13) [[4]](diffhunk://#diff-ab497e102ce360031472573dbede5dd2457ecd5791cb002c52f8bf19d3a3ceaaL91-R108) [[5]](diffhunk://#diff-0402525e2edded65474e5620893e540f1052e22128d76ba9c058630bb3db0116R1-R12) [[6]](diffhunk://#diff-bd50ddfe7a5e000a9dfca8790e80a10cfcb061ea19d44882d29f2d360628bfb8R1-R31) [[7]](diffhunk://#diff-e52a5e3b291e88b72522d2b4f3b4eb7008340793db0f250fc9e4621becda0138R1-R7) [[8]](diffhunk://#diff-f16c0f6b9298e5f2981061c930fc7d92c2e1212fea85a48f94ae7e485af78c21R1-R13) [[9]](diffhunk://#diff-a5b85791afb557f3401f5b3ba45a11584bb1cee77462414b3f0c2fd990f0f711R1-R12)

**Workflow and Stepper Integration:**

* Integrated the strandedness step into the workflow stepper logic, including updates to the step constants and step-building utility to ensure the new step appears in the correct order for relevant workflows. [[1]](diffhunk://#diff-1567f60dfc06f0a058796246d31a6158e2c5de8b8203dd9e55b7a8542befb3e4L1-R15)R1, [[2]](diffhunk://#diff-1567f60dfc06f0a058796246d31a6158e2c5de8b8203dd9e55b7a8542befb3e4L28-R30) [[3]](diffhunk://#diff-1567f60dfc06f0a058796246d31a6158e2c5de8b8203dd9e55b7a8542befb3e4R44) [[4]](diffhunk://#diff-bb2fe33f610464aa7ab3fc665741f08c6ae9015c01f9f79790b6563dbfade46eR52)

**Data Model Update:**

* Extended the `ConfiguredInput` interface to include the new `strandedness` property, enabling storage and retrieval of the user's selection throughout the workflow configuration process. [[1]](diffhunk://#diff-175e93b754fcc9596961cf44fa358200087ffdb8e4b384537da97e5adb6b56baL1-R4) [[2]](diffhunk://#diff-175e93b754fcc9596961cf44fa358200087ffdb8e4b384537da97e5adb6b56baR26)

<img width="1568" height="1235" alt="image" src="https://github.com/user-attachments/assets/55157061-9376-447c-bcbe-e1693c337699" />

<img width="1565" height="1289" alt="image" src="https://github.com/user-attachments/assets/8ced4d99-d76c-4166-939a-6a5b570683a2" />
