### PR TITLE
feat: add open graph and twitter card meta tags for brc analytics

### DIFF
--- a/app/common/meta/brc/constants.ts
+++ b/app/common/meta/brc/constants.ts
@@ -1,7 +1,9 @@
 /**
  * Page metadata for BRC Analytics — titles and descriptions used in OG/Twitter meta tags.
- * GA2 metadata lives in a separate file under meta/ga2/.
  */
+
+export const BRC_DEFAULT_DESCRIPTION =
+  "BRC Analytics: explore, analyze, and share genomic data across organisms using Galaxy workflows.";
 
 export const BRC_PAGE_META = {
   ABOUT: {
@@ -44,8 +46,7 @@ export const BRC_PAGE_META = {
     pageTitle: "Custom Workflow",
   },
   HOME: {
-    pageDescription:
-      "BRC Analytics: explore, analyze, and share genomic data across organisms using Galaxy workflows.",
+    pageDescription: BRC_DEFAULT_DESCRIPTION,
   },
   LEARN: {
     pageDescription:

--- a/app/common/meta/brc/constants.ts
+++ b/app/common/meta/brc/constants.ts
@@ -1,0 +1,92 @@
+/**
+ * Page metadata for BRC Analytics — titles and descriptions used in OG/Twitter meta tags.
+ * GA2 metadata lives in a separate file under meta/ga2/.
+ */
+
+export const BRC_PAGE_META = {
+  ABOUT: {
+    pageDescription:
+      "Learn about BRC Analytics, a platform for genomic analysis across organisms.",
+    pageTitle: "About",
+  },
+  ANALYZE_WORKFLOWS: {
+    pageDescription:
+      "Select and configure workflows for genome analysis on BRC Analytics.",
+    pageTitle: "Analyze",
+  },
+  ASSEMBLIES: {
+    pageDescription:
+      "Browse genome assemblies available for analysis on BRC Analytics.",
+    pageTitle: "Assemblies",
+  },
+  ASSEMBLY_DETAIL: {
+    pageDescription:
+      "Select and configure workflows for genome analysis on BRC Analytics.",
+    pageTitle: "Analyze",
+  },
+  ASSISTANT: {
+    pageDescription:
+      "Get AI-assisted help with genomic analysis on BRC Analytics.",
+    pageTitle: "Analysis Assistant",
+  },
+  CALENDAR: {
+    pageDescription: "View upcoming events and workshops for BRC Analytics.",
+    pageTitle: "Calendar",
+  },
+  CONFIGURE_WORKFLOW: {
+    pageDescription:
+      "Configure workflow inputs for genome analysis on BRC Analytics.",
+    pageTitle: "Configure Workflow",
+  },
+  CUSTOM_WORKFLOW: {
+    pageDescription:
+      "Configure a custom workflow for genome analysis on BRC Analytics.",
+    pageTitle: "Custom Workflow",
+  },
+  HOME: {
+    pageDescription:
+      "BRC Analytics: explore, analyze, and share genomic data across organisms using Galaxy workflows.",
+  },
+  LEARN: {
+    pageDescription:
+      "Learn about genomic analysis tools, workflows, and best practices on BRC Analytics.",
+    pageTitle: "Learn About BRC Analytics",
+  },
+  ORGANISMS: {
+    pageDescription:
+      "Browse organisms available for genomic analysis on BRC Analytics.",
+    pageTitle: "Organisms",
+  },
+  ORGANISM_DETAIL: {
+    pageDescription:
+      "View organism details and available genome assemblies on BRC Analytics.",
+    pageTitle: "Organism",
+  },
+  PRIORITY_PATHOGENS: {
+    pageDescription:
+      "Browse priority pathogens available for analysis on BRC Analytics.",
+    pageTitle: "Priority Pathogens",
+  },
+  PRIORITY_PATHOGEN_DETAIL: {
+    pageDescription: "View priority pathogen details on BRC Analytics.",
+    pageTitle: "Priority Pathogen",
+  },
+  ROADMAP: {
+    pageDescription: "View the development roadmap for BRC Analytics.",
+    pageTitle: "Roadmap",
+  },
+  SEARCH: {
+    pageDescription:
+      "Search across organisms, assemblies, and workflows on BRC Analytics.",
+    pageTitle: "Search",
+  },
+  WORKFLOW: {
+    pageDescription: "View workflow details on BRC Analytics.",
+    pageTitle: "Workflow",
+  },
+  WORKFLOWS: {
+    pageDescription:
+      "Explore Galaxy workflows available for genomic analysis on BRC Analytics.",
+    pageTitle: "Workflows",
+  },
+} as const;

--- a/app/components/common/OgMeta/ogMeta.tsx
+++ b/app/components/common/OgMeta/ogMeta.tsx
@@ -1,0 +1,47 @@
+import { useConfig } from "@databiosphere/findable-ui/lib/hooks/useConfig";
+import NextHead from "next/head";
+import { useRouter } from "next/router";
+import { JSX } from "react";
+
+const DEFAULT_DESCRIPTION =
+  "BRC Analytics: explore, analyze, and share genomic data across organisms using Galaxy workflows.";
+
+interface OgMetaProps {
+  pageDescription?: string;
+  pageTitle?: string;
+}
+
+export const OgMeta = ({
+  pageDescription,
+  pageTitle,
+}: OgMetaProps): JSX.Element => {
+  const { config } = useConfig();
+  const { asPath } = useRouter();
+  const { appTitle, browserURL } = config;
+  const title =
+    pageTitle && pageTitle !== appTitle
+      ? `${pageTitle} - ${appTitle}`
+      : appTitle;
+  const description = pageDescription || DEFAULT_DESCRIPTION;
+  const path = asPath.split(/[?#]/)[0];
+  const url = `${browserURL}${path}`;
+  const image = `${browserURL}/favicons/android-chrome-512x512.png`;
+  return (
+    <NextHead>
+      <meta key="og:title" property="og:title" content={title} />
+      <meta
+        key="og:description"
+        property="og:description"
+        content={description}
+      />
+      <meta key="og:image" property="og:image" content={image} />
+      <meta key="og:image:width" property="og:image:width" content="512" />
+      <meta key="og:image:height" property="og:image:height" content="512" />
+      <meta key="og:site_name" property="og:site_name" content={appTitle} />
+      <meta key="og:type" property="og:type" content="website" />
+      <meta key="og:url" property="og:url" content={url} />
+      <meta key="twitter:card" name="twitter:card" content="summary" />
+      <meta key="twitter:image" name="twitter:image" content={image} />
+    </NextHead>
+  );
+};

--- a/app/components/common/OgMeta/ogMeta.tsx
+++ b/app/components/common/OgMeta/ogMeta.tsx
@@ -1,4 +1,3 @@
-import { useConfig } from "@databiosphere/findable-ui/lib/hooks/useConfig";
 import NextHead from "next/head";
 import { useRouter } from "next/router";
 import { JSX } from "react";
@@ -7,17 +6,19 @@ const DEFAULT_DESCRIPTION =
   "BRC Analytics: explore, analyze, and share genomic data across organisms using Galaxy workflows.";
 
 interface OgMetaProps {
+  appTitle: string;
+  browserURL: string;
   pageDescription?: string;
   pageTitle?: string;
 }
 
 export const OgMeta = ({
+  appTitle,
+  browserURL,
   pageDescription,
   pageTitle,
 }: OgMetaProps): JSX.Element => {
-  const { config } = useConfig();
   const { asPath } = useRouter();
-  const { appTitle, browserURL } = config;
   const title =
     pageTitle && pageTitle !== appTitle
       ? `${pageTitle} - ${appTitle}`

--- a/app/components/common/OgMeta/ogMeta.tsx
+++ b/app/components/common/OgMeta/ogMeta.tsx
@@ -1,11 +1,11 @@
 import NextHead from "next/head";
 import { useRouter } from "next/router";
 import { JSX } from "react";
-import { BRC_PAGE_META } from "../../../common/meta/brc/constants";
 
 interface OgMetaProps {
   appTitle: string;
   browserURL: string;
+  defaultDescription: string;
   pageDescription?: string;
   pageTitle?: string;
 }
@@ -13,6 +13,7 @@ interface OgMetaProps {
 export const OgMeta = ({
   appTitle,
   browserURL,
+  defaultDescription,
   pageDescription,
   pageTitle,
 }: OgMetaProps): JSX.Element => {
@@ -21,7 +22,7 @@ export const OgMeta = ({
     pageTitle && pageTitle !== appTitle
       ? `${pageTitle} - ${appTitle}`
       : appTitle;
-  const description = pageDescription || BRC_PAGE_META.HOME.pageDescription;
+  const description = pageDescription || defaultDescription;
   const path = asPath.split(/[?#]/)[0];
   const url = `${browserURL}${path}`;
   const image = `${browserURL}/favicons/android-chrome-512x512.png`;

--- a/app/components/common/OgMeta/ogMeta.tsx
+++ b/app/components/common/OgMeta/ogMeta.tsx
@@ -1,9 +1,7 @@
 import NextHead from "next/head";
 import { useRouter } from "next/router";
 import { JSX } from "react";
-
-const DEFAULT_DESCRIPTION =
-  "BRC Analytics: explore, analyze, and share genomic data across organisms using Galaxy workflows.";
+import { BRC_PAGE_META } from "../../../common/meta/brc/constants";
 
 interface OgMetaProps {
   appTitle: string;
@@ -23,7 +21,7 @@ export const OgMeta = ({
     pageTitle && pageTitle !== appTitle
       ? `${pageTitle} - ${appTitle}`
       : appTitle;
-  const description = pageDescription || DEFAULT_DESCRIPTION;
+  const description = pageDescription || BRC_PAGE_META.HOME.pageDescription;
   const path = asPath.split(/[?#]/)[0];
   const url = `${browserURL}${path}`;
   const image = `${browserURL}/favicons/android-chrome-512x512.png`;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -22,8 +22,9 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { NextPage } from "next";
 import type { AppProps } from "next/app";
 import { JSX, useMemo } from "react";
-import { StyledFooter } from "../app/components/Layout/components/Footer/footer.styles";
+import { BRC_DEFAULT_DESCRIPTION } from "../app/common/meta/brc/constants";
 import { OgMeta } from "../app/components/common/OgMeta/ogMeta";
+import { StyledFooter } from "../app/components/Layout/components/Footer/footer.styles";
 import { config } from "../app/config/config";
 import { BrcAuthProvider } from "../app/providers/authentication";
 import { useEntities } from "../app/services/workflows/hooks/UseEntities/hook";
@@ -92,6 +93,7 @@ function MyApp({ Component, pageProps }: AppPropsWithComponent): JSX.Element {
     <OgMeta
       appTitle={appConfig.appTitle}
       browserURL={appConfig.browserURL}
+      defaultDescription={BRC_DEFAULT_DESCRIPTION}
       pageDescription={pageDescription}
       pageTitle={pageTitle}
     />

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -86,14 +86,23 @@ function MyApp({ Component, pageProps }: AppPropsWithComponent): JSX.Element {
     };
   }, [header, isAssistantEnabled]);
 
-  if (!isEntitiesLoaded) return <></>;
+  const ogMeta = (
+    <OgMeta
+      appTitle={appConfig.appTitle}
+      browserURL={appConfig.browserURL}
+      pageDescription={pageDescription}
+      pageTitle={pageTitle}
+    />
+  );
+
+  if (!isEntitiesLoaded) return ogMeta;
 
   return (
     <EmotionThemeProvider theme={appTheme}>
       <ThemeProvider theme={appTheme}>
         <DXConfigProvider config={appConfig} entityListType={entityListType}>
           <Head pageTitle={pageTitle} />
-          <OgMeta pageDescription={pageDescription} pageTitle={pageTitle} />
+          {ogMeta}
           <CssBaseline />
           <QueryClientProvider client={queryClient}>
             <ServicesProvider>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -31,7 +31,6 @@ import "../app/styles/fonts/fonts.css";
 import { mergeAppTheme } from "../app/theme/theme";
 import { ROUTES } from "../routes/constants";
 import { APP_KEYS } from "../site-config/common/constants";
-import { AppSiteConfig } from "../site-config/common/entities";
 
 const DEFAULT_ENTITY_LIST_TYPE = "organisms";
 
@@ -88,7 +87,7 @@ function MyApp({ Component, pageProps }: AppPropsWithComponent): JSX.Element {
     };
   }, [header, isAssistantEnabled]);
 
-  const isBRC = (appConfig as AppSiteConfig).appKey === APP_KEYS.BRC_ANALYTICS;
+  const isBRC = appConfig.appKey === APP_KEYS.BRC_ANALYTICS;
   const ogMeta = isBRC ? (
     <OgMeta
       appTitle={appConfig.appTitle}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -23,6 +23,7 @@ import { NextPage } from "next";
 import type { AppProps } from "next/app";
 import { JSX, useMemo } from "react";
 import { StyledFooter } from "../app/components/Layout/components/Footer/footer.styles";
+import { OgMeta } from "../app/components/common/OgMeta/ogMeta";
 import { config } from "../app/config/config";
 import { BrcAuthProvider } from "../app/providers/authentication";
 import { useEntities } from "../app/services/workflows/hooks/UseEntities/hook";
@@ -33,6 +34,7 @@ import { ROUTES } from "../routes/constants";
 const DEFAULT_ENTITY_LIST_TYPE = "organisms";
 
 export interface PageProps extends AzulEntitiesStaticResponse {
+  pageDescription?: string;
   pageTitle?: string;
 }
 
@@ -63,6 +65,7 @@ function MyApp({ Component, pageProps }: AppPropsWithComponent): JSX.Element {
   const { floating, footer, header } = layout || {};
   const {
     entityListType = DEFAULT_ENTITY_LIST_TYPE,
+    pageDescription,
     pageTitle,
     themeOptions,
   } = pageProps;
@@ -90,6 +93,7 @@ function MyApp({ Component, pageProps }: AppPropsWithComponent): JSX.Element {
       <ThemeProvider theme={appTheme}>
         <DXConfigProvider config={appConfig} entityListType={entityListType}>
           <Head pageTitle={pageTitle} />
+          <OgMeta pageDescription={pageDescription} pageTitle={pageTitle} />
           <CssBaseline />
           <QueryClientProvider client={queryClient}>
             <ServicesProvider>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -30,6 +30,8 @@ import { useEntities } from "../app/services/workflows/hooks/UseEntities/hook";
 import "../app/styles/fonts/fonts.css";
 import { mergeAppTheme } from "../app/theme/theme";
 import { ROUTES } from "../routes/constants";
+import { APP_KEYS } from "../site-config/common/constants";
+import { AppSiteConfig } from "../site-config/common/entities";
 
 const DEFAULT_ENTITY_LIST_TYPE = "organisms";
 
@@ -86,16 +88,17 @@ function MyApp({ Component, pageProps }: AppPropsWithComponent): JSX.Element {
     };
   }, [header, isAssistantEnabled]);
 
-  const ogMeta = (
+  const isBRC = (appConfig as AppSiteConfig).appKey === APP_KEYS.BRC_ANALYTICS;
+  const ogMeta = isBRC ? (
     <OgMeta
       appTitle={appConfig.appTitle}
       browserURL={appConfig.browserURL}
       pageDescription={pageDescription}
       pageTitle={pageTitle}
     />
-  );
+  ) : null;
 
-  if (!isEntitiesLoaded) return ogMeta;
+  if (!isEntitiesLoaded) return <>{ogMeta}</>;
 
   return (
     <EmotionThemeProvider theme={appTheme}>

--- a/pages/about/index.tsx
+++ b/pages/about/index.tsx
@@ -25,6 +25,8 @@ export const getStaticProps: GetStaticProps = async () => {
 
   return {
     props: {
+      pageDescription:
+        "Learn about BRC Analytics, a platform for genomic analysis across organisms.",
       pageTitle: "About",
       themeOptions: {
         palette: { background: { default: "#FAFBFB" } }, // SMOKE_LIGHTEST

--- a/pages/about/index.tsx
+++ b/pages/about/index.tsx
@@ -4,6 +4,7 @@ import { StyledPagesMain } from "../../app/components/Layout/components/Main/mai
 import { AboutView } from "../../app/views/AboutView/aboutView";
 import { AboutViewGA2 } from "../../app/views/AboutView/aboutViewGA2";
 import { APP_KEYS } from "../../site-config/common/constants";
+import { BRC_PAGE_META } from "../../app/common/meta/brc/constants";
 import { config } from "../../app/config/config";
 import { ROUTES } from "../../routes/constants";
 
@@ -25,9 +26,7 @@ export const getStaticProps: GetStaticProps = async () => {
 
   return {
     props: {
-      pageDescription:
-        "Learn about BRC Analytics, a platform for genomic analysis across organisms.",
-      pageTitle: "About",
+      ...BRC_PAGE_META.ABOUT,
       themeOptions: {
         palette: { background: { default: "#FAFBFB" } }, // SMOKE_LIGHTEST
       },

--- a/pages/assistant/index.tsx
+++ b/pages/assistant/index.tsx
@@ -10,6 +10,8 @@ export const Assistant = (): JSX.Element => {
 export const getStaticProps: GetStaticProps = async () => {
   return {
     props: {
+      pageDescription:
+        "Get AI-assisted help with genomic analysis on BRC Analytics.",
       pageTitle: "Analysis Assistant",
       themeOptions: {
         palette: { background: { default: "#FAFBFB" } },

--- a/pages/assistant/index.tsx
+++ b/pages/assistant/index.tsx
@@ -1,5 +1,6 @@
 import { JSX } from "react";
 import { GetStaticProps } from "next";
+import { BRC_PAGE_META } from "../../app/common/meta/brc/constants";
 import { StyledPagesMain } from "../../app/components/Layout/components/Main/main.styles";
 import { AssistantView } from "../../app/views/AssistantView/assistantView";
 
@@ -10,9 +11,7 @@ export const Assistant = (): JSX.Element => {
 export const getStaticProps: GetStaticProps = async () => {
   return {
     props: {
-      pageDescription:
-        "Get AI-assisted help with genomic analysis on BRC Analytics.",
-      pageTitle: "Analysis Assistant",
+      ...BRC_PAGE_META.ASSISTANT,
       themeOptions: {
         palette: { background: { default: "#FAFBFB" } },
       },

--- a/pages/calendar/index.tsx
+++ b/pages/calendar/index.tsx
@@ -2,6 +2,7 @@ import { JSX } from "react";
 import { GetStaticProps } from "next";
 import { StyledPagesMain } from "../../app/components/Layout/components/Main/main.styles";
 import { CalendarView } from "../../app/views/CalendarView/calendarView";
+import { BRC_PAGE_META } from "../../app/common/meta/brc/constants";
 import { config } from "../../app/config/config";
 import { ROUTES } from "../../routes/constants";
 
@@ -18,8 +19,7 @@ export const getStaticProps: GetStaticProps = async () => {
 
   return {
     props: {
-      pageDescription: "View upcoming events and workshops for BRC Analytics.",
-      pageTitle: "Calendar",
+      ...BRC_PAGE_META.CALENDAR,
       themeOptions: {
         palette: { background: { default: "#FAFBFB" } }, // SMOKE_LIGHTEST
       },

--- a/pages/calendar/index.tsx
+++ b/pages/calendar/index.tsx
@@ -18,6 +18,7 @@ export const getStaticProps: GetStaticProps = async () => {
 
   return {
     props: {
+      pageDescription: "View upcoming events and workshops for BRC Analytics.",
       pageTitle: "Calendar",
       themeOptions: {
         palette: { background: { default: "#FAFBFB" } }, // SMOKE_LIGHTEST

--- a/pages/data/[entityListType]/[entityId]/analyze/custom.tsx
+++ b/pages/data/[entityListType]/[entityId]/analyze/custom.tsx
@@ -19,6 +19,8 @@ interface Params extends ParsedUrlQuery {
 
 export interface Props {
   entityId: string;
+  pageDescription?: string;
+  pageTitle?: string;
   trsId: string;
 }
 
@@ -55,7 +57,15 @@ export const getStaticProps: GetStaticProps<Props> = async ({
   if (!entityId) return { notFound: true };
 
   // Pass the custom workflow TRS ID as a prop to the page, so that the correct workflow is loaded in the WorkflowInputsView.
-  return { props: { entityId, trsId: CUSTOM_WORKFLOW.trsId } };
+  return {
+    props: {
+      entityId,
+      pageDescription:
+        "Configure a custom workflow for genome analysis on BRC Analytics.",
+      pageTitle: "Custom Workflow",
+      trsId: CUSTOM_WORKFLOW.trsId,
+    },
+  };
 };
 
 /**

--- a/pages/data/[entityListType]/[entityId]/analyze/custom.tsx
+++ b/pages/data/[entityListType]/[entityId]/analyze/custom.tsx
@@ -6,6 +6,7 @@ import {
 } from "next";
 import { ParsedUrlQuery } from "querystring";
 import { JSX } from "react";
+import { BRC_PAGE_META } from "../../../../../app/common/meta/brc/constants";
 import { config } from "../../../../../app/config/config";
 import { getEntities } from "../../../../../app/utils/entityUtils";
 import { seedDatabase } from "../../../../../app/utils/seedDatabase";
@@ -60,9 +61,7 @@ export const getStaticProps: GetStaticProps<Props> = async ({
   return {
     props: {
       entityId,
-      pageDescription:
-        "Configure a custom workflow for genome analysis on BRC Analytics.",
-      pageTitle: "Custom Workflow",
+      ...BRC_PAGE_META.CUSTOM_WORKFLOW,
       trsId: CUSTOM_WORKFLOW.trsId,
     },
   };

--- a/pages/data/[entityListType]/[entityId]/analyze/workflows/[trsId]/index.tsx
+++ b/pages/data/[entityListType]/[entityId]/analyze/workflows/[trsId]/index.tsx
@@ -29,6 +29,8 @@ interface Params extends ParsedUrlQuery {
 interface Props {
   entityId: string;
   entityListType: string;
+  pageDescription?: string;
+  pageTitle?: string;
   trsId: string;
 }
 
@@ -62,7 +64,16 @@ export const getStaticProps = async (
   if (!entityListType || !entityId || !trsId) return { notFound: true };
   if (entityListType !== "assemblies") return { notFound: true };
 
-  return { props: { entityId, entityListType, trsId } };
+  return {
+    props: {
+      entityId,
+      entityListType,
+      pageDescription:
+        "Configure workflow inputs for genome analysis on BRC Analytics.",
+      pageTitle: "Configure Workflow",
+      trsId,
+    },
+  };
 };
 
 const Page = (props: Props): JSX.Element => {

--- a/pages/data/[entityListType]/[entityId]/analyze/workflows/[trsId]/index.tsx
+++ b/pages/data/[entityListType]/[entityId]/analyze/workflows/[trsId]/index.tsx
@@ -8,6 +8,7 @@ import {
 import { ParsedUrlQuery } from "querystring";
 import { JSX } from "react";
 import { EntitiesResponse } from "../../../../../../../app/apis/catalog/brc-analytics-catalog/common/entities";
+import { BRC_PAGE_META } from "../../../../../../../app/common/meta/brc/constants";
 import { config } from "../../../../../../../app/config/config";
 import { getEntities } from "../../../../../../../app/utils/entityUtils";
 import { seedDatabase } from "../../../../../../../app/utils/seedDatabase";
@@ -68,9 +69,7 @@ export const getStaticProps = async (
     props: {
       entityId,
       entityListType,
-      pageDescription:
-        "Configure workflow inputs for genome analysis on BRC Analytics.",
-      pageTitle: "Configure Workflow",
+      ...BRC_PAGE_META.CONFIGURE_WORKFLOW,
       trsId,
     },
   };

--- a/pages/data/[entityListType]/[entityId]/analyze/workflows/index.tsx
+++ b/pages/data/[entityListType]/[entityId]/analyze/workflows/index.tsx
@@ -18,6 +18,8 @@ interface Params extends ParsedUrlQuery {
 
 export interface Props {
   entityId: string;
+  pageDescription?: string;
+  pageTitle?: string;
 }
 
 export const getStaticPaths: GetStaticPaths<Params> = async () => {
@@ -52,7 +54,14 @@ export const getStaticProps: GetStaticProps<Props> = async ({
 
   if (!entityId) return { notFound: true };
 
-  return { props: { entityId } };
+  return {
+    props: {
+      entityId,
+      pageDescription:
+        "Select and configure workflows for genome analysis on BRC Analytics.",
+      pageTitle: "Analyze",
+    },
+  };
 };
 
 /**

--- a/pages/data/[entityListType]/[entityId]/analyze/workflows/index.tsx
+++ b/pages/data/[entityListType]/[entityId]/analyze/workflows/index.tsx
@@ -6,6 +6,7 @@ import {
 } from "next";
 import { ParsedUrlQuery } from "querystring";
 import { JSX } from "react";
+import { BRC_PAGE_META } from "../../../../../../app/common/meta/brc/constants";
 import { config } from "../../../../../../app/config/config";
 import { getEntities } from "../../../../../../app/utils/entityUtils";
 import { seedDatabase } from "../../../../../../app/utils/seedDatabase";
@@ -57,9 +58,7 @@ export const getStaticProps: GetStaticProps<Props> = async ({
   return {
     props: {
       entityId,
-      pageDescription:
-        "Select and configure workflows for genome analysis on BRC Analytics.",
-      pageTitle: "Analyze",
+      ...BRC_PAGE_META.ANALYZE_WORKFLOWS,
     },
   };
 };

--- a/pages/data/[entityListType]/[entityId]/index.tsx
+++ b/pages/data/[entityListType]/[entityId]/index.tsx
@@ -27,7 +27,29 @@ export interface EntityPageProps<R> {
   data?: R;
   entityId: string;
   entityListType: string;
+  pageDescription?: string;
+  pageTitle?: string;
 }
+
+const ENTITY_DETAIL_META: Record<
+  string,
+  { pageDescription: string; pageTitle: string }
+> = {
+  assemblies: {
+    pageDescription:
+      "Select and configure workflows for genome analysis on BRC Analytics.",
+    pageTitle: "Analyze",
+  },
+  organisms: {
+    pageDescription:
+      "View organism details and available genome assemblies on BRC Analytics.",
+    pageTitle: "Organism",
+  },
+  "priority-pathogens": {
+    pageDescription: "View priority pathogen details on BRC Analytics.",
+    pageTitle: "Priority Pathogen",
+  },
+};
 
 /**
  * Entity detail view page.
@@ -89,10 +111,13 @@ export const getStaticProps: GetStaticProps<
   };
 
   const entityConfig = getEntityConfig(entities, entityListType);
+  const entityMeta = ENTITY_DETAIL_META[entityListType];
 
   const props: EntityPageProps<BRCCatalog | GA2Catalog> = {
     entityId,
     entityListType,
+    pageDescription: entityMeta?.pageDescription,
+    pageTitle: entityMeta?.pageTitle,
   };
 
   // Process entity props.

--- a/pages/data/[entityListType]/[entityId]/index.tsx
+++ b/pages/data/[entityListType]/[entityId]/index.tsx
@@ -8,6 +8,7 @@ import {
   EntitiesResponse,
 } from "../../../../app/apis/catalog/brc-analytics-catalog/common/entities";
 import { GA2Catalog } from "../../../../app/apis/catalog/ga2/entities";
+import { BRC_PAGE_META } from "../../../../app/common/meta/brc/constants";
 import { config } from "../../../../app/config/config";
 import { getEntities, getEntity } from "../../../../app/utils/entityUtils";
 import { seedDatabase } from "../../../../app/utils/seedDatabase";
@@ -35,20 +36,9 @@ const ENTITY_DETAIL_META: Record<
   string,
   { pageDescription: string; pageTitle: string }
 > = {
-  assemblies: {
-    pageDescription:
-      "Select and configure workflows for genome analysis on BRC Analytics.",
-    pageTitle: "Analyze",
-  },
-  organisms: {
-    pageDescription:
-      "View organism details and available genome assemblies on BRC Analytics.",
-    pageTitle: "Organism",
-  },
-  "priority-pathogens": {
-    pageDescription: "View priority pathogen details on BRC Analytics.",
-    pageTitle: "Priority Pathogen",
-  },
+  assemblies: BRC_PAGE_META.ASSEMBLY_DETAIL,
+  organisms: BRC_PAGE_META.ORGANISM_DETAIL,
+  "priority-pathogens": BRC_PAGE_META.PRIORITY_PATHOGEN_DETAIL,
 };
 
 /**

--- a/pages/data/[entityListType]/index.tsx
+++ b/pages/data/[entityListType]/index.tsx
@@ -11,6 +11,7 @@ import {
   Outbreak,
 } from "../../../app/apis/catalog/brc-analytics-catalog/common/entities";
 import { GA2Catalog } from "../../../app/apis/catalog/ga2/entities";
+import { BRC_PAGE_META } from "../../../app/common/meta/brc/constants";
 import { config } from "../../../app/config/config";
 import { seedDatabase } from "../../../app/utils/seedDatabase";
 import { StyledExploreView } from "../../../app/views/ExploreView/exploreView.styles";
@@ -31,21 +32,9 @@ const ENTITY_LIST_META: Record<
   string,
   { pageDescription: string; pageTitle: string }
 > = {
-  assemblies: {
-    pageDescription:
-      "Browse genome assemblies available for analysis on BRC Analytics.",
-    pageTitle: "Assemblies",
-  },
-  organisms: {
-    pageDescription:
-      "Browse organisms available for genomic analysis on BRC Analytics.",
-    pageTitle: "Organisms",
-  },
-  "priority-pathogens": {
-    pageDescription:
-      "Browse priority pathogens available for analysis on BRC Analytics.",
-    pageTitle: "Priority Pathogens",
-  },
+  assemblies: BRC_PAGE_META.ASSEMBLIES,
+  organisms: BRC_PAGE_META.ORGANISMS,
+  "priority-pathogens": BRC_PAGE_META.PRIORITY_PATHOGENS,
 };
 
 /**

--- a/pages/data/[entityListType]/index.tsx
+++ b/pages/data/[entityListType]/index.tsx
@@ -23,7 +23,30 @@ interface PageUrl extends ParsedUrlQuery {
 interface EntitiesPageProps<R> {
   data?: EntitiesResponse<R>;
   entityListType: string;
+  pageDescription?: string;
+  pageTitle?: string;
 }
+
+const ENTITY_LIST_META: Record<
+  string,
+  { pageDescription: string; pageTitle: string }
+> = {
+  assemblies: {
+    pageDescription:
+      "Browse genome assemblies available for analysis on BRC Analytics.",
+    pageTitle: "Assemblies",
+  },
+  organisms: {
+    pageDescription:
+      "Browse organisms available for genomic analysis on BRC Analytics.",
+    pageTitle: "Organisms",
+  },
+  "priority-pathogens": {
+    pageDescription:
+      "Browse priority pathogens available for analysis on BRC Analytics.",
+    pageTitle: "Priority Pathogens",
+  },
+};
 
 /**
  * Explore view page.
@@ -87,8 +110,12 @@ export const getStaticProps: GetStaticProps<
   const { exploreMode } = entityConfig;
   const { fetchAllEntities } = getEntityService(entityConfig, undefined); // Determine the type of fetch, either from an API endpoint or a TSV.
 
+  const entityMeta = ENTITY_LIST_META[entityListType];
+
   const props: EntitiesPageProps<BRCCatalog | GA2Catalog> = {
     entityListType,
+    pageDescription: entityMeta?.pageDescription,
+    pageTitle: entityMeta?.pageTitle,
   };
 
   // Seed database.

--- a/pages/data/workflows/[trsId]/index.tsx
+++ b/pages/data/workflows/[trsId]/index.tsx
@@ -13,6 +13,8 @@ interface Params extends ParsedUrlQuery {
 }
 
 export interface Props {
+  pageDescription?: string;
+  pageTitle?: string;
   trsId: string;
 }
 
@@ -52,7 +54,13 @@ export const getStaticProps: GetStaticProps<Props> = async ({
 
   if (!trsId) return { notFound: true };
 
-  return { props: { trsId } };
+  return {
+    props: {
+      pageDescription: "View workflow details on BRC Analytics.",
+      pageTitle: "Workflow",
+      trsId,
+    },
+  };
 };
 
 /**

--- a/pages/data/workflows/[trsId]/index.tsx
+++ b/pages/data/workflows/[trsId]/index.tsx
@@ -1,6 +1,7 @@
 import { GetStaticPaths, GetStaticProps, GetStaticPropsContext } from "next";
 import { ParsedUrlQuery } from "querystring";
 import { JSX } from "react";
+import { BRC_PAGE_META } from "../../../../app/common/meta/brc/constants";
 import { formatTrsId } from "../../../../app/views/AnalyzeWorkflowsView/components/Main/utils";
 import { DIFFERENTIAL_EXPRESSION_ANALYSIS } from "../../../../app/views/AnalyzeWorkflowsView/differentialExpressionAnalysis/constants";
 import { LEXICMAP } from "../../../../app/views/AnalyzeWorkflowsView/lexicmap/constants";
@@ -56,8 +57,7 @@ export const getStaticProps: GetStaticProps<Props> = async ({
 
   return {
     props: {
-      pageDescription: "View workflow details on BRC Analytics.",
-      pageTitle: "Workflow",
+      ...BRC_PAGE_META.WORKFLOW,
       trsId,
     },
   };

--- a/pages/data/workflows/index.tsx
+++ b/pages/data/workflows/index.tsx
@@ -4,7 +4,14 @@ import { JSX } from "react";
 import { WorkflowsView } from "../../../app/views/WorkflowsView/workflowsView";
 
 export const getStaticProps: GetStaticProps = () => {
-  return { props: { entityListType: "workflows", pageTitle: "Workflows" } };
+  return {
+    props: {
+      entityListType: "workflows",
+      pageDescription:
+        "Explore Galaxy workflows available for genomic analysis on BRC Analytics.",
+      pageTitle: "Workflows",
+    },
+  };
 };
 
 const Page = (): JSX.Element => {

--- a/pages/data/workflows/index.tsx
+++ b/pages/data/workflows/index.tsx
@@ -1,5 +1,6 @@
 import { Main as DXMain } from "@databiosphere/findable-ui/lib/components/Layout/components/Main/main.styles";
 import { GetStaticProps } from "next";
+import { BRC_PAGE_META } from "../../../app/common/meta/brc/constants";
 import { JSX } from "react";
 import { WorkflowsView } from "../../../app/views/WorkflowsView/workflowsView";
 
@@ -7,9 +8,7 @@ export const getStaticProps: GetStaticProps = () => {
   return {
     props: {
       entityListType: "workflows",
-      pageDescription:
-        "Explore Galaxy workflows available for genomic analysis on BRC Analytics.",
-      pageTitle: "Workflows",
+      ...BRC_PAGE_META.WORKFLOWS,
     },
   };
 };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -29,6 +29,8 @@ export const getStaticProps: GetStaticProps = async () => {
 
   return {
     props: {
+      pageDescription:
+        "BRC Analytics: explore, analyze, and share genomic data across organisms using Galaxy workflows.",
       pageTitle: appTitle,
       themeOptions: {
         palette: { background: { default: backgroundColor } },

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,6 +3,7 @@ import { GetStaticProps } from "next";
 import { StyledMain } from "../app/components/Layout/components/Main/main.styles";
 import { HomeView } from "../app/views/HomeView/homeView";
 import { HomeView as GA2HomeView } from "../app/views/HomeView/ga2/homeView";
+import { BRC_PAGE_META } from "../app/common/meta/brc/constants";
 import { config } from "../app/config/config";
 import { useConfig } from "@databiosphere/findable-ui/lib/hooks/useConfig";
 import { AppSiteConfig } from "../site-config/common/entities";
@@ -29,8 +30,7 @@ export const getStaticProps: GetStaticProps = async () => {
 
   return {
     props: {
-      pageDescription:
-        "BRC Analytics: explore, analyze, and share genomic data across organisms using Galaxy workflows.",
+      pageDescription: BRC_PAGE_META.HOME.pageDescription,
       pageTitle: appTitle,
       themeOptions: {
         palette: { background: { default: backgroundColor } },

--- a/pages/learn/index.tsx
+++ b/pages/learn/index.tsx
@@ -1,6 +1,7 @@
 import { JSX } from "react";
 import { LearnView } from "../../app/views/LearnView/learnView";
 import { GetStaticProps } from "next";
+import { BRC_PAGE_META } from "../../app/common/meta/brc/constants";
 import { StyledPagesMain } from "../../app/components/Layout/components/Main/main.styles";
 import { PageProps } from "../_app";
 
@@ -13,9 +14,7 @@ export const getStaticProps: GetStaticProps<
 > = async () => {
   return {
     props: {
-      pageDescription:
-        "Learn about genomic analysis tools, workflows, and best practices on BRC Analytics.",
-      pageTitle: "Learn About BRC Analytics",
+      ...BRC_PAGE_META.LEARN,
     },
   };
 };

--- a/pages/learn/index.tsx
+++ b/pages/learn/index.tsx
@@ -11,7 +11,13 @@ const Page = (): JSX.Element => {
 export const getStaticProps: GetStaticProps<
   Pick<StaticProps, "pageTitle">
 > = async () => {
-  return { props: { pageTitle: "Learn About BRC Analytics" } };
+  return {
+    props: {
+      pageDescription:
+        "Learn about genomic analysis tools, workflows, and best practices on BRC Analytics.",
+      pageTitle: "Learn About BRC Analytics",
+    },
+  };
 };
 
 export default Page;

--- a/pages/learn/index.tsx
+++ b/pages/learn/index.tsx
@@ -2,14 +2,14 @@ import { JSX } from "react";
 import { LearnView } from "../../app/views/LearnView/learnView";
 import { GetStaticProps } from "next";
 import { StyledPagesMain } from "../../app/components/Layout/components/Main/main.styles";
-import { StaticProps } from "../../app/docs/common/staticGeneration/types";
+import { PageProps } from "../_app";
 
 const Page = (): JSX.Element => {
   return <LearnView />;
 };
 
 export const getStaticProps: GetStaticProps<
-  Pick<StaticProps, "pageTitle">
+  Pick<PageProps, "pageDescription" | "pageTitle">
 > = async () => {
   return {
     props: {

--- a/pages/learn/index.tsx
+++ b/pages/learn/index.tsx
@@ -3,7 +3,7 @@ import { LearnView } from "../../app/views/LearnView/learnView";
 import { GetStaticProps } from "next";
 import { BRC_PAGE_META } from "../../app/common/meta/brc/constants";
 import { StyledPagesMain } from "../../app/components/Layout/components/Main/main.styles";
-import { PageProps } from "../_app";
+import type { PageProps } from "../_app";
 
 const Page = (): JSX.Element => {
   return <LearnView />;

--- a/pages/roadmap/index.tsx
+++ b/pages/roadmap/index.tsx
@@ -25,6 +25,7 @@ export const getStaticProps: GetStaticProps = async () => {
 
   return {
     props: {
+      pageDescription: "View the development roadmap for BRC Analytics.",
       pageTitle: "Roadmap",
       themeOptions: {
         palette: { background: { default: "#FAFBFB" } }, // SMOKE_LIGHTEST

--- a/pages/roadmap/index.tsx
+++ b/pages/roadmap/index.tsx
@@ -3,6 +3,7 @@ import { GetStaticProps } from "next";
 import { StyledPagesMain } from "../../app/components/Layout/components/Main/main.styles";
 import { RoadmapView } from "../../app/views/RoadmapView/roadmapView";
 import { RoadmapViewGA2 } from "../../app/views/RoadmapView/roadmapViewGA2";
+import { BRC_PAGE_META } from "../../app/common/meta/brc/constants";
 import { config } from "../../app/config/config";
 import { APP_KEYS } from "../../site-config/common/constants";
 import { ROUTES } from "../../routes/constants";
@@ -25,8 +26,7 @@ export const getStaticProps: GetStaticProps = async () => {
 
   return {
     props: {
-      pageDescription: "View the development roadmap for BRC Analytics.",
-      pageTitle: "Roadmap",
+      ...BRC_PAGE_META.ROADMAP,
       themeOptions: {
         palette: { background: { default: "#FAFBFB" } }, // SMOKE_LIGHTEST
       },

--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -10,6 +10,8 @@ export const Search = (): JSX.Element => {
 export const getStaticProps: GetStaticProps = async () => {
   return {
     props: {
+      pageDescription:
+        "Search across organisms, assemblies, and workflows on BRC Analytics.",
       pageTitle: "Search",
       themeOptions: {
         palette: { background: { default: "#FAFBFB" } }, // SMOKE_LIGHTEST

--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -1,5 +1,6 @@
 import { JSX } from "react";
 import { GetStaticProps } from "next";
+import { BRC_PAGE_META } from "../../app/common/meta/brc/constants";
 import { StyledPagesMain } from "../../app/components/Layout/components/Main/main.styles";
 import { SearchView } from "../../app/views/SearchView/searchView";
 
@@ -10,9 +11,7 @@ export const Search = (): JSX.Element => {
 export const getStaticProps: GetStaticProps = async () => {
   return {
     props: {
-      pageDescription:
-        "Search across organisms, assemblies, and workflows on BRC Analytics.",
-      pageTitle: "Search",
+      ...BRC_PAGE_META.SEARCH,
       themeOptions: {
         palette: { background: { default: "#FAFBFB" } }, // SMOKE_LIGHTEST
       },


### PR DESCRIPTION
## Summary
- Adds an `OgMeta` component that renders Open Graph and Twitter Card meta tags in `<head>` via `next/head`
- Integrates `OgMeta` in `_app.tsx` alongside the existing `Head` component
- Adds page-specific `pageDescription` and `pageTitle` to `getStaticProps` across all BRC page routes
- Uses canonical URLs (query strings/hash fragments stripped from `og:url`)
- Uses the existing `android-chrome-512x512.png` favicon as the `og:image`

### Pages with meta content

| Page | og:title | og:description |
|------|----------|----------------|
| Home | BRC Analytics | BRC Analytics: explore, analyze, and share genomic data... |
| Organisms | Organisms - BRC Analytics | Browse organisms available for genomic analysis... |
| Assemblies | Assemblies - BRC Analytics | Browse genome assemblies available for analysis... |
| Workflows | Workflows - BRC Analytics | Explore Galaxy workflows available for genomic analysis... |
| Learn | Learn About BRC Analytics - BRC Analytics | Learn about genomic analysis tools, workflows... |
| Analyze | Analyze - BRC Analytics | Select and configure workflows for genome analysis... |
| About, Roadmap, Search, Calendar, Assistant | [Page] - BRC Analytics | Page-specific descriptions |

GA2 meta tags are tracked separately in #1234.

Closes #1233

## Test plan
- [ ] Share a BRC Analytics link on Slack and verify rich preview with title, description, and image
- [ ] Share on X/Twitter and verify Twitter Card with summary format
- [ ] Verify each page type has a relevant title and description in the preview
- [ ] Verify the BRC Analytics logo appears as the preview image
- [ ] Verify filtered URLs (with query params) still show clean canonical og:url

🤖 Generated with [Claude Code](https://claude.com/claude-code)