### PR TITLE
fix: remove comming soon flag i.e. disabled status on workflows page (#1190)

### DIFF
--- a/app/views/WorkflowsView/utils.ts
+++ b/app/views/WorkflowsView/utils.ts
@@ -36,7 +36,6 @@ export function getWorkflows(
       workflows.push({
         ...workflow,
         category: category.name,
-        disabled: category.showComingSoon === false,
         taxonomyId: workflow.taxonomyId ?? "Unspecified",
       });
     }


### PR DESCRIPTION
Closes #1190.

This pull request makes a minor change to the logic for populating workflows in the `getWorkflows` function. The change removes the assignment of the `disabled` property, which previously depended on the `category.showComingSoon` value.

<img width="1860" height="1289" alt="image" src="https://github.com/user-attachments/assets/19434331-da0f-4254-b9b3-7cd000deaa97" />
