### PR TITLE
feat: add open graph and twitter card meta tags for genome ark 2

### DIFF
--- a/app/common/meta/ga2/constants.ts
+++ b/app/common/meta/ga2/constants.ts
@@ -1,0 +1,65 @@
+/**
+ * Page metadata for Genome Ark 2 — titles and descriptions used in OG/Twitter meta tags.
+ */
+
+export const GA2_DEFAULT_DESCRIPTION =
+  "Genome Ark 2: explore and analyze reference genome assemblies using Galaxy workflows.";
+
+export const GA2_PAGE_META = {
+  ABOUT: {
+    pageDescription:
+      "Learn about the Genome Ark 2 platform for reference genome analysis.",
+    pageTitle: "About",
+  },
+  ANALYZE_WORKFLOWS: {
+    pageDescription:
+      "Select and configure workflows for genome analysis on Genome Ark 2.",
+    pageTitle: "Analyze",
+  },
+  ASSEMBLIES: {
+    pageDescription:
+      "Browse genome assemblies available for analysis on Genome Ark 2.",
+    pageTitle: "Assemblies",
+  },
+  ASSEMBLY_DETAIL: {
+    pageDescription:
+      "Select and configure workflows for genome analysis on Genome Ark 2.",
+    pageTitle: "Analyze",
+  },
+  CONFIGURE_WORKFLOW: {
+    pageDescription:
+      "Configure workflow inputs for genome analysis on Genome Ark 2.",
+    pageTitle: "Configure Workflow",
+  },
+  CUSTOM_WORKFLOW: {
+    pageDescription:
+      "Configure a custom workflow for genome analysis on Genome Ark 2.",
+    pageTitle: "Custom Workflow",
+  },
+  HOME: {
+    pageDescription: GA2_DEFAULT_DESCRIPTION,
+  },
+  ORGANISMS: {
+    pageDescription:
+      "Browse organisms with reference genome assemblies on Genome Ark 2.",
+    pageTitle: "Organisms",
+  },
+  ORGANISM_DETAIL: {
+    pageDescription:
+      "View organism details and available genome assemblies on Genome Ark 2.",
+    pageTitle: "Organism",
+  },
+  ROADMAP: {
+    pageDescription: "View the development roadmap for Genome Ark 2.",
+    pageTitle: "Roadmap",
+  },
+  WORKFLOW: {
+    pageDescription: "View workflow details on Genome Ark 2.",
+    pageTitle: "Workflow",
+  },
+  WORKFLOWS: {
+    pageDescription:
+      "Explore Galaxy workflows available for genomic analysis on Genome Ark 2.",
+    pageTitle: "Workflows",
+  },
+} as const;

--- a/app/common/meta/utils.ts
+++ b/app/common/meta/utils.ts
@@ -1,0 +1,67 @@
+import { APP_KEYS } from "../../../site-config/common/constants";
+import { BRC_DEFAULT_DESCRIPTION, BRC_PAGE_META } from "./brc/constants";
+import { GA2_DEFAULT_DESCRIPTION, GA2_PAGE_META } from "./ga2/constants";
+
+type AppKey = (typeof APP_KEYS)[keyof typeof APP_KEYS];
+
+/**
+ * Returns the default OG description for the given site.
+ * @param appKey - App key identifying the site.
+ * @returns default description string.
+ */
+export function getDefaultDescription(appKey?: AppKey): string {
+  return appKey === APP_KEYS.GA2
+    ? GA2_DEFAULT_DESCRIPTION
+    : BRC_DEFAULT_DESCRIPTION;
+}
+
+/**
+ * Returns entity detail page metadata keyed by entity route for the given site.
+ * @param appKey - App key identifying the site.
+ * @returns record mapping entity route to page metadata.
+ */
+export function getEntityDetailMeta(
+  appKey?: AppKey
+): Record<string, { pageDescription: string; pageTitle: string }> {
+  const meta = getPageMeta(appKey);
+  const result: Record<string, { pageDescription: string; pageTitle: string }> =
+    {
+      assemblies: meta.ASSEMBLY_DETAIL,
+      organisms: meta.ORGANISM_DETAIL,
+    };
+  if (appKey !== APP_KEYS.GA2) {
+    result["priority-pathogens"] = BRC_PAGE_META.PRIORITY_PATHOGEN_DETAIL;
+  }
+  return result;
+}
+
+/**
+ * Returns entity list page metadata keyed by entity route for the given site.
+ * @param appKey - App key identifying the site.
+ * @returns record mapping entity route to page metadata.
+ */
+export function getEntityListMeta(
+  appKey?: AppKey
+): Record<string, { pageDescription: string; pageTitle: string }> {
+  const meta = getPageMeta(appKey);
+  const result: Record<string, { pageDescription: string; pageTitle: string }> =
+    {
+      assemblies: meta.ASSEMBLIES,
+      organisms: meta.ORGANISMS,
+    };
+  if (appKey !== APP_KEYS.GA2) {
+    result["priority-pathogens"] = BRC_PAGE_META.PRIORITY_PATHOGENS;
+  }
+  return result;
+}
+
+/**
+ * Returns the full page metadata object for the given site.
+ * @param appKey - App key identifying the site.
+ * @returns page metadata constants for BRC or GA2.
+ */
+export function getPageMeta(
+  appKey?: AppKey
+): typeof BRC_PAGE_META | typeof GA2_PAGE_META {
+  return appKey === APP_KEYS.GA2 ? GA2_PAGE_META : BRC_PAGE_META;
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -22,8 +22,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { NextPage } from "next";
 import type { AppProps } from "next/app";
 import { JSX, useMemo } from "react";
-import { BRC_DEFAULT_DESCRIPTION } from "../app/common/meta/brc/constants";
-import { GA2_DEFAULT_DESCRIPTION } from "../app/common/meta/ga2/constants";
+import { getDefaultDescription } from "../app/common/meta/utils";
 import { OgMeta } from "../app/components/common/OgMeta/ogMeta";
 import { StyledFooter } from "../app/components/Layout/components/Footer/footer.styles";
 import { config } from "../app/config/config";
@@ -32,7 +31,6 @@ import { useEntities } from "../app/services/workflows/hooks/UseEntities/hook";
 import "../app/styles/fonts/fonts.css";
 import { mergeAppTheme } from "../app/theme/theme";
 import { ROUTES } from "../routes/constants";
-import { APP_KEYS } from "../site-config/common/constants";
 
 const DEFAULT_ENTITY_LIST_TYPE = "organisms";
 
@@ -89,15 +87,11 @@ function MyApp({ Component, pageProps }: AppPropsWithComponent): JSX.Element {
     };
   }, [header, isAssistantEnabled]);
 
