### PR TITLE
feat: run e2e tests against production build

### DIFF
--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -18,6 +18,8 @@ jobs:
         run: npm ci
       - name: Install Playwright browsers
         run: npx playwright install --with-deps
+      - name: Build production bundle
+        run: npm run build:local
       - name: Run e2e tests
         run: npm run test:e2e
       - name: Upload test results

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -16,10 +16,10 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         run: npm ci
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps
       - name: Build production bundle
         run: npm run build:local
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
       - name: Run e2e tests
         run: npm run test:e2e
       - name: Upload test results

--- a/playwright.api.config.ts
+++ b/playwright.api.config.ts
@@ -26,9 +26,9 @@ export default defineConfig({
   },
   webServer: [
     {
-      command: "npm run dev",
+      command: "npm run build:prod && npm run start",
       reuseExistingServer: !process.env.CI,
-      timeout: 120 * 1000,
+      timeout: 600 * 1000,
       url: "http://localhost:3000",
     },
     {

--- a/playwright.api.config.ts
+++ b/playwright.api.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
   },
   webServer: [
     {
-      command: "npm run build:prod && npm run start",
+      command: "npm run build:local && npm run start",
       reuseExistingServer: !process.env.CI,
       timeout: 600 * 1000,
       url: "http://localhost:3000",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -35,9 +35,11 @@ export default defineConfig({
     video: "retain-on-failure",
   },
   webServer: {
-    command: "npm run build:local && npm run start",
+    command: process.env.CI
+      ? "npm run start"
+      : "npm run build:local && npm run start",
     reuseExistingServer: !process.env.CI,
-    timeout: 600 * 1000,
+    timeout: process.env.CI ? 120 * 1000 : 600 * 1000,
     url: "http://localhost:3000",
   },
   workers: 3,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -35,9 +35,9 @@ export default defineConfig({
     video: "retain-on-failure",
   },
   webServer: {
-    command: "npm run dev",
+    command: "npm run build:prod && npm run start",
     reuseExistingServer: !process.env.CI,
-    timeout: 240 * 1000,
+    timeout: 600 * 1000,
     url: "http://localhost:3000",
   },
   workers: 3,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -35,7 +35,7 @@ export default defineConfig({
     video: "retain-on-failure",
   },
   webServer: {
-    command: "npm run build:prod && npm run start",
+    command: "npm run build:local && npm run start",
     reuseExistingServer: !process.env.CI,
     timeout: 600 * 1000,
     url: "http://localhost:3000",


### PR DESCRIPTION
## Summary
- Switch Playwright e2e tests from dev server (`npm run dev`) to a production build to catch production-only errors like `_jsxDEV` (#1162)
- Uses `build:local` instead of `build:prod` to avoid polluting production Sentry/Plausible analytics — `build:local` still runs `next build` (production Next.js compilation)
- In CI, the build runs as a separate workflow step (`npm run build:local`) before Playwright starts, so the web server command is just `npm run start` (serving pre-built static files). This avoids the build time counting against the Playwright `webServer.timeout`
- Locally, the combined command `npm run build:local && npm run start` runs with a 600s timeout to cover the full build + serve
- CI timeout is 120s (sufficient for `npx serve` to start serving static files)
- Applied to both `playwright.config.ts` (UI tests) and `.github/workflows/run-checks.yml`

## Test plan
- [ ] Verify e2e tests pass in CI against the production build

Closes #1165

🤖 Generated with [Claude Code](https://claude.com/claude-code)