### PR TITLE
feat: show serotype and isolate in assembly details on the workflow stepper (#1256)

### DIFF
--- a/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
@@ -133,6 +133,20 @@ export const buildAssemblyDetails = (
       strain
     );
   }
+  const serotype = getGenomeSerotypeText(assembly);
+  if (serotype) {
+    keyValuePairs.set(
+      BRC_DATA_CATALOG_CATEGORY_LABEL.TAXONOMIC_LEVEL_SEROTYPE,
+      serotype
+    );
+  }
+  const isolate = getGenomeIsolateText(assembly);
+  if (isolate) {
+    keyValuePairs.set(
+      BRC_DATA_CATALOG_CATEGORY_LABEL.TAXONOMIC_LEVEL_ISOLATE,
+      isolate
+    );
+  }
   keyValuePairs.set(
     BRC_DATA_CATALOG_CATEGORY_LABEL.ACCESSION,
     C.CopyText({
@@ -1007,10 +1021,13 @@ function getGenomeStrainText(
  * @returns serotype text.
  */
 function getGenomeSerotypeText(
-  genome: BRCDataCatalogGenome,
+  genome: BRCDataCatalogGenome | GA2AssemblyEntity,
   defaultValue = ""
 ): string {
-  if (genome.taxonomicLevelSerotype !== "None")
+  if (
+    "taxonomicLevelSerotype" in genome &&
+    genome.taxonomicLevelSerotype !== "None"
+  )
     return genome.taxonomicLevelSerotype;
   return defaultValue;
 }
@@ -1022,10 +1039,13 @@ function getGenomeSerotypeText(
  * @returns isolate text.
  */
 function getGenomeIsolateText(
-  genome: BRCDataCatalogGenome,
+  genome: BRCDataCatalogGenome | GA2AssemblyEntity,
   defaultValue = ""
 ): string {
-  if (genome.taxonomicLevelIsolate !== "None")
+  if (
+    "taxonomicLevelIsolate" in genome &&
+    genome.taxonomicLevelIsolate !== "None"
+  )
     return genome.taxonomicLevelIsolate;
   return defaultValue;
 }


### PR DESCRIPTION
## Summary

- Display **Serotype** and **Isolate** key-value rows in the Assembly Details side column when values are present
- Order: Species → Strain → Serotype → Isolate → Accession → Priority Pathogen
- Reuses existing `getGenomeSerotypeText()` and `getGenomeIsolateText()` helpers (widened to accept union type)

Closes #1256

## Test plan

- [x] Verify serotype row appears for assemblies with a non-empty serotype
- [x] Verify isolate row appears for assemblies with a non-empty isolate
- [x] Verify rows are omitted when values are missing/None
- [x] Verify field order matches acceptance criteria

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2314" height="1235" alt="image" src="https://github.com/user-attachments/assets/1e245c82-cc5a-40d4-b29c-0d54e6c8654c" />

<img width="2312" height="1232" alt="image" src="https://github.com/user-attachments/assets/8282eaa5-0e42-43bf-84e5-7c3cd045bbd2" />

<img width="2315" height="1234" alt="image" src="https://github.com/user-attachments/assets/93c5989a-c3ce-4531-9b8f-7a67a98785c1" />
