### PR TITLE
chore: upgrade findable-ui to v51, remove next-auth dependency (#1247)

### DIFF
--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/DataSelector/dataSelector.styles.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/DataSelector/dataSelector.styles.ts
@@ -1,5 +1,5 @@
 import { PALETTE } from "@databiosphere/findable-ui/lib/styles/common/constants/palette";
-import { bpDown820 } from "@databiosphere/findable-ui/src/styles/common/mixins/breakpoints";
+import { bpDown820 } from "@databiosphere/findable-ui/lib/styles/common/mixins/breakpoints";
 import styled from "@emotion/styled";
 import { Grid, Paper } from "@mui/material";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "brc-analytics",
       "version": "0.27.0",
       "dependencies": {
-        "@databiosphere/findable-ui": "^50",
+        "@databiosphere/findable-ui": "^51",
         "@emotion/react": "^11",
         "@emotion/styled": "^11",
         "@mdx-js/loader": "^3.0.1",
@@ -29,7 +29,6 @@
         "isomorphic-dompurify": "^2",
         "ky": "^1",
         "next": "^15",
-        "next-auth": "^4",
         "next-compose-plugins": "^2.2.1",
         "next-mdx-remote": "^5",
         "papaparse": "^5.5.3",
@@ -1419,9 +1418,9 @@
       }
     },
     "node_modules/@databiosphere/findable-ui": {
-      "version": "50.7.0",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-50.7.0.tgz",
-      "integrity": "sha512-4ISwTcj2Tdbj5vgHt8mb1bkBcP6LDqP1zaEbl/R5nh0u8BNnine9/fbXS7wT4MaiYbCNclMKucZ1qowcH+KlSQ==",
+      "version": "51.0.0",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-51.0.0.tgz",
+      "integrity": "sha512-Vti9a1VkgcOFuPqgFLOIApwz+DFY4+sjuAnJX8iL7/TA3EfjVzVsYg6rWja7u5M3wo4oapoUvDFim6Irx7gO0g==",
       "license": "Apache-2.0",
       "engines": {
         "node": "22.12.0"
@@ -1458,6 +1457,11 @@
         "unified": "^11.0.5",
         "uuid": "^13.0.0",
         "yup": "^1.7.1"
+      },
+      "peerDependenciesMeta": {
+        "next-auth": {
+          "optional": true
+        }
       }
     },
     "node_modules/@digitak/grubber": {
@@ -5343,6 +5347,8 @@
       "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
       "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -9530,6 +9536,8 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -16759,6 +16767,8 @@
       "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
       "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -18577,6 +18587,8 @@
       "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.13.tgz",
       "integrity": "sha512-sgObCfcfL7BzIK76SS5TnQtc3yo2Oifp/yIpfv6fMfeBOiBJkDWF3A2y9+yqnmJ4JKc2C+nMjSjmgDeTwgN1rQ==",
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.13",
         "@panva/hkdf": "^1.0.2",
@@ -18609,6 +18621,8 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -18728,7 +18742,9 @@
       "version": "0.9.15",
       "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
       "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -18751,6 +18767,8 @@
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
       "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 6"
       }
@@ -18873,6 +18891,8 @@
       "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.2.0.tgz",
       "integrity": "sha512-6gj2m8cJZ+iSW8bm0FXdGF0YhIQbKrfP4yWTNzxc31U6MOjfEmB1rHvlYvxI1B7t7BCi1F2vYTT6YhtQRG4hxw==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "^10.13.0 || >=12.0.0"
       }
@@ -18898,6 +18918,8 @@
       "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.7.1.tgz",
       "integrity": "sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "jose": "^4.15.9",
         "lru-cache": "^6.0.0",
@@ -18913,6 +18935,8 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -18924,7 +18948,9 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -19408,6 +19434,8 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.2.tgz",
       "integrity": "sha512-lbteaWGzGHdlIuiJ0l2Jq454m6kcpI1zNje6d8MlGAFlYvP2GO4ibnat7P74Esfz4sPTdM6UxtTwh/d3pwM9JA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -19418,6 +19446,8 @@
       "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.6.tgz",
       "integrity": "sha512-JyhErpYOvBV1hEPwIxc/fHWXPfnEGdRKxc8gFdAZ7XV4tlzyzG847XAyEZqoDnynP88akM4eaHcSOzNcLWFguw==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "pretty-format": "^3.8.0"
       },
