### PR TITLE
fix: normalize windows line endings in sample sheet upload parser

### DIFF
--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SampleSheetStep/hooks/UseFilePicker/utils.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SampleSheetStep/hooks/UseFilePicker/utils.ts
@@ -45,46 +45,55 @@ export function parseFile(
       return;
     }
 
-    Papa.parse<Record<string, string>>(file, {
-      complete: ({ data: rows, meta }) => {
-        const columnNames = getColumnNames(meta.fields);
+    // Normalize line endings (CRLF and lone CR → LF) so parsing is consistent
+    // across OSes — uploads from Windows/Excel otherwise leave trailing \r in
+    // the last cell of each row.
+    const reader = new FileReader();
+    reader.onerror = (): void => reject(reader.error);
+    reader.onload = (): void => {
+      const normalized = (reader.result as string).replace(/\r\n?/g, "\n");
+      Papa.parse<Record<string, string>>(normalized, {
+        complete: ({ data: rows, meta }) => {
+          const columnNames = getColumnNames(meta.fields);
 
-        // Check for empty headers.
-        if (columnNames.has("")) {
-          resolve({
-            data: [],
-            errors: [VALIDATION_ERROR.EMPTY_HEADERS],
-          });
-          return;
-        }
+          // Check for empty headers.
+          if (columnNames.has("")) {
+            resolve({
+              data: [],
+              errors: [VALIDATION_ERROR.EMPTY_HEADERS],
+            });
+            return;
+          }
 
-        // Check for duplicate headers.
-        if (meta.renamedHeaders) {
-          resolve({
-            data: [],
-            errors: [VALIDATION_ERROR.DUPLICATE_HEADERS],
-          });
-          return;
-        }
+          // Check for duplicate headers.
+          if (meta.renamedHeaders) {
+            resolve({
+              data: [],
+              errors: [VALIDATION_ERROR.DUPLICATE_HEADERS],
+            });
+            return;
+          }
 
-        // Validate column count.
-        if (columnNames.size < MIN_COLUMNS) {
-          errors.push(VALIDATION_ERROR.INSUFFICIENT_COLUMNS);
-        }
+          // Validate column count.
+          if (columnNames.size < MIN_COLUMNS) {
+            errors.push(VALIDATION_ERROR.INSUFFICIENT_COLUMNS);
+          }
 
-        // Validate row count.
-        if (rows.length < MIN_DATA_ROWS) {
-          errors.push(VALIDATION_ERROR.INSUFFICIENT_ROWS);
-        }
+          // Validate row count.
+          if (rows.length < MIN_DATA_ROWS) {
+            errors.push(VALIDATION_ERROR.INSUFFICIENT_ROWS);
+          }
 
-        resolve({ data: rows, errors });
-      },
-      delimiter: getDelimiter(file.name),
-      error: (error) => {
-        reject(error);
-      },
-      header: true,
-      skipEmptyLines: true,
-    });
+          resolve({ data: rows, errors });
+        },
+        delimiter: getDelimiter(file.name),
+        error: (error: Error) => {
+          reject(error);
+        },
+        header: true,
+        skipEmptyLines: true,
+      });
+    };
+    reader.readAsText(file);
   });
 }

--- a/tests/configureWorkflow/sampleSheetStep/useFilePicker.utils.test.ts
+++ b/tests/configureWorkflow/sampleSheetStep/useFilePicker.utils.test.ts
@@ -83,6 +83,60 @@ describe("parseFile", () => {
       ]);
     });
 
+    test("parses CSV file with CRLF line endings", async () => {
+      const csvContent =
+        "name,age,city,country\r\nAlice,30,Boston,USA\r\nBob,25,Seattle,USA\r\n";
+      const file = createMockFile(csvContent, "test.csv");
+
+      const result = await parseFile(file);
+
+      expect(result.data).toEqual([
+        { age: "30", city: "Boston", country: "USA", name: "Alice" },
+        { age: "25", city: "Seattle", country: "USA", name: "Bob" },
+      ]);
+      expect(result.errors).toEqual([]);
+    });
+
+    test("parses TSV file with CRLF line endings", async () => {
+      const tsvContent =
+        "name\tage\tcity\tcountry\r\nAlice\t30\tBoston\tUSA\r\nBob\t25\tSeattle\tUSA\r\n";
+      const file = createMockFile(tsvContent, "test.tsv");
+
+      const result = await parseFile(file);
+
+      expect(result.data).toEqual([
+        { age: "30", city: "Boston", country: "USA", name: "Alice" },
+        { age: "25", city: "Seattle", country: "USA", name: "Bob" },
+      ]);
+      expect(result.errors).toEqual([]);
+    });
+
+    test("skips empty CRLF lines", async () => {
+      const csvContent = "a,b,c,d\r\n1,2,3,4\r\n\r\n5,6,7,8\r\n";
+      const file = createMockFile(csvContent, "test.csv");
+
+      const result = await parseFile(file);
+
+      expect(result.data).toEqual([
+        { a: "1", b: "2", c: "3", d: "4" },
+        { a: "5", b: "6", c: "7", d: "8" },
+      ]);
+      expect(result.errors).toEqual([]);
+    });
+
+    test("parses CSV file with CR-only (classic Mac) line endings", async () => {
+      const csvContent = "a,b,c,d\r1,2,3,4\r5,6,7,8";
+      const file = createMockFile(csvContent, "test.csv");
+
+      const result = await parseFile(file);
+
+      expect(result.data).toEqual([
+        { a: "1", b: "2", c: "3", d: "4" },
+        { a: "5", b: "6", c: "7", d: "8" },
+      ]);
+      expect(result.errors).toEqual([]);
+    });
+
     test("handles values with spaces", async () => {
       const csvContent =
         "name,location,country,notes\nAlice Smith,New York City,USA,test";


### PR DESCRIPTION
## Description

Uploaded CSV/TSV sample sheets with CRLF (`\r\n`) line endings could leave stray `\r` characters in the last cell of each row, and `skipEmptyLines: true` could miss blank CRLF lines. Papa Parse's per-chunk `guessLineEndings` has edge cases (quoted fields, chunk boundaries) where CRLF goes undetected when `delimiter` is set explicitly.

Read the file via `FileReader.readAsText`, normalize `\r\n` and lone `\r` to `\n`, then hand the normalized string to `Papa.parse`. Delimiter detection, size check, and validation are unchanged. Adds unit coverage for CRLF (CSV + TSV), CRLF empty-line skipping, and CR-only (classic Mac).

## Related Issue

Closes #1236

## Test plan

- [x] `npx jest tests/configureWorkflow/sampleSheetStep` — 55 tests pass (original 15 + 4 new CRLF/CR cases in `useFilePicker.utils.test.ts`)
- [x] `npx tsc --noEmit` — clean
- [ ] Manual smoke test: upload a CRLF-ended CSV produced by `printf 'a,b,c,d\r\n1,2,3,4\r\n5,6,7,8\r\n' > sample.csv`; confirm no trailing `\r` in parsed headers/values and classification proceeds.