### PR TITLE
refactor(backend): use uvicorn factory pattern for app creation

### DIFF
--- a/backend/api/Dockerfile
+++ b/backend/api/Dockerfile
@@ -47,4 +47,4 @@ USER app
 
 EXPOSE 8000
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "app.main:create_app", "--factory", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/api/README.md
+++ b/backend/api/README.md
@@ -17,7 +17,7 @@ FastAPI REST API service for BRC Analytics.
 ```bash
 cd backend/api
 uv sync
-uv run uvicorn app.main:app --reload
+uv run uvicorn app.main:create_app --factory --reload
 ```
 
 API documentation: http://localhost:8000/api/docs

--- a/backend/api/app/core/config.py
+++ b/backend/api/app/core/config.py
@@ -9,77 +9,77 @@ load_dotenv()
 
 
 class Settings:
-    """Application settings loaded from environment variables"""
+    """Application settings loaded from environment variables."""
 
-    # Application
-    APP_VERSION: str = os.getenv("APP_VERSION", "0.19.0")
+    def __init__(self):
+        # Application
+        self.APP_VERSION: str = os.getenv("APP_VERSION", "0.19.0")
 
-    # Redis settings
-    REDIS_URL: str = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+        # Redis settings
+        self.REDIS_URL: str = os.getenv("REDIS_URL", "redis://localhost:6379/0")
 
-    # AI/LLM settings (OpenAI or compatible APIs)
-    AI_API_KEY: str = os.getenv(
-        "AI_API_KEY", os.getenv("OPENAI_API_KEY", "")
-    )  # Fallback to OPENAI_API_KEY for backwards compatibility
-    AI_PRIMARY_MODEL: str = os.getenv("AI_PRIMARY_MODEL", "gpt-4-turbo-preview")
-    AI_SECONDARY_MODEL: str = os.getenv(
-        "AI_SECONDARY_MODEL", os.getenv("AI_PRIMARY_MODEL", "gpt-4-turbo-preview")
-    )  # Falls back to primary if not set
-    AI_API_BASE_URL: str = os.getenv(
-        "AI_API_BASE_URL", ""
-    )  # Empty means use OpenAI default; set for custom endpoints
-    AI_SKIP_SSL_VERIFY: bool = (
-        os.getenv("AI_SKIP_SSL_VERIFY", "false").lower() == "true"
-    )  # Skip SSL verification for self-signed certs
+        # AI/LLM settings (OpenAI or compatible APIs)
+        self.AI_API_KEY: str = os.getenv("AI_API_KEY", os.getenv("OPENAI_API_KEY", ""))
+        self.AI_PRIMARY_MODEL: str = os.getenv(
+            "AI_PRIMARY_MODEL", "gpt-4-turbo-preview"
+        )
+        self.AI_SECONDARY_MODEL: str = os.getenv(
+            "AI_SECONDARY_MODEL",
+            os.getenv("AI_PRIMARY_MODEL", "gpt-4-turbo-preview"),
+        )
+        self.AI_API_BASE_URL: str = os.getenv("AI_API_BASE_URL", "")
+        self.AI_SKIP_SSL_VERIFY: bool = (
+            os.getenv("AI_SKIP_SSL_VERIFY", "false").lower() == "true"
+        )
 
-    # Database settings (for future use)
-    DATABASE_URL: str = os.getenv("DATABASE_URL", "")
+        # Database settings (for future use)
+        self.DATABASE_URL: str = os.getenv("DATABASE_URL", "")
 
-    # ENA API settings
-    ENA_API_BASE: str = os.getenv(
-        "ENA_API_BASE", "https://www.ebi.ac.uk/ena/portal/api"
-    )
+        # ENA API settings
+        self.ENA_API_BASE: str = os.getenv(
+            "ENA_API_BASE", "https://www.ebi.ac.uk/ena/portal/api"
+        )
 
-    # CORS settings
-    CORS_ORIGINS: List[str] = os.getenv("CORS_ORIGINS", "http://localhost:3000").split(
-        ","
-    )
+        # CORS settings
+        self.CORS_ORIGINS: List[str] = os.getenv(
+            "CORS_ORIGINS", "http://localhost:3000"
+        ).split(",")
 
-    # Sentry
-    SENTRY_DSN: str = os.getenv("SENTRY_DSN", "")
+        # Sentry
+        self.SENTRY_DSN: str = os.getenv("SENTRY_DSN", "")
 
