### PR TITLE
fix(backend): chain FastMCP lifespan into FastAPI app

### DIFF
--- a/backend/api/app/main.py
+++ b/backend/api/app/main.py
@@ -28,36 +28,36 @@ if settings.SENTRY_DSN:
         traces_sample_rate=1.0,
     )
 
+# Build the MCP ASGI app at module scope so its lifespan can be chained into
+# the parent FastAPI lifespan below. Mounting a FastMCP http_app without
+# running its lifespan leaves the StreamableHTTPSessionManager task group
+# uninitialized, which causes every MCP request to 500.
+mcp = create_mcp_server(get_catalog_data(), get_ena_service())
+mcp_app = mcp.http_app(path="/", stateless_http=True)
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Startup and shutdown events for the application"""
-    # Startup: initialize services and flush cache
-    cache_service = get_cache_service()
-    await cache_service.flush_all()
-    logger.info("Cache cleared on startup")
+    async with mcp_app.lifespan(app):
+        # Startup: initialize services and flush cache
+        cache_service = get_cache_service()
+        await cache_service.flush_all()
+        logger.info("Cache cleared on startup")
 
-    # Pre-initialize services (singletons)
-    catalog_data = get_catalog_data()
-    ena_service = get_ena_service()
-    get_llm_service()
+        # Warm remaining singletons
+        get_llm_service()
 
-    # Mount MCP server for AI tool access to the catalog
-    mcp = create_mcp_server(catalog_data, ena_service)
-    mcp_app = mcp.http_app(path="/", stateless_http=True)
-    app.mount("/api/v1/mcp", mcp_app)
-    logger.info("MCP server mounted at /api/v1/mcp")
+        logger.info("All services initialized")
 
-    logger.info("All services initialized")
+        yield
 
-    yield
-
-    # Shutdown: close connections and reset all service singletons
-    auth_service = get_auth_service()
-    await auth_service.close()
-    await cache_service.close()
-    reset_all_services()
-    logger.info("All services shut down")
+        # Shutdown: close connections and reset all service singletons
+        auth_service = get_auth_service()
+        await auth_service.close()
+        await cache_service.close()
+        reset_all_services()
+        logger.info("All services shut down")
 
 
 app = FastAPI(
@@ -86,6 +86,8 @@ app.include_router(llm.router, prefix="/api/v1/llm", tags=["llm"])
 app.include_router(ena.router, prefix="/api/v1/ena", tags=["ena"])
 app.include_router(assistant.router, prefix="/api/v1/assistant", tags=["assistant"])
 app.include_router(auth.router, prefix="/api/v1/auth", tags=["auth"])
+
+app.mount("/api/v1/mcp", mcp_app)
 
 
 @app.get("/")

--- a/backend/api/tests/test_mcp.py
+++ b/backend/api/tests/test_mcp.py
@@ -1,0 +1,143 @@
+"""Tests for the MCP endpoint mount, tool discovery, and tool invocation.
+
+These are regression tests for the FastMCP + FastAPI lifespan chaining pattern
+in app/main.py. If the mounted FastMCP http_app's lifespan is not chained into
+the parent FastAPI lifespan, the StreamableHTTPSessionManager's anyio task
+group never starts and every request to /api/v1/mcp/ returns 500 with
+RuntimeError("Task group is not initialized. Make sure to use run().").
+"""
+
+import importlib
+import json
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from tests.test_catalog_data import SAMPLE_ORGANISMS, SAMPLE_WORKFLOWS
+
+
+@pytest.fixture()
+def mcp_app(tmp_path, monkeypatch):
+    """Reload app.main with a sample catalog and stubbed Redis-backed services.
+
+    The MCP server is constructed at module scope using get_catalog_data() and
+    get_ena_service(), so CATALOG_PATH must be set and any service that would
+    hit Redis must be patched before importing the module.
+    """
+    (tmp_path / "organisms.json").write_text(json.dumps(SAMPLE_ORGANISMS))
+    (tmp_path / "workflows.json").write_text(json.dumps(SAMPLE_WORKFLOWS))
+    monkeypatch.setenv("CATALOG_PATH", str(tmp_path))
+
+    fake_cache = MagicMock()
+    fake_cache.flush_all = AsyncMock()
+    fake_cache.close = AsyncMock()
+    fake_auth = MagicMock()
+    fake_auth.close = AsyncMock()
+
+    sys.modules.pop("app.main", None)
+    sys.modules.pop("app.core.config", None)
+
+    from app.core import dependencies
+
+    # MagicMock auto-creates attributes like .cache_clear, which
+    # reset_all_services() calls on every dependency getter during shutdown.
+    monkeypatch.setattr(
+        dependencies, "get_cache_service", MagicMock(return_value=fake_cache)
+    )
+    monkeypatch.setattr(
+        dependencies, "get_auth_service", MagicMock(return_value=fake_auth)
+    )
+    monkeypatch.setattr(
+        dependencies, "get_llm_service", MagicMock(return_value=MagicMock())
+    )
+
+    main_module = importlib.import_module("app.main")
+    yield main_module.app
+
+    sys.modules.pop("app.main", None)
+
+
+def _parse_sse(body: str) -> dict:
+    """Return the JSON payload of the first SSE data frame in an MCP response."""
+    for line in body.splitlines():
+        if line.startswith("data: "):
+            return json.loads(line[len("data: ") :])
+    raise AssertionError(f"No SSE data frame in response:\n{body}")
+
+
+def _mcp_post(client: TestClient, method: str, params: dict | None = None) -> dict:
+    response = client.post(
+        "/api/v1/mcp/",
+        json={
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params or {},
+            "id": 1,
+        },
+        headers={"Accept": "application/json, text/event-stream"},
+    )
+    assert response.status_code == 200, (
+        f"MCP {method} returned {response.status_code}: {response.text}"
+    )
+    return _parse_sse(response.text)
+
+
+def test_mcp_initialize_succeeds(mcp_app):
+    """Regression test for the FastMCP lifespan chaining bug.
+
+    A broken mount returns HTTP 500 with a RuntimeError from the session
+    manager. A correctly wired mount returns a JSON-RPC initialize result.
+    """
+    with TestClient(mcp_app) as client:
+        result = _mcp_post(
+            client,
+            "initialize",
+            {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "pytest", "version": "1"},
+            },
+        )
+
+    assert result.get("error") is None, result
+    server_info = result["result"]["serverInfo"]
+    assert server_info["name"] == "BRC Analytics"
+
+
+def test_mcp_tools_list_exposes_expected_tools(mcp_app):
+    with TestClient(mcp_app) as client:
+        result = _mcp_post(client, "tools/list")
+
+    tool_names = {tool["name"] for tool in result["result"]["tools"]}
+    expected = {
+        "search_organisms",
+        "get_organism",
+        "get_assemblies",
+        "get_assembly_details",
+        "list_workflow_categories",
+        "get_workflows_in_category",
+        "get_compatible_workflows",
+        "get_workflow_details",
+        "check_compatibility",
+        "resolve_workflow_inputs",
+        "search_ena",
+        "search_ena_keywords",
+    }
+    missing = expected - tool_names
+    assert not missing, f"MCP tools/list is missing expected tools: {missing}"
+
+
+def test_mcp_tool_call_search_organisms(mcp_app):
+    with TestClient(mcp_app) as client:
+        result = _mcp_post(
+            client,
+            "tools/call",
+            {"name": "search_organisms", "arguments": {"query": "plasmodium"}},
+        )
+
+    structured = result["result"]["structuredContent"]
+    assert structured["count"] >= 1
+    species = {org["species"] for org in structured["organisms"]}
+    assert "Plasmodium falciparum" in species


### PR DESCRIPTION
## Summary

- `/api/v1/mcp/` has been returning 500 on every request because the mounted FastMCP `http_app`'s lifespan was never entered, so its `StreamableHTTPSessionManager` task group wasn't running. The fix lifts `mcp` / `mcp_app` construction to module scope in `backend/api/app/main.py` and wraps the parent FastAPI lifespan in `async with mcp_app.lifespan(app):`, which is the pattern FastMCP docs suggest for mounting into a FastAPI app.
- Adds `backend/api/tests/test_mcp.py` with `TestClient`-based coverage of the MCP surface: an `initialize` round-trip, a `tools/list` check that all expected tools are registered, and a `tools/call` against `search_organisms` backed by the same sample catalog fixture used in `test_catalog_data.py`. I confirmed the tests fail on the pre-fix code with the original `RuntimeError: Task group is not initialized` and pass once the fix is applied.

## Test plan

- [x] `pytest backend/api/tests/test_mcp.py` passes (3/3)
- [x] Local `curl` + MCP Inspector CLI round-trip against `uvicorn app.main:app`
- [ ] Re-verify against `https://dev.brc-analytics.org/api/v1/mcp/` after dev deploy