### PR TITLE
fix: add favicon link tags to _document.tsx for social media crawlers

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,5 +1,5 @@
-import { JSX } from "react";
 import Document, { Head, Html, Main, NextScript } from "next/document";
+import { JSX } from "react";
 
 const siteConfig = process.env.NEXT_PUBLIC_SITE_CONFIG;
 const plausibleDomain = process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN;
@@ -22,6 +22,24 @@ class MyDocument extends Document {
     return (
       <Html>
         <Head>
+          <link rel="icon" type="image/x-icon" href="/favicons/favicon.ico" />
+          <link
+            rel="icon"
+            type="image/png"
+            sizes="16x16"
+            href="/favicons/favicon-16x16.png"
+          />
+          <link
+            rel="icon"
+            type="image/png"
+            sizes="32x32"
+            href="/favicons/favicon-32x32.png"
+          />
+          <link
+            rel="apple-touch-icon"
+            sizes="180x180"
+            href="/favicons/apple-touch-icon.png"
+          />
           <link
             href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Roboto+Mono&display=swap"
             rel="stylesheet"


### PR DESCRIPTION
## Summary
- Adds `<link rel="icon">` and `<link rel="apple-touch-icon">` tags to `_document.tsx` so they are present in the static HTML
- Previously, favicon links were only rendered by the findable-ui `Head` component inside `DXConfigProvider`, which is gated behind `isEntitiesLoaded` — so they never appeared in the SSG output
- Social media crawlers (Slack, Twitter, etc.) don't execute JavaScript and rely on the static HTML to find the site favicon for unfurl previews
- The build script already copies site-specific favicons to `public/favicons/` per site, so this works correctly for both BRC and GA2

Fixes #1241

## Test plan
- [ ] Deploy to dev and share a BRC Analytics link on Slack — verify the favicon icon appears in the unfurl preview
- [ ] Verify GA2 dev build also shows correct favicon in Slack previews

🤖 Generated with [Claude Code](https://claude.com/claude-code)