### PR TITLE
feat: add h1 visibility assertions to e2e smoke tests

### DIFF
--- a/tests/e2e/ui/01-smoke.spec.ts
+++ b/tests/e2e/ui/01-smoke.spec.ts
@@ -40,6 +40,9 @@ test.describe("BRC Analytics - UI Smoke Tests", () => {
 
       // Page should have content
       await expect(page.locator("main")).toBeVisible();
+
+      // Page heading should be visible
+      await expect(page.locator("h1").first()).toBeVisible();
     });
   }
 });


### PR DESCRIPTION
## Summary
- Add `<h1>` visibility assertion to each page in the smoke test loop to catch rendering failures earlier
- Uses `.first()` to handle pages that may have multiple `h1` elements

## Test plan
- [x] Verify e2e smoke tests pass with the new h1 assertions
- [x] Confirm a page with a broken heading render would now fail the test

Closes #1166

🤖 Generated with [Claude Code](https://claude.com/claude-code)