### PR TITLE
fix: move explorestateProvider inside errorboundary to prevent crash loop (#1252)

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -113,29 +113,29 @@ function MyApp({ Component, pageProps }: AppPropsWithComponent): JSX.Element {
                   <LayoutDimensionsProvider>
                     <AppLayout>
                       <DXHeader {...filteredHeader} />
-                      <ExploreStateProvider entityListType={entityListType}>
-                        <Main>
-                          <ErrorBoundary
-                            fallbackRender={({
-                              error,
-                              reset,
-                            }: {
-                              error: DataExplorerError;
-                              reset: () => void;
-                            }): JSX.Element => (
-                              <Error
-                                errorMessage={error.message}
-                                requestUrlMessage={error.requestUrlMessage}
-                                rootPath={redirectRootToPath}
-                                onReset={reset}
-                              />
-                            )}
-                          >
+                      <Main>
+                        <ErrorBoundary
+                          fallbackRender={({
+                            error,
+                            reset,
+                          }: {
+                            error: DataExplorerError;
+                            reset: () => void;
+                          }): JSX.Element => (
+                            <Error
+                              errorMessage={error.message}
+                              requestUrlMessage={error.requestUrlMessage}
+                              rootPath={redirectRootToPath}
+                              onReset={reset}
+                            />
+                          )}
+                        >
+                          <ExploreStateProvider entityListType={entityListType}>
                             <Component {...pageProps} />
                             <Floating {...floating} />
-                          </ErrorBoundary>
-                        </Main>
-                      </ExploreStateProvider>
+                          </ExploreStateProvider>
+                        </ErrorBoundary>
+                      </Main>
                       <StyledFooter {...footer} />
                     </AppLayout>
                   </LayoutDimensionsProvider>


### PR DESCRIPTION
## Summary
- Moves `ExploreStateProvider` inside the `ErrorBoundary` in `_app.tsx`
- Previously, `ExploreStateProvider` sat above the `ErrorBoundary`, so reducer/hook errors (e.g. from invalid filter query params) bypassed the boundary and caused an infinite crash loop
- Header and Footer remain outside the boundary so users can still navigate away from the error page

```
Before:                          After:
ExploreStateProvider             Main
  Main                             ErrorBoundary
    ErrorBoundary                    ExploreStateProvider
      Component                        Component
```

Part of DataBiosphere/findable-ui#888

Fixes #1252

## Test plan
- [x] 487 unit tests pass
- [x] 66 e2e tests pass
- [x] BRC build succeeds
- [x] Verify navigating to a URL with invalid filter params shows the error page instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)