-    # Logging
-    LOG_LEVEL: str = os.getenv("LOG_LEVEL", "INFO")
+        # Logging
+        self.LOG_LEVEL: str = os.getenv("LOG_LEVEL", "INFO")
 
-    # Environment
-    ENVIRONMENT: str = os.getenv("ENVIRONMENT", "development")
+        # Environment
+        self.ENVIRONMENT: str = os.getenv("ENVIRONMENT", "development")
 
-    # Rate limiting
-    RATE_LIMIT_REQUESTS: int = int(os.getenv("RATE_LIMIT_REQUESTS", "100"))
-    RATE_LIMIT_WINDOW: int = int(os.getenv("RATE_LIMIT_WINDOW", "60"))  # seconds
+        # Rate limiting
+        self.RATE_LIMIT_REQUESTS: int = int(os.getenv("RATE_LIMIT_REQUESTS", "100"))
+        self.RATE_LIMIT_WINDOW: int = int(os.getenv("RATE_LIMIT_WINDOW", "60"))
 
-    # Catalog path
-    CATALOG_PATH: str = os.getenv("CATALOG_PATH", "/catalog/output")
+        # Catalog path
+        self.CATALOG_PATH: str = os.getenv("CATALOG_PATH", "/catalog/output")
 
-    # Keycloak / OIDC settings
-    KEYCLOAK_ISSUER_URL: str = os.getenv(
-        "KEYCLOAK_ISSUER_URL",
-        "http://localhost:8180/realms/galaxy",
-    )
-    KEYCLOAK_CLIENT_ID: str = os.getenv("KEYCLOAK_CLIENT_ID", "brc-analytics")
-    KEYCLOAK_CLIENT_SECRET: str = os.getenv(
-        "KEYCLOAK_CLIENT_SECRET", "brc-analytics-dev-secret"
-    )
-    KEYCLOAK_REDIRECT_URI: str = os.getenv(
-        "KEYCLOAK_REDIRECT_URI",
-        "http://localhost:8000/api/v1/auth/callback",
-    )
+        # Keycloak / OIDC settings
+        self.KEYCLOAK_ISSUER_URL: str = os.getenv(
+            "KEYCLOAK_ISSUER_URL",
+            "http://localhost:8180/realms/galaxy",
+        )
+        self.KEYCLOAK_CLIENT_ID: str = os.getenv("KEYCLOAK_CLIENT_ID", "brc-analytics")
+        self.KEYCLOAK_CLIENT_SECRET: str = os.getenv(
+            "KEYCLOAK_CLIENT_SECRET", "brc-analytics-dev-secret"
+        )
+        self.KEYCLOAK_REDIRECT_URI: str = os.getenv(
+            "KEYCLOAK_REDIRECT_URI",
+            "http://localhost:8000/api/v1/auth/callback",
+        )
 
-    # Frontend URL for post-auth redirect
-    FRONTEND_URL: str = os.getenv("FRONTEND_URL", "http://localhost:3000")
+        # Frontend URL for post-auth redirect
+        self.FRONTEND_URL: str = os.getenv("FRONTEND_URL", "http://localhost:3000")
 
 
 @lru_cache()
 def get_settings() -> Settings:
-    """Get cached settings instance"""
+    """Get cached settings instance."""
     return Settings()

