### PR TITLE
chore: ignore .playwright-mcp/ debug output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ backend/**/.env
 /playwright-report
 /playwright/.cache
 
+# Playwright MCP server debug output
+/.playwright-mcp/
+
 # python
 venv
 __pycache__

--- a/.prettierignore
+++ b/.prettierignore
@@ -24,3 +24,6 @@ venv
 
 # claude code config
 .claude
+
+# playwright mcp debug output
+.playwright-mcp


### PR DESCRIPTION
## Summary
- `.playwright-mcp/` accumulates console logs, screenshots, and YAML page snapshots from the Playwright MCP server.
- Untracked but unignored, so `prettier --check` picks up the YAML files and the pre-commit hook fails on unrelated branches.
- Adds the directory to `.gitignore` and `.prettierignore`.

## Test plan
- [ ] Stray `.playwright-mcp/*.yml` files no longer surface in `npm run check-format`
- [ ] `git status` doesn't list them in any state