-  const defaultDescription =
-    appConfig.appKey === APP_KEYS.BRC_ANALYTICS
-      ? BRC_DEFAULT_DESCRIPTION
-      : GA2_DEFAULT_DESCRIPTION;
   const ogMeta = (
     <OgMeta
       appTitle={appConfig.appTitle}
       browserURL={appConfig.browserURL}
-      defaultDescription={defaultDescription}
+      defaultDescription={getDefaultDescription(appConfig.appKey)}
       pageDescription={pageDescription}
       pageTitle={pageTitle}
     />

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -23,6 +23,7 @@ import { NextPage } from "next";
 import type { AppProps } from "next/app";
 import { JSX, useMemo } from "react";
 import { BRC_DEFAULT_DESCRIPTION } from "../app/common/meta/brc/constants";
+import { GA2_DEFAULT_DESCRIPTION } from "../app/common/meta/ga2/constants";
 import { OgMeta } from "../app/components/common/OgMeta/ogMeta";
 import { StyledFooter } from "../app/components/Layout/components/Footer/footer.styles";
 import { config } from "../app/config/config";
@@ -88,18 +89,21 @@ function MyApp({ Component, pageProps }: AppPropsWithComponent): JSX.Element {
     };
   }, [header, isAssistantEnabled]);
 
-  const isBRC = appConfig.appKey === APP_KEYS.BRC_ANALYTICS;
-  const ogMeta = isBRC ? (
+  const defaultDescription =
+    appConfig.appKey === APP_KEYS.BRC_ANALYTICS
+      ? BRC_DEFAULT_DESCRIPTION
+      : GA2_DEFAULT_DESCRIPTION;
+  const ogMeta = (
     <OgMeta
       appTitle={appConfig.appTitle}
       browserURL={appConfig.browserURL}
-      defaultDescription={BRC_DEFAULT_DESCRIPTION}
+      defaultDescription={defaultDescription}
       pageDescription={pageDescription}
       pageTitle={pageTitle}
     />
-  ) : null;
+  );
 