--- a/backend/api/app/main.py
+++ b/backend/api/app/main.py
@@ -18,78 +18,77 @@ from app.core.dependencies import (
 from app.services.mcp_server import create_mcp_server
 
 logger = logging.getLogger(__name__)
-settings = get_settings()
 
-if settings.SENTRY_DSN:
-    sentry_sdk.init(
-        dsn=settings.SENTRY_DSN,
-        environment=settings.ENVIRONMENT,
-        release=settings.APP_VERSION,
-        traces_sample_rate=1.0,
+
+def create_app() -> FastAPI:
+    """Build and return the fully configured FastAPI application.
+
+    Used by uvicorn via --factory so that importing this module has no side
+    effects (no Sentry init, no catalog loading, no MCP server construction).
+    """
+    settings = get_settings()
+
+    if settings.SENTRY_DSN:
+        sentry_sdk.init(
+            dsn=settings.SENTRY_DSN,
+            environment=settings.ENVIRONMENT,
+            release=settings.APP_VERSION,
+            traces_sample_rate=1.0,
+        )
+
+    mcp = create_mcp_server(get_catalog_data(), get_ena_service())
+    mcp_app = mcp.http_app(path="/", stateless_http=True)
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        """Startup and shutdown events for the application."""
+        async with mcp_app.lifespan(app):
+            cache_service = get_cache_service()
+            await cache_service.flush_all()
+            logger.info("Cache cleared on startup")
+
+            get_llm_service()
+
+            logger.info("All services initialized")
+
+            yield
+
+            auth_service = get_auth_service()
+            await auth_service.close()
+            await cache_service.close()
+            reset_all_services()
+            logger.info("All services shut down")
+
+    app = FastAPI(
+        title="BRC Analytics API",
+        version=settings.APP_VERSION,
+        openapi_url="/api/v1/openapi.json",
+        docs_url="/api/v1/docs",
+        redoc_url="/api/v1/redoc",
+        lifespan=lifespan,
     )
 
-# Build the MCP ASGI app at module scope so its lifespan can be chained into
-# the parent FastAPI lifespan below. Mounting a FastMCP http_app without
-# running its lifespan leaves the StreamableHTTPSessionManager task group
-# uninitialized, which causes every MCP request to 500.
-mcp = create_mcp_server(get_catalog_data(), get_ena_service())
-mcp_app = mcp.http_app(path="/", stateless_http=True)
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=settings.CORS_ORIGINS,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
 
+    app.include_router(health.router, prefix="/api/v1", tags=["health"])
+    app.include_router(cache.router, prefix="/api/v1/cache", tags=["cache"])
+    app.include_router(version.router, prefix="/api/v1/version", tags=["version"])
+    app.include_router(links.router, prefix="/api/v1", tags=["links"])
+    app.include_router(llm.router, prefix="/api/v1/llm", tags=["llm"])
+    app.include_router(ena.router, prefix="/api/v1/ena", tags=["ena"])
+    app.include_router(assistant.router, prefix="/api/v1/assistant", tags=["assistant"])
+    app.include_router(auth.router, prefix="/api/v1/auth", tags=["auth"])
 
-@asynccontextmanager
-async def lifespan(app: FastAPI):
-    """Startup and shutdown events for the application"""
-    async with mcp_app.lifespan(app):
-        # Startup: initialize services and flush cache
-        cache_service = get_cache_service()
-        await cache_service.flush_all()
-        logger.info("Cache cleared on startup")
+    app.mount("/api/v1/mcp", mcp_app)
 
-        # Warm remaining singletons
-        get_llm_service()
+    @app.get("/")
+    async def root():
+        return {"message": "BRC Analytics API", "version": settings.APP_VERSION}
 
-        logger.info("All services initialized")
-
-        yield
-
-        # Shutdown: close connections and reset all service singletons
-        auth_service = get_auth_service()
-        await auth_service.close()
-        await cache_service.close()
-        reset_all_services()
-        logger.info("All services shut down")
-
-
-app = FastAPI(
-    title="BRC Analytics API",
-    version=settings.APP_VERSION,
-    openapi_url="/api/v1/openapi.json",
-    docs_url="/api/v1/docs",
-    redoc_url="/api/v1/redoc",
-    lifespan=lifespan,
-)
-
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=settings.CORS_ORIGINS,
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
-
-# Include routers
-app.include_router(health.router, prefix="/api/v1", tags=["health"])
-app.include_router(cache.router, prefix="/api/v1/cache", tags=["cache"])
-app.include_router(version.router, prefix="/api/v1/version", tags=["version"])
-app.include_router(links.router, prefix="/api/v1", tags=["links"])
-app.include_router(llm.router, prefix="/api/v1/llm", tags=["llm"])
-app.include_router(ena.router, prefix="/api/v1/ena", tags=["ena"])
-app.include_router(assistant.router, prefix="/api/v1/assistant", tags=["assistant"])
-app.include_router(auth.router, prefix="/api/v1/auth", tags=["auth"])
-
-app.mount("/api/v1/mcp", mcp_app)
-
-
-@app.get("/")
-async def root():
-    return {"message": "BRC Analytics API", "version": settings.APP_VERSION}
+    return app

--- a/backend/api/app/main.py
+++ b/backend/api/app/main.py
@@ -41,7 +41,6 @@ def create_app() -> FastAPI:
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):
-        """Startup and shutdown events for the application."""
         async with mcp_app.lifespan(app):
             cache_service = get_cache_service()
             await cache_service.flush_all()

--- a/backend/api/tests/test_mcp.py
+++ b/backend/api/tests/test_mcp.py
@@ -7,9 +7,7 @@ group never starts and every request to /api/v1/mcp/ returns 500 with
 RuntimeError("Task group is not initialized. Make sure to use run().").
 """
 
-import importlib
 import json
-import sys
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -20,12 +18,8 @@ from tests.test_catalog_data import SAMPLE_ORGANISMS, SAMPLE_WORKFLOWS
 
 @pytest.fixture()
 def mcp_app(tmp_path, monkeypatch):
-    """Reload app.main with a sample catalog and stubbed Redis-backed services.
-
-    The MCP server is constructed at module scope using get_catalog_data() and
-    get_ena_service(), so CATALOG_PATH must be set and any service that would
-    hit Redis must be patched before importing the module.
-    """
+    """Build a fresh app via create_app() with a sample catalog and stubbed
+    Redis-backed services."""
     (tmp_path / "organisms.json").write_text(json.dumps(SAMPLE_ORGANISMS))
     (tmp_path / "workflows.json").write_text(json.dumps(SAMPLE_WORKFLOWS))
     monkeypatch.setenv("CATALOG_PATH", str(tmp_path))
@@ -36,13 +30,12 @@ def mcp_app(tmp_path, monkeypatch):
     fake_auth = MagicMock()
     fake_auth.close = AsyncMock()
 
-    sys.modules.pop("app.main", None)
-    sys.modules.pop("app.core.config", None)
-
     from app.core import dependencies
+    from app.core.config import get_settings
 
-    # MagicMock auto-creates attributes like .cache_clear, which
-    # reset_all_services() calls on every dependency getter during shutdown.
+    get_settings.cache_clear()
+    dependencies.reset_all_services()
+
     monkeypatch.setattr(
         dependencies, "get_cache_service", MagicMock(return_value=fake_cache)
     )
@@ -53,10 +46,9 @@ def mcp_app(tmp_path, monkeypatch):
         dependencies, "get_llm_service", MagicMock(return_value=MagicMock())
     )
 
-    main_module = importlib.import_module("app.main")
-    yield main_module.app
+    from app.main import create_app
 
-    sys.modules.pop("app.main", None)
+    yield create_app()
 
 
 def _parse_sse(body: str) -> dict:

--- a/backend/api/tests/test_sentry_startup.py
+++ b/backend/api/tests/test_sentry_startup.py
@@ -1,6 +1,7 @@
 """Regression tests for Sentry startup wiring."""
 
 from app.core.config import get_settings
+from app.core.dependencies import reset_all_services
 from app.main import create_app
 
 
@@ -9,6 +10,7 @@ def test_create_app_with_sentry_dsn(monkeypatch):
         "SENTRY_DSN", "https://examplePublicKey@example.ingest.sentry.io/1"
     )
     get_settings.cache_clear()
+    reset_all_services()
 
     app = create_app()
 

--- a/backend/api/tests/test_sentry_startup.py
+++ b/backend/api/tests/test_sentry_startup.py
@@ -1,20 +1,15 @@
 """Regression tests for Sentry startup wiring."""
 
-import importlib
-import sys
+from app.core.config import get_settings
+from app.main import create_app
 
 
-def _reload_app_main():
-    sys.modules.pop("app.main", None)
-    sys.modules.pop("app.core.config", None)
-    return importlib.import_module("app.main")
-
-
-def test_import_app_main_with_sentry_dsn(monkeypatch):
+def test_create_app_with_sentry_dsn(monkeypatch):
     monkeypatch.setenv(
         "SENTRY_DSN", "https://examplePublicKey@example.ingest.sentry.io/1"
     )
+    get_settings.cache_clear()
 
-    module = _reload_app_main()
+    app = create_app()
 
-    assert module.app.title == "BRC Analytics API"
+    assert app.title == "BRC Analytics API"


### PR DESCRIPTION
Follow-up to https://github.com/galaxyproject/brc-analytics/pull/1227#discussion_r3069232334

Wasn't as bad as I thought.

## Summary

- Wraps all side effects in `backend/api/app/main.py` into a `create_app()` factory function so importing the module no longer triggers Sentry init, catalog loading, or MCP server construction. Uvicorn calls it via `--factory`.
- Updates Dockerfile CMD and README dev command to use `app.main:create_app --factory`.
- Simplifies test files to call the factory directly instead of the `sys.modules.pop` / `importlib.import_module` dance.

## Test plan

- [x] `pytest tests/` passes (62/62, excluding pre-existing `test_links.py` failures)
- [x] `python -c "from app.main import create_app"` completes with no side effects
- [x] `uvicorn app.main:create_app --factory` boots cleanly, MCP initialize returns 200