@@ -19429,7 +19459,9 @@
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
       "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "brc-analytics",
       "version": "0.27.0",
       "dependencies": {
-        "@databiosphere/findable-ui": "^51",
+        "@databiosphere/findable-ui": "^51.0.1",
         "@emotion/react": "^11",
         "@emotion/styled": "^11",
         "@mdx-js/loader": "^3.0.1",
@@ -1418,9 +1418,9 @@
       }
     },
     "node_modules/@databiosphere/findable-ui": {
-      "version": "51.0.0",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-51.0.0.tgz",
-      "integrity": "sha512-Vti9a1VkgcOFuPqgFLOIApwz+DFY4+sjuAnJX8iL7/TA3EfjVzVsYg6rWja7u5M3wo4oapoUvDFim6Irx7gO0g==",
+      "version": "51.0.1",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-51.0.1.tgz",
+      "integrity": "sha512-kHHf38QoQUJP+LQAPFKmGuOdZWWeb8Fjer+1CgIa8CryAnGI4HGNQT1KetrnMP0KuPRVOw3VmQOtzsynSdauKg==",
       "license": "Apache-2.0",
       "engines": {
         "node": "22.12.0"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "validate-ga2-catalog": "./catalog/ga2/schema/scripts/validate-catalog.sh"
   },
   "dependencies": {
-    "@databiosphere/findable-ui": "^51",
+    "@databiosphere/findable-ui": "^51.0.1",
     "@emotion/react": "^11",
     "@emotion/styled": "^11",
     "@mdx-js/loader": "^3.0.1",
@@ -57,7 +57,6 @@
     "isomorphic-dompurify": "^2",
     "ky": "^1",
     "next": "^15",
-
     "next-compose-plugins": "^2.2.1",
     "next-mdx-remote": "^5",
     "papaparse": "^5.5.3",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "validate-ga2-catalog": "./catalog/ga2/schema/scripts/validate-catalog.sh"
   },
   "dependencies": {
-    "@databiosphere/findable-ui": "^50",
+    "@databiosphere/findable-ui": "^51",
     "@emotion/react": "^11",
     "@emotion/styled": "^11",
     "@mdx-js/loader": "^3.0.1",
@@ -57,7 +57,7 @@
     "isomorphic-dompurify": "^2",
     "ky": "^1",
     "next": "^15",
-    "next-auth": "^4",
+
     "next-compose-plugins": "^2.2.1",
     "next-mdx-remote": "^5",
     "papaparse": "^5.5.3",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -11,7 +11,7 @@ import { setFeatureFlags } from "@databiosphere/findable-ui/lib/hooks/useFeature
 import { useFeatureFlag } from "@databiosphere/findable-ui/lib/hooks/useFeatureFlag/useFeatureFlag";
 import { ConfigProvider as DXConfigProvider } from "@databiosphere/findable-ui/lib/providers/config";
 import { ExploreStateProvider } from "@databiosphere/findable-ui/lib/providers/exploreState";
-import { GoogleSignInAuthenticationProvider } from "@databiosphere/findable-ui/lib/providers/googleSignInAuthentication/provider";
+import { GoogleSignInAuthenticationProvider } from "@databiosphere/findable-ui/lib/google/provider";
 import { LayoutDimensionsProvider } from "@databiosphere/findable-ui/lib/providers/layoutDimensions/provider";
 import { ServicesProvider } from "@databiosphere/findable-ui/lib/providers/services/provider";
 import { SystemStatusProvider } from "@databiosphere/findable-ui/lib/providers/systemStatus";

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -11,7 +11,7 @@ import { setFeatureFlags } from "@databiosphere/findable-ui/lib/hooks/useFeature
 import { useFeatureFlag } from "@databiosphere/findable-ui/lib/hooks/useFeatureFlag/useFeatureFlag";
 import { ConfigProvider as DXConfigProvider } from "@databiosphere/findable-ui/lib/providers/config";
 import { ExploreStateProvider } from "@databiosphere/findable-ui/lib/providers/exploreState";
-import { GoogleSignInAuthenticationProvider } from "@databiosphere/findable-ui/lib/google/provider";
+
 import { LayoutDimensionsProvider } from "@databiosphere/findable-ui/lib/providers/layoutDimensions/provider";
 import { ServicesProvider } from "@databiosphere/findable-ui/lib/providers/services/provider";
 import { SystemStatusProvider } from "@databiosphere/findable-ui/lib/providers/systemStatus";
@@ -111,39 +111,37 @@ function MyApp({ Component, pageProps }: AppPropsWithComponent): JSX.Element {
           <QueryClientProvider client={queryClient}>
             <ServicesProvider>
               <SystemStatusProvider>
-                <GoogleSignInAuthenticationProvider>
-                  <BrcAuthProvider loginEnabled={appConfig.loginEnabled}>
-                    <LayoutDimensionsProvider>
-                      <AppLayout>
-                        <DXHeader {...filteredHeader} />
-                        <ExploreStateProvider entityListType={entityListType}>
-                          <Main>
-                            <ErrorBoundary
-                              fallbackRender={({
-                                error,
-                                reset,
-                              }: {
-                                error: DataExplorerError;
-                                reset: () => void;
-                              }): JSX.Element => (
-                                <Error
-                                  errorMessage={error.message}
-                                  requestUrlMessage={error.requestUrlMessage}
-                                  rootPath={redirectRootToPath}
-                                  onReset={reset}
-                                />
-                              )}
-                            >
-                              <Component {...pageProps} />
-                              <Floating {...floating} />
-                            </ErrorBoundary>
-                          </Main>
-                        </ExploreStateProvider>
-                        <StyledFooter {...footer} />
-                      </AppLayout>
-                    </LayoutDimensionsProvider>
-                  </BrcAuthProvider>
-                </GoogleSignInAuthenticationProvider>
+                <BrcAuthProvider loginEnabled={appConfig.loginEnabled}>
+                  <LayoutDimensionsProvider>
+                    <AppLayout>
+                      <DXHeader {...filteredHeader} />
+                      <ExploreStateProvider entityListType={entityListType}>
+                        <Main>
+                          <ErrorBoundary
+                            fallbackRender={({
+                              error,
+                              reset,
+                            }: {
+                              error: DataExplorerError;
+                              reset: () => void;
+                            }): JSX.Element => (
+                              <Error
+                                errorMessage={error.message}
+                                requestUrlMessage={error.requestUrlMessage}
+                                rootPath={redirectRootToPath}
+                                onReset={reset}
+                              />
+                            )}
+                          >
+                            <Component {...pageProps} />
+                            <Floating {...floating} />
+                          </ErrorBoundary>
+                        </Main>
+                      </ExploreStateProvider>
+                      <StyledFooter {...footer} />
+                    </AppLayout>
+                  </LayoutDimensionsProvider>
+                </BrcAuthProvider>
               </SystemStatusProvider>
             </ServicesProvider>
           </QueryClientProvider>

--- a/tests/e2e/ui/02-workflow-stepper.spec.ts
+++ b/tests/e2e/ui/02-workflow-stepper.spec.ts
@@ -1,3 +1,5 @@
+// .js extension required: Playwright uses Node's native module resolution which
+// enforces the package exports field strictly (no auto-resolving extensions).
 import { replaceParameters } from "@databiosphere/findable-ui/lib/utils/replaceParameters.js";
 import { Locator, Page } from "@playwright/test";
 import { sanitizeEntityId } from "../../../app/apis/catalog/common/utils";

--- a/tests/e2e/ui/02-workflow-stepper.spec.ts
+++ b/tests/e2e/ui/02-workflow-stepper.spec.ts
@@ -1,4 +1,4 @@
-import { replaceParameters } from "@databiosphere/findable-ui/lib/utils/replaceParameters";
+import { replaceParameters } from "@databiosphere/findable-ui/lib/utils/replaceParameters.js";
 import { Locator, Page } from "@playwright/test";
 import { sanitizeEntityId } from "../../../app/apis/catalog/common/utils";
 import { ROUTES } from "../../../routes/constants";


### PR DESCRIPTION
## Summary
- Upgrades `@databiosphere/findable-ui` from `^50` (v50.7.0) to `^51` (v51.0.1)
- Removes `next-auth` from dependencies — it's now an optional peer dep in findable-ui v51, and we only use Google OAuth (not NextAuth)
- Removes `GoogleSignInAuthenticationProvider` from `_app.tsx` — BRC uses its own `BrcAuthProvider` for auth, and findable-ui v51.0.1 fixes the entity list loading issue that previously required this provider (DataBiosphere/findable-ui#883)
- Fixes stale `src/` import path for breakpoints mixin to `lib/`
- Adds `.js` extension to findable-ui import in Playwright e2e test — required because Playwright uses Node's native module resolution which enforces the package `exports` field strictly (no auto-resolving extensions), unlike webpack which handles this transparently

### Breaking change in v51
NextAuth and Google Auth integrations were refactored to be tree-shakeable. Import paths moved from `lib/providers/` to `lib/google/`, `lib/nextauth/`, `lib/auth/`. No functional API changes.

### Entity list loading fix (v51.0.1)
findable-ui v51.0.1 (DataBiosphere/findable-ui#883) moves the token-change reset from `ExploreStateProvider` to `useEntityList`, scoped to SS_FETCH modes only. This eliminates the dependency on `GoogleSignInAuthenticationProvider` for CS_FETCH_CS_FILTERING apps like BRC.

Closes #1247

## Test plan
- [x] Verify BRC analytics builds successfully
- [x] Verify GA2 builds successfully
- [x] Verify entity list pages load without stuck loading spinner
- [x] Verify e2e tests pass
- [x] Smoke test the app locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)