-  if (!isEntitiesLoaded) return <>{ogMeta}</>;
+  if (!isEntitiesLoaded) return ogMeta;
 
   return (
     <EmotionThemeProvider theme={appTheme}>

--- a/pages/about/index.tsx
+++ b/pages/about/index.tsx
@@ -5,6 +5,7 @@ import { AboutView } from "../../app/views/AboutView/aboutView";
 import { AboutViewGA2 } from "../../app/views/AboutView/aboutViewGA2";
 import { APP_KEYS } from "../../site-config/common/constants";
 import { BRC_PAGE_META } from "../../app/common/meta/brc/constants";
+import { GA2_PAGE_META } from "../../app/common/meta/ga2/constants";
 import { config } from "../../app/config/config";
 import { ROUTES } from "../../routes/constants";
 
@@ -18,15 +19,18 @@ export const About = (): JSX.Element => {
 };
 
 export const getStaticProps: GetStaticProps = async () => {
-  const { allowedPaths } = config();
+  const { allowedPaths, appKey } = config();
 
   if (allowedPaths && !allowedPaths.includes(ROUTES.ABOUT)) {
     return { notFound: true };
   }
 
+  const meta =
+    appKey === APP_KEYS.GA2 ? GA2_PAGE_META.ABOUT : BRC_PAGE_META.ABOUT;
+
   return {
     props: {
-      ...BRC_PAGE_META.ABOUT,
+      ...meta,
       themeOptions: {
         palette: { background: { default: "#FAFBFB" } }, // SMOKE_LIGHTEST
       },

--- a/pages/about/index.tsx
+++ b/pages/about/index.tsx
@@ -4,8 +4,7 @@ import { StyledPagesMain } from "../../app/components/Layout/components/Main/mai
 import { AboutView } from "../../app/views/AboutView/aboutView";
 import { AboutViewGA2 } from "../../app/views/AboutView/aboutViewGA2";
 import { APP_KEYS } from "../../site-config/common/constants";
-import { BRC_PAGE_META } from "../../app/common/meta/brc/constants";
-import { GA2_PAGE_META } from "../../app/common/meta/ga2/constants";
+import { getPageMeta } from "../../app/common/meta/utils";
 import { config } from "../../app/config/config";
 import { ROUTES } from "../../routes/constants";
 
@@ -25,12 +24,9 @@ export const getStaticProps: GetStaticProps = async () => {
     return { notFound: true };
   }
 
-  const meta =
-    appKey === APP_KEYS.GA2 ? GA2_PAGE_META.ABOUT : BRC_PAGE_META.ABOUT;
-
   return {
     props: {
-      ...meta,
+      ...getPageMeta(appKey).ABOUT,
       themeOptions: {
         palette: { background: { default: "#FAFBFB" } }, // SMOKE_LIGHTEST
       },

--- a/pages/data/[entityListType]/[entityId]/analyze/custom.tsx
+++ b/pages/data/[entityListType]/[entityId]/analyze/custom.tsx
@@ -6,10 +6,8 @@ import {
 } from "next";
 import { ParsedUrlQuery } from "querystring";
 import { JSX } from "react";
-import { BRC_PAGE_META } from "../../../../../app/common/meta/brc/constants";
-import { GA2_PAGE_META } from "../../../../../app/common/meta/ga2/constants";
+import { getPageMeta } from "../../../../../app/common/meta/utils";
 import { config } from "../../../../../app/config/config";
-import { APP_KEYS } from "../../../../../site-config/common/constants";
 import { getEntities } from "../../../../../app/utils/entityUtils";
 import { seedDatabase } from "../../../../../app/utils/seedDatabase";
 import { CUSTOM_WORKFLOW } from "../../../../../app/views/AnalyzeWorkflowsView/custom/constants";
@@ -63,9 +61,7 @@ export const getStaticProps: GetStaticProps<Props> = async ({
   return {
     props: {
       entityId,
-      ...(config().appKey === APP_KEYS.GA2
-        ? GA2_PAGE_META.CUSTOM_WORKFLOW
-        : BRC_PAGE_META.CUSTOM_WORKFLOW),
+      ...getPageMeta(config().appKey).CUSTOM_WORKFLOW,
       trsId: CUSTOM_WORKFLOW.trsId,
     },
   };

--- a/pages/data/[entityListType]/[entityId]/analyze/custom.tsx
+++ b/pages/data/[entityListType]/[entityId]/analyze/custom.tsx
@@ -7,7 +7,9 @@ import {
 import { ParsedUrlQuery } from "querystring";
 import { JSX } from "react";
 import { BRC_PAGE_META } from "../../../../../app/common/meta/brc/constants";
+import { GA2_PAGE_META } from "../../../../../app/common/meta/ga2/constants";
 import { config } from "../../../../../app/config/config";
+import { APP_KEYS } from "../../../../../site-config/common/constants";
 import { getEntities } from "../../../../../app/utils/entityUtils";
 import { seedDatabase } from "../../../../../app/utils/seedDatabase";
 import { CUSTOM_WORKFLOW } from "../../../../../app/views/AnalyzeWorkflowsView/custom/constants";
@@ -61,7 +63,9 @@ export const getStaticProps: GetStaticProps<Props> = async ({
   return {
     props: {
       entityId,
-      ...BRC_PAGE_META.CUSTOM_WORKFLOW,
+      ...(config().appKey === APP_KEYS.GA2
+        ? GA2_PAGE_META.CUSTOM_WORKFLOW
+        : BRC_PAGE_META.CUSTOM_WORKFLOW),
       trsId: CUSTOM_WORKFLOW.trsId,
     },
   };

--- a/pages/data/[entityListType]/[entityId]/analyze/workflows/[trsId]/index.tsx
+++ b/pages/data/[entityListType]/[entityId]/analyze/workflows/[trsId]/index.tsx
@@ -8,10 +8,8 @@ import {
 import { ParsedUrlQuery } from "querystring";
 import { JSX } from "react";
 import { EntitiesResponse } from "../../../../../../../app/apis/catalog/brc-analytics-catalog/common/entities";
-import { BRC_PAGE_META } from "../../../../../../../app/common/meta/brc/constants";
-import { GA2_PAGE_META } from "../../../../../../../app/common/meta/ga2/constants";
+import { getPageMeta } from "../../../../../../../app/common/meta/utils";
 import { config } from "../../../../../../../app/config/config";
-import { APP_KEYS } from "../../../../../../../site-config/common/constants";
 import { getEntities } from "../../../../../../../app/utils/entityUtils";
 import { seedDatabase } from "../../../../../../../app/utils/seedDatabase";
 import {
@@ -71,9 +69,7 @@ export const getStaticProps = async (
     props: {
       entityId,
       entityListType,
-      ...(config().appKey === APP_KEYS.GA2
-        ? GA2_PAGE_META.CONFIGURE_WORKFLOW
-        : BRC_PAGE_META.CONFIGURE_WORKFLOW),
+      ...getPageMeta(config().appKey).CONFIGURE_WORKFLOW,
       trsId,
     },
   };

--- a/pages/data/[entityListType]/[entityId]/analyze/workflows/[trsId]/index.tsx
+++ b/pages/data/[entityListType]/[entityId]/analyze/workflows/[trsId]/index.tsx
@@ -9,7 +9,9 @@ import { ParsedUrlQuery } from "querystring";
 import { JSX } from "react";
 import { EntitiesResponse } from "../../../../../../../app/apis/catalog/brc-analytics-catalog/common/entities";
 import { BRC_PAGE_META } from "../../../../../../../app/common/meta/brc/constants";
+import { GA2_PAGE_META } from "../../../../../../../app/common/meta/ga2/constants";
 import { config } from "../../../../../../../app/config/config";
+import { APP_KEYS } from "../../../../../../../site-config/common/constants";
 import { getEntities } from "../../../../../../../app/utils/entityUtils";
 import { seedDatabase } from "../../../../../../../app/utils/seedDatabase";
 import {
@@ -69,7 +71,9 @@ export const getStaticProps = async (
     props: {
       entityId,
       entityListType,
-      ...BRC_PAGE_META.CONFIGURE_WORKFLOW,
+      ...(config().appKey === APP_KEYS.GA2
+        ? GA2_PAGE_META.CONFIGURE_WORKFLOW
+        : BRC_PAGE_META.CONFIGURE_WORKFLOW),
       trsId,
     },
   };

--- a/pages/data/[entityListType]/[entityId]/analyze/workflows/index.tsx
+++ b/pages/data/[entityListType]/[entityId]/analyze/workflows/index.tsx
@@ -6,10 +6,8 @@ import {
 } from "next";
 import { ParsedUrlQuery } from "querystring";
 import { JSX } from "react";
-import { BRC_PAGE_META } from "../../../../../../app/common/meta/brc/constants";
-import { GA2_PAGE_META } from "../../../../../../app/common/meta/ga2/constants";
+import { getPageMeta } from "../../../../../../app/common/meta/utils";
 import { config } from "../../../../../../app/config/config";
-import { APP_KEYS } from "../../../../../../site-config/common/constants";
 import { getEntities } from "../../../../../../app/utils/entityUtils";
 import { seedDatabase } from "../../../../../../app/utils/seedDatabase";
 import { AnalyzeWorkflowsView } from "../../../../../../app/views/AnalyzeWorkflowsView/analyzeWorkflowsView";
@@ -60,9 +58,7 @@ export const getStaticProps: GetStaticProps<Props> = async ({
   return {
     props: {
       entityId,
-      ...(config().appKey === APP_KEYS.GA2
-        ? GA2_PAGE_META.ANALYZE_WORKFLOWS
-        : BRC_PAGE_META.ANALYZE_WORKFLOWS),
+      ...getPageMeta(config().appKey).ANALYZE_WORKFLOWS,
     },
   };
 };

--- a/pages/data/[entityListType]/[entityId]/analyze/workflows/index.tsx
+++ b/pages/data/[entityListType]/[entityId]/analyze/workflows/index.tsx
@@ -7,7 +7,9 @@ import {
 import { ParsedUrlQuery } from "querystring";
 import { JSX } from "react";
 import { BRC_PAGE_META } from "../../../../../../app/common/meta/brc/constants";
+import { GA2_PAGE_META } from "../../../../../../app/common/meta/ga2/constants";
 import { config } from "../../../../../../app/config/config";
+import { APP_KEYS } from "../../../../../../site-config/common/constants";
 import { getEntities } from "../../../../../../app/utils/entityUtils";
 import { seedDatabase } from "../../../../../../app/utils/seedDatabase";
 import { AnalyzeWorkflowsView } from "../../../../../../app/views/AnalyzeWorkflowsView/analyzeWorkflowsView";
@@ -58,7 +60,9 @@ export const getStaticProps: GetStaticProps<Props> = async ({
   return {
     props: {
       entityId,
-      ...BRC_PAGE_META.ANALYZE_WORKFLOWS,
+      ...(config().appKey === APP_KEYS.GA2
+        ? GA2_PAGE_META.ANALYZE_WORKFLOWS
+        : BRC_PAGE_META.ANALYZE_WORKFLOWS),
     },
   };
 };

--- a/pages/data/[entityListType]/[entityId]/index.tsx
+++ b/pages/data/[entityListType]/[entityId]/index.tsx
@@ -8,10 +8,8 @@ import {
   EntitiesResponse,
 } from "../../../../app/apis/catalog/brc-analytics-catalog/common/entities";
 import { GA2Catalog } from "../../../../app/apis/catalog/ga2/entities";
-import { BRC_PAGE_META } from "../../../../app/common/meta/brc/constants";
-import { GA2_PAGE_META } from "../../../../app/common/meta/ga2/constants";
+import { getEntityDetailMeta } from "../../../../app/common/meta/utils";
 import { config } from "../../../../app/config/config";
-import { APP_KEYS } from "../../../../site-config/common/constants";
 import { getEntities, getEntity } from "../../../../app/utils/entityUtils";
 import { seedDatabase } from "../../../../app/utils/seedDatabase";
 import { AnalyzeView } from "../../../../app/views/AnalyzeView/analyzeView";
@@ -32,19 +30,6 @@ export interface EntityPageProps<R> {
   entityListType: string;
   pageDescription?: string;
   pageTitle?: string;
-}
-
-function getEntityDetailMeta(
-  appKey?: string
-): Record<string, { pageDescription: string; pageTitle: string }> {
-  const meta = appKey === APP_KEYS.GA2 ? GA2_PAGE_META : BRC_PAGE_META;
-  return {
-    assemblies: meta.ASSEMBLY_DETAIL,
-    organisms: meta.ORGANISM_DETAIL,
-    ...("PRIORITY_PATHOGEN_DETAIL" in meta
-      ? { "priority-pathogens": meta.PRIORITY_PATHOGEN_DETAIL }
-      : {}),
-  };
 }
 
 /**

--- a/pages/data/[entityListType]/[entityId]/index.tsx
+++ b/pages/data/[entityListType]/[entityId]/index.tsx
@@ -9,7 +9,9 @@ import {
 } from "../../../../app/apis/catalog/brc-analytics-catalog/common/entities";
 import { GA2Catalog } from "../../../../app/apis/catalog/ga2/entities";
 import { BRC_PAGE_META } from "../../../../app/common/meta/brc/constants";
+import { GA2_PAGE_META } from "../../../../app/common/meta/ga2/constants";
 import { config } from "../../../../app/config/config";
+import { APP_KEYS } from "../../../../site-config/common/constants";
 import { getEntities, getEntity } from "../../../../app/utils/entityUtils";
 import { seedDatabase } from "../../../../app/utils/seedDatabase";
 import { AnalyzeView } from "../../../../app/views/AnalyzeView/analyzeView";
@@ -32,14 +34,18 @@ export interface EntityPageProps<R> {
   pageTitle?: string;
 }
 
-const ENTITY_DETAIL_META: Record<
-  string,
-  { pageDescription: string; pageTitle: string }
-> = {
-  assemblies: BRC_PAGE_META.ASSEMBLY_DETAIL,
-  organisms: BRC_PAGE_META.ORGANISM_DETAIL,
-  "priority-pathogens": BRC_PAGE_META.PRIORITY_PATHOGEN_DETAIL,
-};
+function getEntityDetailMeta(
+  appKey?: string
+): Record<string, { pageDescription: string; pageTitle: string }> {
+  const meta = appKey === APP_KEYS.GA2 ? GA2_PAGE_META : BRC_PAGE_META;
+  return {
+    assemblies: meta.ASSEMBLY_DETAIL,
+    organisms: meta.ORGANISM_DETAIL,
+    ...("PRIORITY_PATHOGEN_DETAIL" in meta
+      ? { "priority-pathogens": meta.PRIORITY_PATHOGEN_DETAIL }
+      : {}),
+  };
+}
 
 /**
  * Entity detail view page.
@@ -101,7 +107,7 @@ export const getStaticProps: GetStaticProps<
   };
 
   const entityConfig = getEntityConfig(entities, entityListType);
-  const entityMeta = ENTITY_DETAIL_META[entityListType];
+  const entityMeta = getEntityDetailMeta(appConfig.appKey)[entityListType];
 
   const props: EntityPageProps<BRCCatalog | GA2Catalog> = {
     entityId,

--- a/pages/data/[entityListType]/index.tsx
+++ b/pages/data/[entityListType]/index.tsx
@@ -12,7 +12,9 @@ import {
 } from "../../../app/apis/catalog/brc-analytics-catalog/common/entities";
 import { GA2Catalog } from "../../../app/apis/catalog/ga2/entities";
 import { BRC_PAGE_META } from "../../../app/common/meta/brc/constants";
+import { GA2_PAGE_META } from "../../../app/common/meta/ga2/constants";
 import { config } from "../../../app/config/config";
+import { APP_KEYS } from "../../../site-config/common/constants";
 import { seedDatabase } from "../../../app/utils/seedDatabase";
 import { StyledExploreView } from "../../../app/views/ExploreView/exploreView.styles";
 import { PriorityPathogensView } from "../../../app/views/PriorityPathogensView/priorityPathogensView";
@@ -28,14 +30,18 @@ interface EntitiesPageProps<R> {
   pageTitle?: string;
 }
 
-const ENTITY_LIST_META: Record<
-  string,
-  { pageDescription: string; pageTitle: string }
-> = {
-  assemblies: BRC_PAGE_META.ASSEMBLIES,
-  organisms: BRC_PAGE_META.ORGANISMS,
-  "priority-pathogens": BRC_PAGE_META.PRIORITY_PATHOGENS,
-};
+function getEntityListMeta(
+  appKey?: string
+): Record<string, { pageDescription: string; pageTitle: string }> {
+  const meta = appKey === APP_KEYS.GA2 ? GA2_PAGE_META : BRC_PAGE_META;
+  return {
+    assemblies: meta.ASSEMBLIES,
+    organisms: meta.ORGANISMS,
+    ...("PRIORITY_PATHOGENS" in meta
+      ? { "priority-pathogens": meta.PRIORITY_PATHOGENS }
+      : {}),
+  };
+}
 
 /**
  * Explore view page.
@@ -99,7 +105,7 @@ export const getStaticProps: GetStaticProps<
   const { exploreMode } = entityConfig;
   const { fetchAllEntities } = getEntityService(entityConfig, undefined); // Determine the type of fetch, either from an API endpoint or a TSV.
 
-  const entityMeta = ENTITY_LIST_META[entityListType];
+  const entityMeta = getEntityListMeta(appConfig.appKey)[entityListType];
 
   const props: EntitiesPageProps<BRCCatalog | GA2Catalog> = {
     entityListType,

--- a/pages/data/[entityListType]/index.tsx
+++ b/pages/data/[entityListType]/index.tsx
@@ -11,10 +11,8 @@ import {
   Outbreak,
 } from "../../../app/apis/catalog/brc-analytics-catalog/common/entities";
 import { GA2Catalog } from "../../../app/apis/catalog/ga2/entities";
-import { BRC_PAGE_META } from "../../../app/common/meta/brc/constants";
-import { GA2_PAGE_META } from "../../../app/common/meta/ga2/constants";
+import { getEntityListMeta } from "../../../app/common/meta/utils";
 import { config } from "../../../app/config/config";
-import { APP_KEYS } from "../../../site-config/common/constants";
 import { seedDatabase } from "../../../app/utils/seedDatabase";
 import { StyledExploreView } from "../../../app/views/ExploreView/exploreView.styles";
 import { PriorityPathogensView } from "../../../app/views/PriorityPathogensView/priorityPathogensView";
@@ -28,19 +26,6 @@ interface EntitiesPageProps<R> {
   entityListType: string;
   pageDescription?: string;
   pageTitle?: string;
-}
-
-function getEntityListMeta(
-  appKey?: string
-): Record<string, { pageDescription: string; pageTitle: string }> {
-  const meta = appKey === APP_KEYS.GA2 ? GA2_PAGE_META : BRC_PAGE_META;
-  return {
-    assemblies: meta.ASSEMBLIES,
-    organisms: meta.ORGANISMS,
-    ...("PRIORITY_PATHOGENS" in meta
-      ? { "priority-pathogens": meta.PRIORITY_PATHOGENS }
-      : {}),
-  };
 }
 
 /**

--- a/pages/data/workflows/[trsId]/index.tsx
+++ b/pages/data/workflows/[trsId]/index.tsx
@@ -2,6 +2,9 @@ import { GetStaticPaths, GetStaticProps, GetStaticPropsContext } from "next";
 import { ParsedUrlQuery } from "querystring";
 import { JSX } from "react";
 import { BRC_PAGE_META } from "../../../../app/common/meta/brc/constants";
+import { GA2_PAGE_META } from "../../../../app/common/meta/ga2/constants";
+import { config } from "../../../../app/config/config";
+import { APP_KEYS } from "../../../../site-config/common/constants";
 import { formatTrsId } from "../../../../app/views/AnalyzeWorkflowsView/components/Main/utils";
 import { DIFFERENTIAL_EXPRESSION_ANALYSIS } from "../../../../app/views/AnalyzeWorkflowsView/differentialExpressionAnalysis/constants";
 import { LEXICMAP } from "../../../../app/views/AnalyzeWorkflowsView/lexicmap/constants";
@@ -55,9 +58,12 @@ export const getStaticProps: GetStaticProps<Props> = async ({
 
   if (!trsId) return { notFound: true };
 
+  const { appKey } = config();
+  const meta =
+    appKey === APP_KEYS.GA2 ? GA2_PAGE_META.WORKFLOW : BRC_PAGE_META.WORKFLOW;
   return {
     props: {
-      ...BRC_PAGE_META.WORKFLOW,
+      ...meta,
       trsId,
     },
   };

--- a/pages/data/workflows/[trsId]/index.tsx
+++ b/pages/data/workflows/[trsId]/index.tsx
@@ -1,10 +1,8 @@
 import { GetStaticPaths, GetStaticProps, GetStaticPropsContext } from "next";
 import { ParsedUrlQuery } from "querystring";
 import { JSX } from "react";
-import { BRC_PAGE_META } from "../../../../app/common/meta/brc/constants";
-import { GA2_PAGE_META } from "../../../../app/common/meta/ga2/constants";
+import { getPageMeta } from "../../../../app/common/meta/utils";
 import { config } from "../../../../app/config/config";
-import { APP_KEYS } from "../../../../site-config/common/constants";
 import { formatTrsId } from "../../../../app/views/AnalyzeWorkflowsView/components/Main/utils";
 import { DIFFERENTIAL_EXPRESSION_ANALYSIS } from "../../../../app/views/AnalyzeWorkflowsView/differentialExpressionAnalysis/constants";
 import { LEXICMAP } from "../../../../app/views/AnalyzeWorkflowsView/lexicmap/constants";
@@ -58,12 +56,9 @@ export const getStaticProps: GetStaticProps<Props> = async ({
 
   if (!trsId) return { notFound: true };
 
-  const { appKey } = config();
-  const meta =
-    appKey === APP_KEYS.GA2 ? GA2_PAGE_META.WORKFLOW : BRC_PAGE_META.WORKFLOW;
   return {
     props: {
-      ...meta,
+      ...getPageMeta(config().appKey).WORKFLOW,
       trsId,
     },
   };

--- a/pages/data/workflows/index.tsx
+++ b/pages/data/workflows/index.tsx
@@ -1,20 +1,15 @@
 import { Main as DXMain } from "@databiosphere/findable-ui/lib/components/Layout/components/Main/main.styles";
 import { GetStaticProps } from "next";
-import { BRC_PAGE_META } from "../../../app/common/meta/brc/constants";
-import { GA2_PAGE_META } from "../../../app/common/meta/ga2/constants";
 import { JSX } from "react";
+import { getPageMeta } from "../../../app/common/meta/utils";
 import { config } from "../../../app/config/config";
-import { APP_KEYS } from "../../../site-config/common/constants";
 import { WorkflowsView } from "../../../app/views/WorkflowsView/workflowsView";
 
 export const getStaticProps: GetStaticProps = () => {
-  const { appKey } = config();
-  const meta =
-    appKey === APP_KEYS.GA2 ? GA2_PAGE_META.WORKFLOWS : BRC_PAGE_META.WORKFLOWS;
   return {
     props: {
       entityListType: "workflows",
-      ...meta,
+      ...getPageMeta(config().appKey).WORKFLOWS,
     },
   };
 };

--- a/pages/data/workflows/index.tsx
+++ b/pages/data/workflows/index.tsx
@@ -1,14 +1,20 @@
 import { Main as DXMain } from "@databiosphere/findable-ui/lib/components/Layout/components/Main/main.styles";
 import { GetStaticProps } from "next";
 import { BRC_PAGE_META } from "../../../app/common/meta/brc/constants";
+import { GA2_PAGE_META } from "../../../app/common/meta/ga2/constants";
 import { JSX } from "react";
+import { config } from "../../../app/config/config";
+import { APP_KEYS } from "../../../site-config/common/constants";
 import { WorkflowsView } from "../../../app/views/WorkflowsView/workflowsView";
 
 export const getStaticProps: GetStaticProps = () => {
+  const { appKey } = config();
+  const meta =
+    appKey === APP_KEYS.GA2 ? GA2_PAGE_META.WORKFLOWS : BRC_PAGE_META.WORKFLOWS;
   return {
     props: {
       entityListType: "workflows",
-      ...BRC_PAGE_META.WORKFLOWS,
+      ...meta,
     },
   };
 };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,8 +3,7 @@ import { GetStaticProps } from "next";
 import { StyledMain } from "../app/components/Layout/components/Main/main.styles";
 import { HomeView } from "../app/views/HomeView/homeView";
 import { HomeView as GA2HomeView } from "../app/views/HomeView/ga2/homeView";
-import { BRC_PAGE_META } from "../app/common/meta/brc/constants";
-import { GA2_PAGE_META } from "../app/common/meta/ga2/constants";
+import { getPageMeta } from "../app/common/meta/utils";
 import { config } from "../app/config/config";
 import { useConfig } from "@databiosphere/findable-ui/lib/hooks/useConfig";
 import { AppSiteConfig } from "../site-config/common/entities";
@@ -31,10 +30,7 @@ export const getStaticProps: GetStaticProps = async () => {
 
   return {
     props: {
-      pageDescription:
-        appKey === APP_KEYS.GA2
-          ? GA2_PAGE_META.HOME.pageDescription
-          : BRC_PAGE_META.HOME.pageDescription,
+      pageDescription: getPageMeta(appKey).HOME.pageDescription,
       pageTitle: appTitle,
       themeOptions: {
         palette: { background: { default: backgroundColor } },

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,6 +4,7 @@ import { StyledMain } from "../app/components/Layout/components/Main/main.styles
 import { HomeView } from "../app/views/HomeView/homeView";
 import { HomeView as GA2HomeView } from "../app/views/HomeView/ga2/homeView";
 import { BRC_PAGE_META } from "../app/common/meta/brc/constants";
+import { GA2_PAGE_META } from "../app/common/meta/ga2/constants";
 import { config } from "../app/config/config";
 import { useConfig } from "@databiosphere/findable-ui/lib/hooks/useConfig";
 import { AppSiteConfig } from "../site-config/common/entities";
@@ -30,7 +31,10 @@ export const getStaticProps: GetStaticProps = async () => {
 
   return {
     props: {
-      pageDescription: BRC_PAGE_META.HOME.pageDescription,
+      pageDescription:
+        appKey === APP_KEYS.GA2
+          ? GA2_PAGE_META.HOME.pageDescription
+          : BRC_PAGE_META.HOME.pageDescription,
       pageTitle: appTitle,
       themeOptions: {
         palette: { background: { default: backgroundColor } },

--- a/pages/roadmap/index.tsx
+++ b/pages/roadmap/index.tsx
@@ -4,6 +4,7 @@ import { StyledPagesMain } from "../../app/components/Layout/components/Main/mai
 import { RoadmapView } from "../../app/views/RoadmapView/roadmapView";
 import { RoadmapViewGA2 } from "../../app/views/RoadmapView/roadmapViewGA2";
 import { BRC_PAGE_META } from "../../app/common/meta/brc/constants";
+import { GA2_PAGE_META } from "../../app/common/meta/ga2/constants";
 import { config } from "../../app/config/config";
 import { APP_KEYS } from "../../site-config/common/constants";
 import { ROUTES } from "../../routes/constants";
@@ -18,15 +19,18 @@ export const Roadmap = (): JSX.Element => {
 };
 
 export const getStaticProps: GetStaticProps = async () => {
-  const { allowedPaths } = config();
+  const { allowedPaths, appKey } = config();
 
   if (allowedPaths && !allowedPaths.includes(ROUTES.ROADMAP)) {
     return { notFound: true };
   }
 
+  const meta =
+    appKey === APP_KEYS.GA2 ? GA2_PAGE_META.ROADMAP : BRC_PAGE_META.ROADMAP;
+
   return {
     props: {
-      ...BRC_PAGE_META.ROADMAP,
+      ...meta,
       themeOptions: {
         palette: { background: { default: "#FAFBFB" } }, // SMOKE_LIGHTEST
       },

--- a/pages/roadmap/index.tsx
+++ b/pages/roadmap/index.tsx
@@ -3,8 +3,7 @@ import { GetStaticProps } from "next";
 import { StyledPagesMain } from "../../app/components/Layout/components/Main/main.styles";
 import { RoadmapView } from "../../app/views/RoadmapView/roadmapView";
 import { RoadmapViewGA2 } from "../../app/views/RoadmapView/roadmapViewGA2";
-import { BRC_PAGE_META } from "../../app/common/meta/brc/constants";
-import { GA2_PAGE_META } from "../../app/common/meta/ga2/constants";
+import { getPageMeta } from "../../app/common/meta/utils";
 import { config } from "../../app/config/config";
 import { APP_KEYS } from "../../site-config/common/constants";
 import { ROUTES } from "../../routes/constants";
@@ -25,12 +24,9 @@ export const getStaticProps: GetStaticProps = async () => {
     return { notFound: true };
   }
 
-  const meta =
-    appKey === APP_KEYS.GA2 ? GA2_PAGE_META.ROADMAP : BRC_PAGE_META.ROADMAP;
-
   return {
     props: {
-      ...meta,
+      ...getPageMeta(appKey).ROADMAP,
       themeOptions: {
         palette: { background: { default: "#FAFBFB" } }, // SMOKE_LIGHTEST
       },


### PR DESCRIPTION
## Summary
- Creates `app/common/meta/ga2/constants.ts` with GA2-specific page metadata (`GA2_PAGE_META`, `GA2_DEFAULT_DESCRIPTION`)
- Removes the BRC-only gate on `OgMeta` in `_app.tsx` — both sites now render OG tags, each with their own default description
- Updates all shared pages (home, about, roadmap, entity list, entity detail, workflows, analyze) to select the correct metadata based on `appKey`
- Reuses the existing `OgMeta` component — no duplication

### GA2 pages with meta content

| Page | og:title | og:description |
|------|----------|----------------|
| Home | Genome Ark 2 | Genome Ark 2: explore and analyze reference genome assemblies using Galaxy workflows. |
| Organisms | Organisms - Genome Ark 2 | Browse organisms with reference genome assemblies on Genome Ark 2. |
| Assemblies | Assemblies - Genome Ark 2 | Browse genome assemblies available for analysis on Genome Ark 2. |
| Workflows | Workflows - Genome Ark 2 | Explore Galaxy workflows available for genomic analysis on Genome Ark 2. |
| About | About - Genome Ark 2 | Learn about the Genome Ark 2 platform for reference genome analysis. |
| Roadmap | Roadmap - Genome Ark 2 | View the development roadmap for Genome Ark 2. |
| Analyze | Analyze - Genome Ark 2 | Select and configure workflows for genome analysis on Genome Ark 2. |

Closes #1234

## Test plan
- [x] Verify GA2 builds successfully
- [ ] Share a GA2 link on Slack and verify rich preview with title, description, and GA2 favicon
- [ ] Verify BRC analytics still shows BRC-specific metadata (no regression)
- [ ] Verify each GA2 page type has a relevant title and description

🤖 Generated with [Claude Code](https://claude.com/claude-code)