### PR TITLE
feat: build organism table via usereacttable (#1275)

### DIFF
--- a/app/components/common/Table/hooks/UseRowDirection/hook.ts
+++ b/app/components/common/Table/hooks/UseRowDirection/hook.ts
@@ -1,0 +1,20 @@
+import { ROW_DIRECTION } from "@databiosphere/findable-ui/lib/components/Table/common/entities";
+import {
+  BREAKPOINT_FN_NAME,
+  useBreakpointHelper,
+} from "@databiosphere/findable-ui/lib/hooks/useBreakpointHelper";
+
+/**
+ * Returns the row direction for the table based on the current breakpoint.
+ * Vertical on small viewports; horizontal otherwise.
+ * @returns Row direction.
+ */
+export function useRowDirection(): { rowDirection: ROW_DIRECTION } {
+  const bpDownSm = useBreakpointHelper(BREAKPOINT_FN_NAME.DOWN, "sm");
+
+  const rowDirection = bpDownSm
+    ? ROW_DIRECTION.VERTICAL
+    : ROW_DIRECTION.DEFAULT;
+
+  return { rowDirection };
+}

--- a/app/components/common/Table/table.tsx
+++ b/app/components/common/Table/table.tsx
@@ -1,0 +1,43 @@
+import { TableBody } from "@databiosphere/findable-ui/lib/components/Table/components/TableBody/tableBody";
+import { TableHead } from "@databiosphere/findable-ui/lib/components/Table/components/TableHead/tableHead";
+import { useVirtualization } from "@databiosphere/findable-ui/lib/components/Table/hooks/UseVirtualization/hook";
+import { GridTable } from "@databiosphere/findable-ui/lib/components/Table/table.styles";
+import { getColumnTrackSizing } from "@databiosphere/findable-ui/lib/components/TableCreator/options/columnTrackSizing/utils";
+import { TableContainer } from "@mui/material";
+import { RowData } from "@tanstack/react-table";
+import { JSX } from "react";
+import { useRowDirection } from "./hooks/UseRowDirection/hook";
+import { Props } from "./types";
+
+/**
+ * Renders a virtualized table for a TanStack Table instance, with responsive
+ * row direction (horizontal on default viewports, vertical on small viewports).
+ * @param props - Component props.
+ * @param props.table - Table instance.
+ * @returns Table component.
+ */
+export const Table = <T extends RowData>({ table }: Props<T>): JSX.Element => {
+  const { rowDirection } = useRowDirection();
+  const { rows, scrollElementRef, virtualizer } = useVirtualization({
+    rowDirection,
+    table,
+  });
+  return (
+    <TableContainer ref={scrollElementRef}>
+      <GridTable
+        gridTemplateColumns={getColumnTrackSizing(
+          table.getVisibleFlatColumns()
+        )}
+        collapsable
+      >
+        <TableHead tableInstance={table} />
+        <TableBody
+          rowDirection={rowDirection}
+          rows={rows}
+          tableInstance={table}
+          virtualizer={virtualizer}
+        />
+      </GridTable>
+    </TableContainer>
+  );
+};

--- a/app/components/common/Table/types.ts
+++ b/app/components/common/Table/types.ts
@@ -1,0 +1,5 @@
+import { RowData, Table } from "@tanstack/react-table";
+
+export interface Props<T extends RowData> {
+  table: Table<T>;
+}

--- a/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
@@ -3,11 +3,10 @@ import {
   Key,
   Value,
 } from "@databiosphere/findable-ui/lib/components/common/KeyValuePairs/keyValuePairs";
-import { FluidPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/paper.styles";
 import { COLUMN_IDENTIFIER } from "@databiosphere/findable-ui/lib/components/Table/common/columnIdentifier";
 import { CHIP_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/chip";
 import { replaceParameters } from "@databiosphere/findable-ui/lib/utils/replaceParameters";
-import { ColumnDef, getSortedRowModel } from "@tanstack/react-table";
+import { ColumnDef, RowData } from "@tanstack/react-table";
 import { LinkProps } from "next/link";
 import Router from "next/router";
 import { ComponentProps } from "react";
@@ -812,36 +811,29 @@ export const buildOrganismViewMain = (
   return {
     entityId: getOrganismId(organism),
     organism,
-    tableProps: buildOrganismGenomesTable(organism),
+    tableOptions: buildOrganismGenomesTable(organism),
   };
 };
 
 /**
  * Build props for the genomes table for the given organism.
- * @param organism - Organism entity.
- * @returns props to be used for the table.
+ * @param organism - Organism entity with genomes to be displayed in the table.
+ * @returns table options.
  */
 export function buildOrganismGenomesTable(
   organism: BRCDataCatalogOrganism
-): ComponentProps<typeof C.DetailViewTable<BRCDataCatalogGenome>> {
+): ComponentProps<typeof C.OrganismViewMain>["tableOptions"] {
   return {
-    Paper: FluidPaper,
-    columns: buildOrganismGenomesTableColumns(),
-    gridTemplateColumns:
-      "auto minmax(164px, 1fr) minmax(180px, 0.5fr) minmax(180px, 0.5fr) minmax(180px, 0.5fr) minmax(144px, 0.5fr) minmax(100px, 0.5fr) repeat(2, minmax(142px, 0.5fr)) minmax(132px, 0.5fr) minmax(120px, 0.5fr) minmax(120px, 0.5fr) repeat(3, minmax(120px, 0.5fr)) minmax(180px, 0.5fr)",
-    items: organism.genomes,
-    noResultsTitle: "No Assemblies",
-    tableOptions: {
-      enableRowPosition: false,
-      enableSorting: true,
-      getSortedRowModel: getSortedRowModel(),
-      initialState: {
-        columnVisibility: { [COLUMN_IDENTIFIER.ROW_POSITION]: false },
-        sorting: [
-          { desc: true, id: BRC_DATA_CATALOG_CATEGORY_KEY.IS_REF },
-          { desc: false, id: BRC_DATA_CATALOG_CATEGORY_KEY.ACCESSION },
-        ],
-      },
+    // Cast: ColumnDef<T> is invariant in T, so the catalog-specific row type
+    // cannot widen to RowData even though BRCDataCatalogGenome extends it.
+    columns: buildOrganismGenomesTableColumns() as ColumnDef<RowData>[],
+    data: organism.genomes,
+    initialState: {
+      columnVisibility: { [COLUMN_IDENTIFIER.ROW_POSITION]: false },
+      sorting: [
+        { desc: true, id: BRC_DATA_CATALOG_CATEGORY_KEY.IS_REF },
+        { desc: false, id: BRC_DATA_CATALOG_CATEGORY_KEY.ACCESSION },
+      ],
     },
   };
 }
@@ -855,86 +847,105 @@ function buildOrganismGenomesTableColumns(): ColumnDef<BRCDataCatalogGenome>[] {
     {
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.ANALYZE_GENOME,
       cell: ({ row }) => C.AnalyzeGenome(buildAnalyzeGenome(row.original)),
+      enableSorting: false,
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.ANALYZE_GENOME,
+      meta: { width: "auto" },
     },
     {
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.ACCESSION,
       cell: ({ row }) => C.BasicCell(buildAccession(row.original)),
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.ACCESSION,
-      meta: { columnPinned: true },
+      meta: { columnPinned: true, width: { max: "1fr", min: "164px" } },
     },
     {
-      accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.TAXONOMIC_LEVEL_STRAIN,
+      accessorFn: (row) => getGenomeStrainText(row),
       cell: ({ row }) =>
         C.BasicCell(buildGenomeTaxonomicLevelStrain(row.original)),
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.TAXONOMIC_LEVEL_STRAIN,
+      id: BRC_DATA_CATALOG_CATEGORY_KEY.TAXONOMIC_LEVEL_STRAIN,
+      meta: { width: { max: "0.5fr", min: "180px" } },
     },
     {
-      accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.TAXONOMIC_LEVEL_SEROTYPE,
+      accessorFn: (row) => getGenomeSerotypeText(row),
       cell: ({ row }) =>
         C.BasicCell(buildGenomeTaxonomicLevelSerotype(row.original)),
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.TAXONOMIC_LEVEL_SEROTYPE,
+      id: BRC_DATA_CATALOG_CATEGORY_KEY.TAXONOMIC_LEVEL_SEROTYPE,
+      meta: { width: { max: "0.5fr", min: "180px" } },
     },
     {
-      accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.TAXONOMIC_LEVEL_ISOLATE,
+      accessorFn: (row) => getGenomeIsolateText(row),
       cell: ({ row }) =>
         C.BasicCell(buildGenomeTaxonomicLevelIsolate(row.original)),
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.TAXONOMIC_LEVEL_ISOLATE,
+      id: BRC_DATA_CATALOG_CATEGORY_KEY.TAXONOMIC_LEVEL_ISOLATE,
+      meta: { width: { max: "0.5fr", min: "180px" } },
     },
     {
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.TAXONOMY_ID,
       cell: ({ row }) => C.BasicCell(buildTaxonomyId(row.original)),
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.TAXONOMY_ID,
+      meta: { width: { max: "0.5fr", min: "144px" } },
     },
     {
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.IS_REF,
       cell: ({ row }) => C.ChipCell(buildIsRef(row.original)),
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.IS_REF,
+      meta: { width: { max: "0.5fr", min: "100px" } },
     },
     {
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.LEVEL,
       cell: ({ row }) => C.BasicCell(buildLevel(row.original)),
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.LEVEL,
+      meta: { width: { max: "0.5fr", min: "142px" } },
     },
     {
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.CHROMOSOMES,
       cell: ({ row }) => C.BasicCell(buildChromosomes(row.original)),
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.CHROMOSOMES,
+      meta: { width: { max: "0.5fr", min: "142px" } },
     },
     {
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.LENGTH,
       cell: ({ row }) => C.BasicCell(buildLength(row.original)),
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.LENGTH,
+      meta: { width: { max: "0.5fr", min: "132px" } },
     },
     {
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.SCAFFOLD_COUNT,
       cell: ({ row }) => C.BasicCell(buildScaffoldCount(row.original)),
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.SCAFFOLD_COUNT,
+      meta: { width: { max: "0.5fr", min: "120px" } },
     },
     {
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.SCAFFOLD_N50,
       cell: ({ row }) => C.BasicCell(buildScaffoldN50(row.original)),
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.SCAFFOLD_N50,
+      meta: { width: { max: "0.5fr", min: "120px" } },
     },
     {
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.SCAFFOLD_L50,
       cell: ({ row }) => C.BasicCell(buildScaffoldL50(row.original)),
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.SCAFFOLD_L50,
+      meta: { width: { max: "0.5fr", min: "120px" } },
     },
     {
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.COVERAGE,
       cell: ({ row }) => C.BasicCell(buildCoverage(row.original)),
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.COVERAGE,
+      meta: { width: { max: "0.5fr", min: "120px" } },
     },
     {
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.GC_PERCENT,
       cell: ({ row }) => C.BasicCell(buildGcPercent(row.original)),
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.GC_PERCENT,
+      meta: { width: { max: "0.5fr", min: "120px" } },
     },
     {
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.ANNOTATION_STATUS,
       cell: ({ row }) => C.BasicCell(buildAnnotationStatus(row.original)),
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.ANNOTATION_STATUS,
+      meta: { width: { max: "0.5fr", min: "180px" } },
     },
   ];
 }
@@ -1019,7 +1030,7 @@ function getEntityLinkWithPriorityPathogenFilter(
  * @param defaultValue - Default value to use if there's no strain.
  * @returns strain text.
  */
-function getGenomeStrainText(
+export function getGenomeStrainText(
   entity: BRCDataCatalogGenome | GA2AssemblyEntity,
   defaultValue = ""
 ): string {
@@ -1035,7 +1046,7 @@ function getGenomeStrainText(
  * @param defaultValue - Default value if no serotype is found.
  * @returns serotype text.
  */
-function getGenomeSerotypeText(
+export function getGenomeSerotypeText(
   genome: BRCDataCatalogGenome | GA2AssemblyEntity,
   defaultValue = ""
 ): string {
@@ -1053,7 +1064,7 @@ function getGenomeSerotypeText(
  * @param defaultValue - Default value if no isolate is found.
  * @returns isolate text.
  */
-function getGenomeIsolateText(
+export function getGenomeIsolateText(
   genome: BRCDataCatalogGenome | GA2AssemblyEntity,
   defaultValue = ""
 ): string {

--- a/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
@@ -816,7 +816,7 @@ export const buildOrganismViewMain = (
 };
 
 /**
- * Build props for the genomes table for the given organism.
+ * Build table options (columns, data, initial state) for the genomes table for the given organism.
  * @param organism - Organism entity with genomes to be displayed in the table.
  * @returns table options.
  */

--- a/app/viewModelBuilders/catalog/ga2/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/ga2/viewModelBuilders.ts
@@ -1,6 +1,5 @@
-import { FluidPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/paper.styles";
 import { COLUMN_IDENTIFIER } from "@databiosphere/findable-ui/lib/components/Table/common/columnIdentifier";
-import { ColumnDef, getSortedRowModel } from "@tanstack/react-table";
+import { ColumnDef, RowData } from "@tanstack/react-table";
 import { ComponentProps } from "react";
 import { ROUTES } from "../../../../routes/constants";
 import {
@@ -18,6 +17,7 @@ import {
   buildGenomeTaxonomicLevelStrain,
   buildIsRef,
   formatNumber,
+  getGenomeStrainText,
 } from "../brc-analytics-catalog/common/viewModelBuilders";
 
 /**
@@ -48,7 +48,7 @@ export const buildOrganismViewMain = (
   return {
     entityId: sanitizeEntityId(entity.ncbiTaxonomyId),
     organism: entity,
-    tableProps: buildOrganismGenomesTable(entity),
+    tableOptions: buildOrganismGenomesTable(entity),
   };
 };
 
@@ -73,24 +73,18 @@ export const buildOrganismImageThumbnail = (
  */
 export function buildOrganismGenomesTable(
   entity: GA2OrganismEntity
-): ComponentProps<typeof C.DetailViewTable<GA2AssemblyEntity>> {
+): ComponentProps<typeof C.OrganismViewMain>["tableOptions"] {
   return {
-    Paper: C.FluidPaper as typeof FluidPaper,
-    columns: buildOrganismGenomesTableColumns(),
-    gridTemplateColumns: "auto repeat(13, minmax(152px, 1fr))",
-    items: entity.genomes,
-    noResultsTitle: "No Assemblies",
-    tableOptions: {
-      enableRowPosition: false,
-      enableSorting: true,
-      getSortedRowModel: getSortedRowModel(),
-      initialState: {
-        columnVisibility: { [COLUMN_IDENTIFIER.ROW_POSITION]: false },
-        sorting: [
-          { desc: true, id: GA2_CATEGORY_KEY.IS_REF },
-          { desc: false, id: GA2_CATEGORY_KEY.ACCESSION },
-        ],
-      },
+    // Cast: ColumnDef<T> is invariant in T, so the catalog-specific row type
+    // cannot widen to RowData even though GA2AssemblyEntity extends it.
+    columns: buildOrganismGenomesTableColumns() as ColumnDef<RowData>[],
+    data: entity.genomes,
+    initialState: {
+      columnVisibility: { [COLUMN_IDENTIFIER.ROW_POSITION]: false },
+      sorting: [
+        { desc: true, id: GA2_CATEGORY_KEY.IS_REF },
+        { desc: false, id: GA2_CATEGORY_KEY.ACCESSION },
+      ],
     },
   };
 }
@@ -104,67 +98,82 @@ function buildOrganismGenomesTableColumns(): ColumnDef<GA2AssemblyEntity>[] {
     {
       accessorKey: GA2_CATEGORY_KEY.ANALYZE_GENOME,
       cell: ({ row }) => C.AnalyzeGenome(buildAnalyzeGenome(row.original)),
+      enableSorting: false,
       header: GA2_CATEGORY_LABEL.ANALYZE_GENOME,
+      meta: { width: "auto" },
     },
     {
       accessorKey: GA2_CATEGORY_KEY.ACCESSION,
       header: GA2_CATEGORY_LABEL.ACCESSION,
-      meta: { columnPinned: true },
+      meta: { columnPinned: true, width: { max: "1fr", min: "152px" } },
     },
     {
-      accessorKey: GA2_CATEGORY_KEY.TAXONOMIC_LEVEL_STRAIN,
+      accessorFn: (row) => getGenomeStrainText(row),
       cell: ({ row }) =>
         C.BasicCell(buildGenomeTaxonomicLevelStrain(row.original)),
       header: GA2_CATEGORY_LABEL.TAXONOMIC_LEVEL_STRAIN,
+      id: GA2_CATEGORY_KEY.TAXONOMIC_LEVEL_STRAIN,
+      meta: { width: { max: "1fr", min: "152px" } },
     },
     {
       accessorKey: GA2_CATEGORY_KEY.TAXONOMY_ID,
       header: GA2_CATEGORY_LABEL.TAXONOMY_ID,
+      meta: { width: { max: "1fr", min: "152px" } },
     },
     {
       accessorKey: GA2_CATEGORY_KEY.IS_REF,
       cell: ({ row }) => C.ChipCell(buildIsRef(row.original)),
       header: GA2_CATEGORY_LABEL.IS_REF,
+      meta: { width: { max: "1fr", min: "152px" } },
     },
     {
       accessorKey: GA2_CATEGORY_KEY.LEVEL,
       header: GA2_CATEGORY_LABEL.LEVEL,
+      meta: { width: { max: "1fr", min: "152px" } },
     },
     {
       accessorKey: GA2_CATEGORY_KEY.CHROMOSOMES,
       header: GA2_CATEGORY_LABEL.CHROMOSOMES,
+      meta: { width: { max: "1fr", min: "152px" } },
     },
     {
       accessorKey: GA2_CATEGORY_KEY.LENGTH,
       cell: ({ getValue }) => formatNumber(getValue()),
       header: GA2_CATEGORY_LABEL.LENGTH,
+      meta: { width: { max: "1fr", min: "152px" } },
     },
     {
       accessorKey: GA2_CATEGORY_KEY.SCAFFOLD_COUNT,
       cell: ({ getValue }) => formatNumber(getValue()),
       header: GA2_CATEGORY_LABEL.SCAFFOLD_COUNT,
+      meta: { width: { max: "1fr", min: "152px" } },
     },
     {
       accessorKey: GA2_CATEGORY_KEY.SCAFFOLD_N50,
       cell: ({ getValue }) => formatNumber(getValue()),
       header: GA2_CATEGORY_LABEL.SCAFFOLD_N50,
+      meta: { width: { max: "1fr", min: "152px" } },
     },
     {
       accessorKey: GA2_CATEGORY_KEY.SCAFFOLD_L50,
       cell: ({ getValue }) => formatNumber(getValue()),
       header: GA2_CATEGORY_LABEL.SCAFFOLD_L50,
+      meta: { width: { max: "1fr", min: "152px" } },
     },
     {
       accessorKey: GA2_CATEGORY_KEY.COVERAGE,
       header: GA2_CATEGORY_LABEL.COVERAGE,
+      meta: { width: { max: "1fr", min: "152px" } },
     },
     {
       accessorKey: GA2_CATEGORY_KEY.GC_PERCENT,
       header: GA2_CATEGORY_LABEL.GC_PERCENT,
+      meta: { width: { max: "1fr", min: "152px" } },
     },
     {
       accessorKey: GA2_CATEGORY_KEY.ANNOTATION_STATUS,
       header: GA2_CATEGORY_LABEL.ANNOTATION_STATUS,
+      meta: { width: { max: "1fr", min: "152px" } },
     },
   ];
 }

--- a/app/viewModelBuilders/catalog/ga2/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/ga2/viewModelBuilders.ts
@@ -67,9 +67,9 @@ export const buildOrganismImageThumbnail = (
 };
 
 /**
- * Build props for the genomes table for the given organism.
- * @param entity - Entity.
- * @returns props to be used for the table.
+ * Build table options (columns, data, initial state) for the genomes table for the given organism.
+ * @param entity - Organism entity with genomes to be displayed in the table.
+ * @returns table options.
  */
 export function buildOrganismGenomesTable(
   entity: GA2OrganismEntity

--- a/app/views/OrganismView/components/Main/main.tsx
+++ b/app/views/OrganismView/components/Main/main.tsx
@@ -1,14 +1,17 @@
 import { ALERT_PROPS } from "@databiosphere/findable-ui/lib/components/common/Alert/constants";
 import { FluidPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/components/FluidPaper/fluidPaper";
-import { DetailViewTable } from "@databiosphere/findable-ui/lib/components/Detail/components/DetailViewTable/detailViewTable";
 import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
 import { Alert } from "@mui/material";
+import { RowData } from "@tanstack/react-table";
 import { JSX } from "react";
 import WORKFLOW_CATEGORIES from "../../../../../catalog/output/workflows.json";
 import { ROUTES } from "../../../../../routes/constants";
+import { Table } from "../../../../components/common/Table/table";
 import { Accordion } from "../../../AnalyzeWorkflowsView/components/Main/components/Accordion/accordion";
 import { EmptyState } from "./components/EmptyState/emptyState";
 import { StyledSectionTitle } from "./main.styles";
+import { useTable } from "./table/hooks/UseTable/hook";
+import { StyledFluidPaper } from "./table/table.styles";
 import type { Props } from "./types";
 import { buildOrganismWorkflows } from "./utils";
 
@@ -18,14 +21,15 @@ import { buildOrganismWorkflows } from "./utils";
  * @param props - Component props.
  * @param props.entityId - Organism entity ID.
  * @param props.organism - Organism.
- * @param props.tableProps - Props for the assemblies DetailViewTable.
+ * @param props.tableOptions - Options for the assemblies table.
  * @returns A JSX element with the organism detail main content.
  */
-export const Main = ({
+export const Main = <T extends RowData>({
   entityId,
   organism,
-  tableProps,
-}: Props): JSX.Element => {
+  tableOptions,
+}: Props<T>): JSX.Element => {
+  const table = useTable<T>(tableOptions);
   const workflowCategories = buildOrganismWorkflows(
     organism,
     WORKFLOW_CATEGORIES
@@ -63,7 +67,15 @@ export const Main = ({
       <Alert component={FluidPaper} {...ALERT_PROPS.STANDARD_INFO}>
         Perform an analysis in the context of an assembly.
       </Alert>
-      <DetailViewTable {...tableProps} />
+      {table.getRowCount() === 0 ? (
+        <EmptyState>
+          No assemblies are associated with this organism in the catalog.
+        </EmptyState>
+      ) : (
+        <StyledFluidPaper elevation={0}>
+          <Table table={table} />
+        </StyledFluidPaper>
+      )}
     </>
   );
 };

--- a/app/views/OrganismView/components/Main/table/hooks/UseTable/hook.ts
+++ b/app/views/OrganismView/components/Main/table/hooks/UseTable/hook.ts
@@ -1,0 +1,25 @@
+import { ROW_POSITION } from "@databiosphere/findable-ui/lib/components/Table/features/RowPosition/constants";
+import { ROW_PREVIEW } from "@databiosphere/findable-ui/lib/components/Table/features/RowPreview/constants";
+import {
+  getCoreRowModel,
+  getSortedRowModel,
+  RowData,
+  Table,
+  TableOptions,
+  useReactTable,
+} from "@tanstack/react-table";
+
+export const useTable = <T extends RowData>(
+  tableOptions: Pick<TableOptions<T>, "columns" | "data" | "initialState">
+): Table<T> => {
+  return useReactTable({
+    _features: [ROW_POSITION, ROW_PREVIEW],
+    enableRowPosition: false,
+    enableSorting: true,
+    enableSortingInteraction: true,
+    enableSortingRemoval: false,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    ...tableOptions,
+  });
+};

--- a/app/views/OrganismView/components/Main/table/table.styles.ts
+++ b/app/views/OrganismView/components/Main/table/table.styles.ts
@@ -1,0 +1,14 @@
+import { FluidPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/components/FluidPaper/fluidPaper";
+import { PALETTE } from "@databiosphere/findable-ui/lib/styles/common/constants/palette";
+import styled from "@emotion/styled";
+
+export const StyledFluidPaper = styled(FluidPaper)`
+  display: grid;
+  flex: 1;
+  max-height: 100%;
+
+  .MuiTableContainer-root {
+    background-color: ${PALETTE.SMOKE_MAIN};
+    height: 100%;
+  }
+`;

--- a/app/views/OrganismView/components/Main/types.ts
+++ b/app/views/OrganismView/components/Main/types.ts
@@ -1,12 +1,8 @@
-import { DetailViewTable } from "@databiosphere/findable-ui/lib/components/Detail/components/DetailViewTable/detailViewTable";
-import type { ComponentProps } from "react";
+import { RowData, TableOptions } from "@tanstack/react-table";
 import type { Organism } from "../../types";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- table is generic over row data
-export type AssembliesTableProps = ComponentProps<typeof DetailViewTable<any>>;
-
-export interface Props {
+export interface Props<T extends RowData> {
   entityId: string;
   organism: Organism;
-  tableProps: AssembliesTableProps;
+  tableOptions: Pick<TableOptions<T>, "columns" | "data" | "initialState">;
 }


### PR DESCRIPTION
## Summary

Closes #1275.

Replaces `<DetailViewTable {...tableProps} />` in `OrganismView/Main` with a locally constructed table instance.

- `OrganismView/Main` is now generic over `T extends RowData` and calls a new local `useTable<T>(tableOptions)` hook (`app/views/OrganismView/components/Main/table/hooks/UseTable/hook.ts`) that wraps `useReactTable` with project-appropriate defaults (`getCoreRowModel`, `getSortedRowModel`, `enableSorting: true`, `enableRowPosition: false`, features `[ROW_POSITION, ROW_PREVIEW]`).
- The resulting table instance is rendered via a new `app/components/common/Table/table.tsx` — a slim virtualized renderer that uses findable-ui's `TableHead`, `TableBody`, `GridTable`, and `useVirtualization` primitives. `useRowDirection` (`app/components/common/Table/hooks/UseRowDirection/hook.ts`) drives responsive vertical/horizontal layout.
- `Props.tableOptions` is `Pick<TableOptions<T>, "columns" | "data" | "initialState">` — no more aggregated `DetailViewTable` props blob.
- `AssembliesTableProps = ComponentProps<typeof DetailViewTable<any>>` deleted.

### Column metadata + grid sizing

Per-column widths moved from a top-level `gridTemplateColumns` string into each column's `meta: { width: "auto" | { min, max } }`. The rendered grid template is now derived from `getColumnTrackSizing(table.getVisibleFlatColumns())` (findable-ui), matching the pattern used elsewhere in the codebase (`AssemblySelector`, `ENASequencingData`). The `ACCESSION` column keeps `meta.columnPinned: true`.

### Strain/Serotype/Isolate sort fix (side fix)

The Strain column's `accessorKey` was the raw `taxonomicLevelStrain` field, but the cell rendered `getGenomeStrainText(row)` (which prefers `strainName` when set). Sort key and displayed value disagreed → the rendered column looked unsorted. Switched these columns (BRC: strain, serotype, isolate; GA2: strain) to `accessorFn: (row) => getGenomeXxxText(row)` so the sort key matches the cell. Exported `getGenomeStrainText`, `getGenomeSerotypeText`, `getGenomeIsolateText` from the BRC viewModelBuilders to support this.

### Empty-state

When `organism.genomes` is empty, an `<EmptyState>` placeholder ("No assemblies are associated with this organism in the catalog.") renders in place of the table — replaces the prior `DetailViewTable` `noResultsTitle` behaviour.

### Note on issue scope

The issue's proposed changes listed *"Move column definitions out of `buildOrganismGenomesTableColumns` (BRC and GA2) into a location consumed by `Main`."* The column definitions physically stayed in the catalog-specific `viewModelBuilders.ts` files — moving them out would require either (a) duplicating catalog-specific cell renderers in `OrganismView`, or (b) widening the cell input type to `RowData` (losing inference inside cells). The intent of the move — eliminating the `any` alias and the aggregated `tableProps` blob — is achieved without relocating the column source code; the columns now flow through `tableOptions.columns` (typed `ColumnDef<RowData>[]` at the boundary via a single invariance cast).

## Test plan

- [x] Organism detail page (BRC + GA2): assemblies table renders, headers sortable, sort defaults to `isRef desc, accession asc`.
- [x] Click Strain column header — sort matches the displayed values (no more scrambled order).
- [x] Same check for Serotype and Isolate columns (BRC only).
- [x] Small viewport: rows collapse to vertical direction.
- [x] Empty-state: an organism with zero genomes shows the "No assemblies..." placeholder (use a hand-crafted catalog row if needed to test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1981" height="1134" alt="image" src="https://github.com/user-attachments/assets/acda2792-f265-4f5c-932a-84b16bc88bdb" />
