### PR TITLE
content: re-add NIAID BRC AI Codeathon 2.0 card to the home carousel

### DIFF
--- a/app/components/Home/components/Section/components/SectionHero/components/Carousel/cards/constants.ts
+++ b/app/components/Home/components/Section/components/SectionHero/components/Carousel/cards/constants.ts
@@ -3,6 +3,9 @@ import * as MDX from "../content";
 
 export const CAROUSEL_CARDS: Pick<CardProps, "text">[] = [
   {
+    text: MDX.AICodeathon2({}),
+  },
+  {
     text: MDX.UserSurvey({}),
   },
   {

--- a/app/components/Home/components/Section/components/SectionHero/components/Carousel/content/aiCodeathon2.mdx
+++ b/app/components/Home/components/Section/components/SectionHero/components/Carousel/content/aiCodeathon2.mdx
@@ -1,0 +1,5 @@
+### NIAID BRC AI Codeathon 2.0
+
+Join us September 16-18, 2026 at Argonne National Laboratory for a three-day, in-person codeathon advancing infectious disease research through AI, large language models, and agentic frameworks. Participation is free; applications are due June 30, 2026.
+
+[Learn more & apply](https://niaid-brc-codeathons.github.io/)

--- a/app/components/Home/components/Section/components/SectionHero/components/Carousel/content/index.tsx
+++ b/app/components/Home/components/Section/components/SectionHero/components/Carousel/content/index.tsx
@@ -1,3 +1,4 @@
+export { default as AICodeathon2 } from "./aiCodeathon2.mdx";
 export { default as EvolutionaryDynamicsOfCodingOverlapsInMeaslesVirus } from "./evolutionary-dynamics-of-coding-overlaps-in-measles-virus.mdx";
 export { default as Roadmap } from "./roadmap.mdx";
 export { default as ShareUsageAndJoinAdvisoryPanel } from "./shareUsageAndJoinAdvisoryPanel.mdx";


### PR DESCRIPTION
## What

Re-adds the NIAID BRC codeathon notice to the homepage hero carousel. We had a card for the 2025 event that was removed afterward (#1019); this restores it as the first carousel card with updated copy for the 2.0 event.

Details (from https://niaid-brc-codeathons.github.io/):

- Sept 16-18, 2026, in person at Argonne National Laboratory
- Free to attend; applications due June 30, 2026

## Changes

- New `aiCodeathon2.mdx` carousel content
- Wired the export into the carousel `content/index.tsx`
- Added it as the first entry in `CAROUSEL_CARDS`

## Screenshot

![Codeathon card](https://raw.githubusercontent.com/dannon/brc-analytics/pr-assets/codeathon-card/codeathon-card.png)
