### PR TITLE
feat: use prod workflow ID for differential expression on usegalaxy.org

### DIFF
--- a/app/components/Entity/components/AnalysisMethod/components/DifferentialExpressionAnalysis/constants.ts
+++ b/app/components/Entity/components/AnalysisMethod/components/DifferentialExpressionAnalysis/constants.ts
@@ -9,6 +9,9 @@ export const DIFFERENTIAL_EXPRESSION_ANALYSIS: Workflow = {
   trsId: "differential-expression-analysis",
   workflowDescription:
     "Run end-to-end differential expression analysis by combining RNA-seq quantification with DESeq2. Upload your sample sheet, configure the experimental design, and launch the workflow in Galaxy.",
-  workflowId: "f0e86e1b05fe73d9", // Galaxy stored workflow ID
+  workflowId:
+    process.env.NEXT_PUBLIC_GALAXY_INSTANCE_URL === "https://usegalaxy.org"
+      ? "7f8eb3a584e8080b"
+      : "f0e86e1b05fe73d9", // Galaxy stored workflow ID
   workflowName: "Differential Expression Analysis",
 };


### PR DESCRIPTION
Select the correct Galaxy stored workflow ID based on the Galaxy instance URL, using 7f8eb3a584e8080b for usegalaxy.org (prod) and f0e86e1b05fe73d9 for test instances.

## Description

Brief description of the changes made in this PR.

## Related Issue

If this addresses an existing GitHub issue, link it here (e.g., "Closes #123"). If no existing issue exists, consider creating one first to discuss the changes.
