### PR TITLE
refactor: workflow stepper: reorder rhs — workflow, assembly, rest (#1283)

### DIFF
--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/SideColumn/sideColumn.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/SideColumn/sideColumn.tsx
@@ -22,11 +22,6 @@ export const SideColumn = ({
   return (
     <FluidPaper>
       <GridPaper>
-        <CollapsableSection title="Configuration">
-          <KeyValuePairs
-            {...buildWorkflowConfiguration(configuredInput, configuredSteps)}
-          />
-        </CollapsableSection>
         <CollapsableSection title="Workflow Details">
           <KeyValuePairs {...buildWorkflowDetails(workflow)} />
         </CollapsableSection>
@@ -35,6 +30,11 @@ export const SideColumn = ({
             <KeyValuePairs {...buildAssemblyDetails(assembly)} />
           </CollapsableSection>
         )}
+        <CollapsableSection title="Configuration">
+          <KeyValuePairs
+            {...buildWorkflowConfiguration(configuredInput, configuredSteps)}
+          />
+        </CollapsableSection>
       </GridPaper>
     </FluidPaper>
   );

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/SideColumn/sideColumn.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/SideColumn/sideColumn.tsx
@@ -22,15 +22,15 @@ export const SideColumn = ({
   return (
     <FluidPaper>
       <GridPaper>
-        <CollapsableSection title="Workflow Details">
+        <CollapsableSection key="workflow-details" title="Workflow Details">
           <KeyValuePairs {...buildWorkflowDetails(workflow)} />
         </CollapsableSection>
         {assembly && (
-          <CollapsableSection title="Assembly Details">
+          <CollapsableSection key="assembly-details" title="Assembly Details">
             <KeyValuePairs {...buildAssemblyDetails(assembly)} />
           </CollapsableSection>
         )}
-        <CollapsableSection title="Configuration">
+        <CollapsableSection key="configuration" title="Configuration">
           <KeyValuePairs
             {...buildWorkflowConfiguration(configuredInput, configuredSteps)}
           />


### PR DESCRIPTION
## Summary

- Reorders the right-hand-side panel in the workflow stepper so users see context-first content (Workflow Details, Assembly Details) before the editable Configuration section.
- New section order in `SideColumn`: **Workflow Details → Assembly Details → Configuration** (was: Configuration → Workflow Details → Assembly Details).
- Adds stable `key` props (`workflow-details`, `assembly-details`, `configuration`) to each `CollapsableSection`. Because Assembly Details is conditionally rendered between two unconditional siblings, position-based reconciliation could otherwise carry `CollapsableSection` internal expand/collapse state across sections when the conditional toggles. Keys aren't required for current behaviour (assembly is always set on this view) but make the order robust against future refactors.

Closes #1283

## Test plan
- [ ] Navigate to the workflow stepper (select a workflow + assembly, then proceed)
- [ ] Confirm RHS panel sections appear in order: Workflow Details, Assembly Details, Configuration
- [ ] Confirm each section still expands/collapses and shows the same content as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)