### PR TITLE
fix: ena picker uses species taxon id for prefilters and validation (#1193)

### DIFF
--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/CollectionSummary/components/Alert/alert.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/CollectionSummary/components/Alert/alert.tsx
@@ -8,7 +8,7 @@ import { Props } from "./types";
 export const Alert = ({ requirementsMatches }: Props): JSX.Element | null => {
   if (requirementsMatches.length === 0) return null;
   return (
-    <StyledAlert {...ALERT_PROPS.STANDARD_WARNING} size={SIZE.LARGE}>
+    <StyledAlert {...ALERT_PROPS.STANDARD_INFO} size={SIZE.LARGE}>
       <AlertTitle>
         Some selected data may not match expected criteria
       </AlertTitle>

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/CollectionSummary/components/Alert/alert.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/CollectionSummary/components/Alert/alert.tsx
@@ -9,7 +9,9 @@ export const Alert = ({ requirementsMatches }: Props): JSX.Element | null => {
   if (requirementsMatches.length === 0) return null;
   return (
     <StyledAlert {...ALERT_PROPS.STANDARD_WARNING} size={SIZE.LARGE}>
-      <AlertTitle>Some selected data may not match requirements</AlertTitle>
+      <AlertTitle>
+        Some selected data may not match expected criteria
+      </AlertTitle>
       <ul>
         {requirementsMatches.map((requirement) => (
           <li key={requirement}>{requirement}</li>

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/CollectionSummary/components/Alert/hooks/UseRequirementsMatches/utils.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/CollectionSummary/components/Alert/hooks/UseRequirementsMatches/utils.ts
@@ -80,14 +80,20 @@ function buildSpeciesWarnings(
 ): string[] {
   if (!genome) return [];
 
-  const { ncbiTaxonomyId, taxonomicLevelSpecies } = genome;
+  const { ncbiTaxonomyId, speciesTaxonomyId, taxonomicLevelSpecies } = genome;
 
   // Build a set of unmatched values.
   const unmatchedSet = new Set();
   for (const { original } of rows) {
-    const { scientific_name = LABEL.UNSPECIFIED, tax_id } = original;
+    const {
+      scientific_name = LABEL.UNSPECIFIED,
+      tax_id,
+      tax_lineage = "",
+    } = original;
     // Compare the row value to the expected value.
-    if (ncbiTaxonomyId === tax_id) continue;
+    if (tax_id === ncbiTaxonomyId) continue;
+    if (tax_id === speciesTaxonomyId) continue;
+    if (tax_lineage.split(";").includes(speciesTaxonomyId)) continue;
 
     // Add the unmatched value to the set.
     unmatchedSet.add(`${tax_id} (${scientific_name})`);

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/DataSelector/components/Alert/alert.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/DataSelector/components/Alert/alert.tsx
@@ -15,7 +15,7 @@ export const Alert = ({
   if (taxonomyMatches > 0) return null;
 
   return (
-    <StyledAlert {...ALERT_PROPS.STANDARD_WARNING} size={SIZE.LARGE}>
+    <StyledAlert {...ALERT_PROPS.STANDARD_INFO} size={SIZE.LARGE}>
       <AlertTitle>No matching read runs found by Taxonomy ID</AlertTitle>
       Data labels may not always be accurate. You can still select and use any
       available sequences.

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/hooks/UseENADataByAccession/constants.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/hooks/UseENADataByAccession/constants.ts
@@ -26,4 +26,5 @@ export const ENA_FIELDS = [
   "scientific_name",
   "study_accession",
   "tax_id",
+  "tax_lineage",
 ];

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/types.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/types.ts
@@ -21,6 +21,7 @@ export interface BaseReadRun {
   study_accession: string;
   submitted_ftp: string;
   tax_id: string;
+  tax_lineage?: string;
 }
 
 export interface ReadRun extends BaseReadRun {

--- a/tests/configureWorkflow/sequencingStep/useRequirementsMatches.utils.test.ts
+++ b/tests/configureWorkflow/sequencingStep/useRequirementsMatches.utils.test.ts
@@ -168,17 +168,48 @@ describe("buildRequirementWarnings", () => {
       expect.stringContaining(EXPECTED.SPECIES_MISMATCH),
     ]);
   });
+
+  test("no species warning when read tax_id matches speciesTaxonomyId", () => {
+    const filters: ColumnFiltersState = [];
+    const genome = makeGenome("330879", "746128");
+    const rows = makeRows({ tax_id: "746128" });
+
+    expect(buildRequirementWarnings(filters, rows, genome)).toEqual([]);
+  });
+
+  test("no species warning when speciesTaxonomyId appears in tax_lineage", () => {
+    const filters: ColumnFiltersState = [];
+    const genome = makeGenome("330879", "746128");
+    const rows = makeRows({
+      tax_id: "41122",
+      tax_lineage: "1;131567;2759;746128;41122",
+    });
+
+    expect(buildRequirementWarnings(filters, rows, genome)).toEqual([]);
+  });
+
+  test("species warning when tax_id and tax_lineage do not match", () => {
+    const filters: ColumnFiltersState = [];
+    const genome = makeGenome("330879", "746128");
+    const rows = makeRows({ scientific_name: "Other sp.", tax_id: "99999" });
+
+    expect(buildRequirementWarnings(filters, rows, genome)).toEqual([
+      expect.stringContaining(EXPECTED.SPECIES_MISMATCH),
+    ]);
+  });
 });
 
 /**
  * Returns partial genome entity for unit tests.
  * @param ncbiTaxonomyId - NCBI Tax ID.
+ * @param speciesTaxonomyId - Species Tax ID.
  * @returns genome entity.
  */
 function makeGenome(
-  ncbiTaxonomyId: string
+  ncbiTaxonomyId: string,
+  speciesTaxonomyId = ncbiTaxonomyId
 ): BRCDataCatalogGenome | GA2AssemblyEntity {
-  return { ncbiTaxonomyId } as unknown as
+  return { ncbiTaxonomyId, speciesTaxonomyId } as unknown as
     | BRCDataCatalogGenome
     | GA2AssemblyEntity;
 }


### PR DESCRIPTION
## Summary

- Match ENA read runs against `speciesTaxonomyId` in addition to `ncbiTaxonomyId`, so strain-level assemblies no longer warn when reads are tagged at species level
- Request `tax_lineage` from ENA and check if the assembly's species ID appears in the read's lineage, catching sub-species reads that roll up to the same species
- Reword alert title from "requirements" to "expected criteria" to read as a non-blocking warning

Closes #1193

## Test plan

- [x] Navigate to GCF_000002655.1 (A. fumigatus Af293, strain tax ID 330879, species tax ID 746128)
- [x] Pick a workflow with a sequencing step, enter accession PRJEB60964 or PRJNA673120
- [x] Select reads — species mismatch warning should NOT appear (reads are tagged at species level 746128)
- [x] Verify legitimate warnings (e.g., library source mismatch) still display correctly
- [x] Verify alert title reads "Some selected data may not match expected criteria"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1659" height="1121" alt="image" src="https://github.com/user-attachments/assets/ae0a73d9-7717-4986-8057-04b12c22161f" />

