### PR TITLE
feat: persistent user data layer (favorites, saved analyses, workflow run tracking)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,7 +5,15 @@
 coverage/*
 
 venv
+**/venv/*
+.venv
+**/.venv/*
+.pytest_cache
+.ruff_cache
 coverage
+
+# GitHub Actions CommonJS helpers (not project source)
+.github/actions/**/*.js
 
 # generated
 /catalog/schema/generated

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+  "root": true,
   "parser": "@typescript-eslint/parser",
   "ignorePatterns": [
     "next-env.d.ts",

--- a/.prettierignore
+++ b/.prettierignore
@@ -13,6 +13,8 @@ coverage
 # python
 venv
 .venv
+.pytest_cache
+.ruff_cache
 
 # releases
 /CHANGELOG.md

--- a/app/components/Assistant/ChatPanel/chatPanel.tsx
+++ b/app/components/Assistant/ChatPanel/chatPanel.tsx
@@ -7,6 +7,7 @@ import {
   Typography,
 } from "@mui/material";
 import { JSX, useEffect, useRef, useState } from "react";
+import { useAuth } from "../../../providers/authentication";
 import { SuggestionChip } from "../../../types/api";
 import { ChatMessage } from "../ChatMessage/chatMessage";
 import { SuggestionChips } from "../SuggestionChips/suggestionChips";
@@ -23,19 +24,46 @@ interface ChatPanelProps {
   loading: boolean;
   messages: ChatMessageDisplay[];
   onRetry?: () => Promise<void>;
+  onSave: () => void;
   onSend: (message: string) => void;
+  saveLabel: string | null;
+  saveLoading: boolean;
   suggestions: SuggestionChip[];
 }
 
+/**
+ * The main chat interface with message list, input, and suggestion chips.
+ * @param props - Component props
+ * @param props.error - Error message to display
+ * @param props.isRestoring - Whether a previous session is being restored
+ * @param props.loading - Whether the assistant is processing
+ * @param props.messages - Chat message history
+ * @param props.onRetry - Callback to retry the last failed request
+ * @param props.onSave - Callback to save the current chat
+ * @param props.onSend - Callback to send a message
+ * @param props.saveLabel - Save status message
+ * @param props.saveLoading - Whether a save request is in flight
+ * @param props.suggestions - Suggestion chips to display
+ * @returns Chat panel element
+ */
 export const ChatPanel = ({
   error,
   isRestoring,
   loading,
   messages,
   onRetry,
+  onSave,
   onSend,
+  saveLabel,
+  saveLoading,
   suggestions,
 }: ChatPanelProps): JSX.Element => {
+  const {
+    isAuthenticated,
+    isConfigured,
+    isLoading: isAuthLoading,
+    login,
+  } = useAuth();
   const [input, setInput] = useState("");
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
@@ -65,6 +93,21 @@ export const ChatPanel = ({
   };
 
   const inputDisabled = loading || !!isRestoring;
+
+  const handleSave = (): void => {
+    if (isConfigured && !isAuthLoading && !isAuthenticated) {
+      login();
+      return;
+    }
+    onSave();
+  };
+
+  let saveButtonLabel = "Save";
+  if (saveLoading) {
+    saveButtonLabel = "Saving...";
+  } else if (isConfigured && !isAuthenticated) {
+    saveButtonLabel = "Sign In to Save";
+  }
 
   return (
     <ChatContainer>
@@ -127,6 +170,15 @@ export const ChatPanel = ({
       />
 
       <InputRow>
+        <Button
+          disabled={
+            loading || saveLoading || messages.length === 0 || isAuthLoading
+          }
+          onClick={handleSave}
+          variant="outlined"
+        >
+          {saveButtonLabel}
+        </Button>
         <TextField
           disabled={inputDisabled}
           fullWidth
@@ -146,6 +198,13 @@ export const ChatPanel = ({
           Send
         </Button>
       </InputRow>
+      {saveLabel && (
+        <Box sx={{ pb: 2, px: 2 }}>
+          <Typography color="text.secondary" variant="body2">
+            {saveLabel}
+          </Typography>
+        </Box>
+      )}
     </ChatContainer>
   );
 };

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/hooks/UseLaunchGalaxy/useLaunchGalaxy.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/hooks/UseLaunchGalaxy/useLaunchGalaxy.ts
@@ -1,5 +1,7 @@
 import { useAsync } from "@databiosphere/findable-ui/lib/hooks/useAsync";
 import { useConfig } from "@databiosphere/findable-ui/lib/hooks/useConfig";
+import { brcAPIClient } from "app/services/brc-api-client";
+import { useRouter } from "next/router";
 import { useCallback } from "react";
 import { Workflow } from "../../../../../../../../../../../../apis/catalog/brc-analytics-catalog/common/entities";
 import {
@@ -19,7 +21,11 @@ import {
   Props,
   UseLaunchGalaxy,
 } from "./types";
-import { getConfiguredValues, launchGalaxy } from "./utils";
+import {
+  buildWorkflowRunPayload,
+  getConfiguredValues,
+  launchGalaxy,
+} from "./utils";
 
 /**
  * Gets the appropriate landing URL based on workflow type.
@@ -118,6 +124,7 @@ export const useLaunchGalaxy = ({
 }: Props): UseLaunchGalaxy => {
   const { error, isLoading: loading, run } = useAsync<string>();
   const { config } = useConfig();
+  const router = useRouter();
   const configuredValue = getConfiguredValues(configuredInput, workflow);
   const disabled = !configuredValue;
 
@@ -133,8 +140,25 @@ export const useLaunchGalaxy = ({
       throw new Error("Failed to retrieve Galaxy workflow launch URL.");
     }
 
+    try {
+      await brcAPIClient.createWorkflowRun(
+        buildWorkflowRunPayload({
+          assistantSessionId:
+            typeof router.query.assistantSessionId === "string"
+              ? router.query.assistantSessionId
+              : null,
+          configuredInput,
+          configuredValue,
+          handoffUrl: landingUrl,
+          workflow,
+        })
+      );
+    } catch (trackingError) {
+      console.warn("Failed to record workflow launch handoff", trackingError);
+    }
+
     launchGalaxy(landingUrl);
-  }, [config, configuredValue, run, workflow]);
+  }, [config, configuredInput, configuredValue, router.query, run, workflow]);
 
   let errorMessage: string | null = null;
   if (error) {

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/hooks/UseLaunchGalaxy/utils.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/hooks/UseLaunchGalaxy/utils.ts
@@ -4,6 +4,7 @@ import {
 } from "@databiosphere/findable-ui/lib/components/Links/common/entities";
 import { Workflow } from "../../../../../../../../../../../../apis/catalog/brc-analytics-catalog/common/entities";
 import { WORKFLOW_PARAMETER_VARIABLE } from "../../../../../../../../../../../../apis/catalog/brc-analytics-catalog/common/schema-entities";
+import { WorkflowRunCreateRequest } from "../../../../../../../../../../../../types/api";
 import { DIFFERENTIAL_EXPRESSION_ANALYSIS } from "../../../../../../../../../../../../views/AnalyzeWorkflowsView/differentialExpressionAnalysis/constants";
 import { ConfiguredInput } from "../../../../../../../../../../../../views/WorkflowInputsView/hooks/UseConfigureInputs/types";
 import { ConfiguredValue } from "./types";
@@ -241,4 +242,64 @@ export function launchGalaxy(url: string): void {
   document.body.appendChild(el);
   el.click();
   document.body.removeChild(el);
+}
+
+interface BuildWorkflowRunPayloadParams {
+  assistantSessionId: string | null;
+  configuredInput: ConfiguredInput;
+  configuredValue: ConfiguredValue;
+  handoffUrl: string;
+  workflow: Workflow;
+}
+
+export function buildWorkflowRunPayload({
+  assistantSessionId,
+  configuredInput,
+  configuredValue,
+  handoffUrl,
+  workflow,
+}: BuildWorkflowRunPayloadParams): WorkflowRunCreateRequest {
+  let galaxyInstanceUrl: string | null = null;
+
+  try {
+    galaxyInstanceUrl = new URL(handoffUrl).origin;
+  } catch {
+    galaxyInstanceUrl = null;
+  }
+
+  return {
+    assembly_accession: configuredValue.referenceAssembly || null,
+    assistant_session_id: assistantSessionId,
+    galaxy_instance_url: galaxyInstanceUrl,
+    handoff_url: handoffUrl,
+    launch_source: assistantSessionId ? "assistant" : "site",
+    parameters: {
+      design_formula: configuredValue.designFormula ?? null,
+      gene_model_url: configuredValue.geneModelUrl ?? null,
+      number_of_hits: configuredValue.numberOfHits ?? null,
+      primary_contrasts: configuredValue.primaryContrasts ?? null,
+      read_runs_paired:
+        configuredValue.readRunsPaired?.map(
+          ({ runAccession }) => runAccession
+        ) ?? [],
+      read_runs_single:
+        configuredValue.readRunsSingle?.map(
+          ({ runAccession }) => runAccession
+        ) ?? [],
+      sample_sheet_classification:
+        configuredValue.sampleSheetClassification ?? null,
+      sample_sheet_rows: configuredValue.sampleSheet?.length ?? 0,
+      sequence_file_name: configuredInput.sequenceFileName ?? null,
+      sequence_length: configuredValue.sequence?.length ?? null,
+      strandedness: configuredValue.strandedness ?? null,
+      tracks:
+        configuredValue.tracks?.map((track) => ({
+          group_id: track.groupId,
+          name: track.shortLabel ?? track.longLabel ?? track.bigDataUrl,
+          url: track.bigDataUrl,
+        })) ?? [],
+    },
+    workflow_id: workflow.workflowId ?? null,
+    workflow_trs_id: workflow.trsId,
+  };
 }

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/hooks/UseLaunchGalaxy/utils.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/hooks/UseLaunchGalaxy/utils.ts
@@ -7,7 +7,11 @@ import { WORKFLOW_PARAMETER_VARIABLE } from "../../../../../../../../../../../..
 import { WorkflowRunCreateRequest } from "../../../../../../../../../../../../types/api";
 import { DIFFERENTIAL_EXPRESSION_ANALYSIS } from "../../../../../../../../../../../../views/AnalyzeWorkflowsView/differentialExpressionAnalysis/constants";
 import { ConfiguredInput } from "../../../../../../../../../../../../views/WorkflowInputsView/hooks/UseConfigureInputs/types";
-import { ConfiguredValue } from "./types";
+import {
+  ConfiguredValue,
+  isAssemblyConfiguredValue,
+  isSequenceConfiguredValue,
+} from "./types";
 
 export function getRequiredParameterTypes(
   workflow: Workflow
@@ -267,17 +271,30 @@ export function buildWorkflowRunPayload({
     galaxyInstanceUrl = null;
   }
 
+  // Assembly-scope and sequence-scope variants carry distinct fields; narrow
+  // before reading so the tracking payload tolerates any scope.
+  const isAssembly = isAssemblyConfiguredValue(configuredValue);
+  const isSequence = isSequenceConfiguredValue(configuredValue);
+
   return {
-    assembly_accession: configuredValue.referenceAssembly || null,
+    assembly_accession: isAssembly ? configuredValue.referenceAssembly : null,
     assistant_session_id: assistantSessionId,
     galaxy_instance_url: galaxyInstanceUrl,
     handoff_url: handoffUrl,
     launch_source: assistantSessionId ? "assistant" : "site",
     parameters: {
-      design_formula: configuredValue.designFormula ?? null,
-      gene_model_url: configuredValue.geneModelUrl ?? null,
-      number_of_hits: configuredValue.numberOfHits ?? null,
-      primary_contrasts: configuredValue.primaryContrasts ?? null,
+      design_formula: isAssembly
+        ? (configuredValue.designFormula ?? null)
+        : null,
+      gene_model_url: isAssembly
+        ? (configuredValue.geneModelUrl ?? null)
+        : null,
+      number_of_hits: isSequence
+        ? (configuredValue.numberOfHits ?? null)
+        : null,
+      primary_contrasts: isAssembly
+        ? (configuredValue.primaryContrasts ?? null)
+        : null,
       read_runs_paired:
         configuredValue.readRunsPaired?.map(
           ({ runAccession }) => runAccession
@@ -286,12 +303,17 @@ export function buildWorkflowRunPayload({
         configuredValue.readRunsSingle?.map(
           ({ runAccession }) => runAccession
         ) ?? [],
-      sample_sheet_classification:
-        configuredValue.sampleSheetClassification ?? null,
-      sample_sheet_rows: configuredValue.sampleSheet?.length ?? 0,
+      sample_sheet_classification: isAssembly
+        ? (configuredValue.sampleSheetClassification ?? null)
+        : null,
+      sample_sheet_rows: isAssembly
+        ? (configuredValue.sampleSheet?.length ?? 0)
+        : 0,
       sequence_file_name: configuredInput.sequenceFileName ?? null,
-      sequence_length: configuredValue.sequence?.length ?? null,
-      strandedness: configuredValue.strandedness ?? null,
+      sequence_length: isSequence
+        ? (configuredValue.sequence?.length ?? null)
+        : null,
+      strandedness: isAssembly ? (configuredValue.strandedness ?? null) : null,
       tracks:
         configuredValue.tracks?.map((track) => ({
           group_id: track.groupId,

--- a/app/components/Favorites/AssemblyFavoriteButton/assemblyFavoriteButton.tsx
+++ b/app/components/Favorites/AssemblyFavoriteButton/assemblyFavoriteButton.tsx
@@ -16,7 +16,8 @@ export function AssemblyFavoriteButton({ accession }: Props): JSX.Element {
     isLoading: isAuthLoading,
     login,
   } = useAuth();
-  const { isFavorited, isLoading, toggleFavorite } = useAssemblyFavorites();
+  const { error, isFavorited, isLoading, isToggling, toggleFavorite } =
+    useAssemblyFavorites();
 
   if (!isConfigured || isAuthLoading) {
     return <CircularProgress size={20} />;
@@ -36,14 +37,27 @@ export function AssemblyFavoriteButton({ accession }: Props): JSX.Element {
     );
   }
 
-  return (
+  const favorited = isFavorited(accession);
+  const button = (
     <Button
-      disabled={isLoading}
+      disabled={isLoading || isToggling}
       onClick={() => void toggleFavorite(accession)}
-      startIcon={isFavorited(accession) ? <StarIcon /> : <StarBorderIcon />}
-      variant={isFavorited(accession) ? "contained" : "outlined"}
+      startIcon={favorited ? <StarIcon /> : <StarBorderIcon />}
+      variant={favorited ? "contained" : "outlined"}
     >
-      {isFavorited(accession) ? "Saved" : "Save Assembly"}
+      {favorited ? "Saved" : "Save Assembly"}
     </Button>
   );
+
+  // The toggle stays clickable on failure (the next click clears the error
+  // and retries); the tooltip just tells the user the last attempt failed.
+  if (error) {
+    return (
+      <Tooltip title={`Could not update favorite: ${error.message}`}>
+        <span>{button}</span>
+      </Tooltip>
+    );
+  }
+
+  return button;
 }

--- a/app/components/Favorites/AssemblyFavoriteButton/assemblyFavoriteButton.tsx
+++ b/app/components/Favorites/AssemblyFavoriteButton/assemblyFavoriteButton.tsx
@@ -1,5 +1,5 @@
-import StarBorderIcon from "@mui/icons-material/StarBorder";
 import StarIcon from "@mui/icons-material/Star";
+import StarBorderIcon from "@mui/icons-material/StarBorder";
 import { Button, CircularProgress, Tooltip } from "@mui/material";
 import { JSX } from "react";
 import { useAssemblyFavorites } from "../../../hooks/useAssemblyFavorites";

--- a/app/components/Favorites/AssemblyFavoriteButton/assemblyFavoriteButton.tsx
+++ b/app/components/Favorites/AssemblyFavoriteButton/assemblyFavoriteButton.tsx
@@ -1,0 +1,49 @@
+import StarBorderIcon from "@mui/icons-material/StarBorder";
+import StarIcon from "@mui/icons-material/Star";
+import { Button, CircularProgress, Tooltip } from "@mui/material";
+import { JSX } from "react";
+import { useAssemblyFavorites } from "../../../hooks/useAssemblyFavorites";
+import { useAuth } from "../../../providers/authentication";
+
+interface Props {
+  accession: string;
+}
+
+export function AssemblyFavoriteButton({ accession }: Props): JSX.Element {
+  const {
+    isAuthenticated,
+    isConfigured,
+    isLoading: isAuthLoading,
+    login,
+  } = useAuth();
+  const { isFavorited, isLoading, toggleFavorite } = useAssemblyFavorites();
+
+  if (!isConfigured || isAuthLoading) {
+    return <CircularProgress size={20} />;
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <Tooltip title="Sign in to save favorites">
+        <Button
+          onClick={login}
+          startIcon={<StarBorderIcon />}
+          variant="outlined"
+        >
+          Save Assembly
+        </Button>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <Button
+      disabled={isLoading}
+      onClick={() => void toggleFavorite(accession)}
+      startIcon={isFavorited(accession) ? <StarIcon /> : <StarBorderIcon />}
+      variant={isFavorited(accession) ? "contained" : "outlined"}
+    >
+      {isFavorited(accession) ? "Saved" : "Save Assembly"}
+    </Button>
+  );
+}

--- a/app/components/Layout/components/Header/components/AuthButton/authButton.tsx
+++ b/app/components/Layout/components/Header/components/AuthButton/authButton.tsx
@@ -67,6 +67,9 @@ export function AuthButton(): JSX.Element | null {
         <MenuItem onClick={() => navigateTo("/assistant/saved")}>
           Saved Analyses
         </MenuItem>
+        <MenuItem onClick={() => navigateTo("/account/workflow-runs")}>
+          Workflow Runs
+        </MenuItem>
         <MenuItem onClick={() => navigateTo("/account/preferences")}>
           Preferences
         </MenuItem>

--- a/app/components/Layout/components/Header/components/AuthButton/authButton.tsx
+++ b/app/components/Layout/components/Header/components/AuthButton/authButton.tsx
@@ -1,5 +1,6 @@
-import { Button, Typography } from "@mui/material";
-import { JSX } from "react";
+import { Button, Menu, MenuItem, Typography } from "@mui/material";
+import { useRouter } from "next/router";
+import { JSX, MouseEvent, useState } from "react";
 import { useAuth } from "../../../../../../providers/authentication";
 import { AuthButtonWrapper } from "./authButton.styles";
 
@@ -10,6 +11,8 @@ import { AuthButtonWrapper } from "./authButton.styles";
 export function AuthButton(): JSX.Element | null {
   const { isAuthenticated, isConfigured, isLoading, login, logout, user } =
     useAuth();
+  const router = useRouter();
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
 
   if (!isConfigured || isLoading) return null;
 
@@ -21,12 +24,55 @@ export function AuthButton(): JSX.Element | null {
     );
   }
 
+  const isMenuOpen = !!anchorEl;
+
+  function handleMenuOpen(event: MouseEvent<HTMLElement>): void {
+    setAnchorEl(event.currentTarget);
+  }
+
+  function handleMenuClose(): void {
+    setAnchorEl(null);
+  }
+
+  async function handleLogout(): Promise<void> {
+    handleMenuClose();
+    await logout();
+  }
+
+  async function navigateTo(path: string): Promise<void> {
+    handleMenuClose();
+    await router.push(path);
+  }
+
   return (
     <AuthButtonWrapper>
-      <Typography variant="body2">{user?.name}</Typography>
-      <Button color="primary" onClick={logout} size="small" variant="text">
-        Sign Out
+      <Button
+        color="primary"
+        onClick={handleMenuOpen}
+        size="small"
+        variant="text"
+      >
+        {user?.name}
       </Button>
+      <Menu
+        anchorEl={anchorEl}
+        anchorOrigin={{ horizontal: "right", vertical: "bottom" }}
+        onClose={handleMenuClose}
+        open={isMenuOpen}
+        transformOrigin={{ horizontal: "right", vertical: "top" }}
+      >
+        <MenuItem onClick={() => navigateTo("/data/favorites")}>
+          Favorites
+        </MenuItem>
+        <MenuItem onClick={() => navigateTo("/assistant/saved")}>
+          Saved Analyses
+        </MenuItem>
+        <MenuItem onClick={() => navigateTo("/account/preferences")}>
+          Preferences
+        </MenuItem>
+        <MenuItem onClick={handleLogout}>Sign Out</MenuItem>
+      </Menu>
+      <Typography variant="body2">{user?.email}</Typography>
     </AuthButtonWrapper>
   );
 }

--- a/app/hooks/useAssemblyFavorites.ts
+++ b/app/hooks/useAssemblyFavorites.ts
@@ -4,6 +4,7 @@ import { brcAPIClient } from "../services/brc-api-client";
 import { FavoriteResponse } from "../types/api";
 
 interface UseAssemblyFavoritesReturn {
+  error: Error | null;
   favorites: FavoriteResponse[];
   isFavorited: (entityId: string) => boolean;
   isLoading: boolean;
@@ -14,6 +15,7 @@ export function useAssemblyFavorites(): UseAssemblyFavoritesReturn {
   const { isAuthenticated, isConfigured } = useAuth();
   const [favorites, setFavorites] = useState<FavoriteResponse[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
 
   const favoriteIds = useMemo(
     () => new Set(favorites.map((favorite) => favorite.entity_id)),
@@ -23,12 +25,18 @@ export function useAssemblyFavorites(): UseAssemblyFavoritesReturn {
   const loadFavorites = useCallback(async (): Promise<void> => {
     if (!isAuthenticated || !isConfigured) {
       setFavorites([]);
+      setError(null);
       return;
     }
 
     setIsLoading(true);
+    setError(null);
     try {
       setFavorites(await brcAPIClient.getFavorites());
+    } catch (err) {
+      // Surface the failure so the page can render an error state
+      // instead of falsely showing "no favorites yet."
+      setError(err instanceof Error ? err : new Error(String(err)));
     } finally {
       setIsLoading(false);
     }
@@ -40,16 +48,24 @@ export function useAssemblyFavorites(): UseAssemblyFavoritesReturn {
 
   const toggleFavorite = useCallback(
     async (entityId: string): Promise<void> => {
-      if (!favoriteIds.has(entityId)) {
-        const favorite = await brcAPIClient.createFavorite(entityId);
-        setFavorites((current) => [favorite, ...current]);
-        return;
-      }
+      setError(null);
+      try {
+        if (!favoriteIds.has(entityId)) {
+          const favorite = await brcAPIClient.createFavorite(entityId);
+          setFavorites((current) => [favorite, ...current]);
+          return;
+        }
 
-      await brcAPIClient.deleteFavorite(entityId);
-      setFavorites((current) =>
-        current.filter((favorite) => favorite.entity_id !== entityId)
-      );
+        await brcAPIClient.deleteFavorite(entityId);
+        setFavorites((current) =>
+          current.filter((favorite) => favorite.entity_id !== entityId)
+        );
+      } catch (err) {
+        // Caller uses `void toggleFavorite(...)`; without this catch the
+        // failure becomes an unhandled promise rejection and the button
+        // state silently disagrees with the server.
+        setError(err instanceof Error ? err : new Error(String(err)));
+      }
     },
     [favoriteIds]
   );
@@ -60,6 +76,7 @@ export function useAssemblyFavorites(): UseAssemblyFavoritesReturn {
   );
 
   return {
+    error,
     favorites,
     isFavorited,
     isLoading,

--- a/app/hooks/useAssemblyFavorites.ts
+++ b/app/hooks/useAssemblyFavorites.ts
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useAuth } from "../providers/authentication";
+import { brcAPIClient } from "../services/brc-api-client";
+import { FavoriteResponse } from "../types/api";
+
+interface UseAssemblyFavoritesReturn {
+  favorites: FavoriteResponse[];
+  isFavorited: (entityId: string) => boolean;
+  isLoading: boolean;
+  toggleFavorite: (entityId: string) => Promise<void>;
+}
+
+export function useAssemblyFavorites(): UseAssemblyFavoritesReturn {
+  const { isAuthenticated, isConfigured } = useAuth();
+  const [favorites, setFavorites] = useState<FavoriteResponse[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const favoriteIds = useMemo(
+    () => new Set(favorites.map((favorite) => favorite.entity_id)),
+    [favorites]
+  );
+
+  const loadFavorites = useCallback(async (): Promise<void> => {
+    if (!isAuthenticated || !isConfigured) {
+      setFavorites([]);
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      setFavorites(await brcAPIClient.getFavorites());
+    } finally {
+      setIsLoading(false);
+    }
+  }, [isAuthenticated, isConfigured]);
+
+  useEffect(() => {
+    void loadFavorites();
+  }, [loadFavorites]);
+
+  const toggleFavorite = useCallback(
+    async (entityId: string): Promise<void> => {
+      if (!favoriteIds.has(entityId)) {
+        const favorite = await brcAPIClient.createFavorite(entityId);
+        setFavorites((current) => [favorite, ...current]);
+        return;
+      }
+
+      await brcAPIClient.deleteFavorite(entityId);
+      setFavorites((current) =>
+        current.filter((favorite) => favorite.entity_id !== entityId)
+      );
+    },
+    [favoriteIds]
+  );
+
+  const isFavorited = useCallback(
+    (entityId: string): boolean => favoriteIds.has(entityId),
+    [favoriteIds]
+  );
+
+  return {
+    favorites,
+    isFavorited,
+    isLoading,
+    toggleFavorite,
+  };
+}

--- a/app/hooks/useAssemblyFavorites.ts
+++ b/app/hooks/useAssemblyFavorites.ts
@@ -15,7 +15,10 @@ interface UseAssemblyFavoritesReturn {
 export function useAssemblyFavorites(): UseAssemblyFavoritesReturn {
   const { isAuthenticated, isConfigured } = useAuth();
   const [favorites, setFavorites] = useState<FavoriteResponse[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
+  // Default to loading so an authenticated page shows a spinner on first
+  // paint instead of briefly flashing the "no favorites yet" empty state
+  // before the initial load resolves.
+  const [isLoading, setIsLoading] = useState(true);
   const [isToggling, setIsToggling] = useState(false);
   const [error, setError] = useState<Error | null>(null);
 
@@ -28,6 +31,7 @@ export function useAssemblyFavorites(): UseAssemblyFavoritesReturn {
     if (!isAuthenticated || !isConfigured) {
       setFavorites([]);
       setError(null);
+      setIsLoading(false);
       return;
     }
 

--- a/app/hooks/useAssemblyFavorites.ts
+++ b/app/hooks/useAssemblyFavorites.ts
@@ -8,6 +8,7 @@ interface UseAssemblyFavoritesReturn {
   favorites: FavoriteResponse[];
   isFavorited: (entityId: string) => boolean;
   isLoading: boolean;
+  isToggling: boolean;
   toggleFavorite: (entityId: string) => Promise<void>;
 }
 
@@ -15,6 +16,7 @@ export function useAssemblyFavorites(): UseAssemblyFavoritesReturn {
   const { isAuthenticated, isConfigured } = useAuth();
   const [favorites, setFavorites] = useState<FavoriteResponse[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+  const [isToggling, setIsToggling] = useState(false);
   const [error, setError] = useState<Error | null>(null);
 
   const favoriteIds = useMemo(
@@ -49,6 +51,9 @@ export function useAssemblyFavorites(): UseAssemblyFavoritesReturn {
   const toggleFavorite = useCallback(
     async (entityId: string): Promise<void> => {
       setError(null);
+      // Gate re-entry so a double-click can't fire two create/delete calls
+      // off the same pre-toggle `favoriteIds` snapshot.
+      setIsToggling(true);
       try {
         if (!favoriteIds.has(entityId)) {
           const favorite = await brcAPIClient.createFavorite(entityId);
@@ -65,6 +70,8 @@ export function useAssemblyFavorites(): UseAssemblyFavoritesReturn {
         // failure becomes an unhandled promise rejection and the button
         // state silently disagrees with the server.
         setError(err instanceof Error ? err : new Error(String(err)));
+      } finally {
+        setIsToggling(false);
       }
     },
     [favoriteIds]
@@ -80,6 +87,7 @@ export function useAssemblyFavorites(): UseAssemblyFavoritesReturn {
     favorites,
     isFavorited,
     isLoading,
+    isToggling,
     toggleFavorite,
   };
 }

--- a/app/hooks/useAssistantChat.ts
+++ b/app/hooks/useAssistantChat.ts
@@ -5,7 +5,6 @@ import { brcAPIClient } from "../services/brc-api-client";
 import {
   AnalysisSchema,
   AssistantChatResponse,
-  SavedAnalysisDetail,
   SuggestionChip,
 } from "../types/api";
 
@@ -34,7 +33,6 @@ interface UseAssistantChatReturn {
 }
 
 interface UseAssistantChatOptions {
-  initialSavedAnalysisId?: string;
   initialSessionId?: string;
 }
 
@@ -43,12 +41,10 @@ interface UseAssistantChatOptions {
  * Persists session_id to localStorage and restores on mount; explicit
  * `initialSessionId` from URL params takes precedence over the stored value.
  * @param root0 - Hook options.
- * @param root0.initialSavedAnalysisId - Saved analysis to hydrate into the chat.
  * @param root0.initialSessionId - Existing assistant session to continue.
  * @returns Chat state, sendMessage, save/reset/retry functions.
  */
 export const useAssistantChat = ({
-  initialSavedAnalysisId,
   initialSessionId,
 }: UseAssistantChatOptions = {}): UseAssistantChatReturn => {
   const [messages, setMessages] = useState<ChatMessageDisplay[]>([]);
@@ -74,21 +70,23 @@ export const useAssistantChat = ({
     }
   }, [initialSessionId]);
 
-  // Restore last session from localStorage on mount, unless an explicit
-  // initialSessionId was provided (URL > localStorage).
+  // Hydrate from either an explicit initialSessionId (URL param, set by the
+  // saved-analysis restore flow) or a localStorage-stored session. URL wins.
+  // Either way we call the restore endpoint so we get computed handoff state
+  // (handoff_url, is_complete, suggestions), not just messages + schema.
   useEffect(() => {
-    if (initialSessionId) return;
-    const storedId = localStorage.getItem(SESSION_KEY);
-    if (!storedId) return;
+    const sourceId = initialSessionId ?? localStorage.getItem(SESSION_KEY);
+    if (!sourceId) return;
 
     let cancelled = false;
     setIsRestoring(true);
 
     assistantAPIClient
-      .assistantRestore(storedId)
+      .assistantRestore(sourceId)
       .then((restored) => {
         if (cancelled) return;
         sessionIdRef.current = restored.session_id;
+        localStorage.setItem(SESSION_KEY, restored.session_id);
         setMessages(restored.messages);
         setSchema(restored.schema_state);
         setSuggestions(restored.suggestions);
@@ -97,7 +95,8 @@ export const useAssistantChat = ({
       })
       .catch(() => {
         if (cancelled) return;
-        localStorage.removeItem(SESSION_KEY);
+        if (!initialSessionId) localStorage.removeItem(SESSION_KEY);
+        setError("Failed to restore the previous conversation.");
       })
       .finally(() => {
         if (!cancelled) setIsRestoring(false);
@@ -106,32 +105,7 @@ export const useAssistantChat = ({
     return (): void => {
       cancelled = true;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only restore
-  }, []);
-
-  // Hydrate the chat from a saved analysis when one is requested via URL.
-  useEffect(() => {
-    if (!initialSavedAnalysisId) return;
-
-    let isMounted = true;
-    setError(null);
-
-    brcAPIClient
-      .getSavedAnalysis(initialSavedAnalysisId)
-      .then((savedAnalysis: SavedAnalysisDetail) => {
-        if (!isMounted) return;
-        setMessages(savedAnalysis.messages);
-        setSchema(savedAnalysis.schema);
-      })
-      .catch(() => {
-        if (!isMounted) return;
-        setError("Failed to restore the saved analysis.");
-      });
-
-    return (): void => {
-      isMounted = false;
-    };
-  }, [initialSavedAnalysisId]);
+  }, [initialSessionId]);
 
   const sendMessage = useCallback(async (message: string): Promise<void> => {
     if (!message.trim() || sendingRef.current) return;

--- a/app/hooks/useAssistantChat.ts
+++ b/app/hooks/useAssistantChat.ts
@@ -1,9 +1,11 @@
 import { HTTPError } from "ky";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { assistantAPIClient } from "../services/assistant-api-client";
+import { brcAPIClient } from "../services/brc-api-client";
 import {
   AnalysisSchema,
   AssistantChatResponse,
+  SavedAnalysisDetail,
   SuggestionChip,
 } from "../types/api";
 
@@ -23,17 +25,32 @@ interface UseAssistantChatReturn {
   messages: ChatMessageDisplay[];
   onRetry?: () => Promise<void>;
   resetSession: () => void;
+  saveAnalysis: () => Promise<void>;
+  saveLoading: boolean;
+  saveMessage: string | null;
   schema: AnalysisSchema | null;
   sendMessage: (message: string) => Promise<void>;
   suggestions: SuggestionChip[];
 }
 
+interface UseAssistantChatOptions {
+  initialSavedAnalysisId?: string;
+  initialSessionId?: string;
+}
+
 /**
  * Manages assistant chat state: messages, session, schema, and suggestions.
- * Persists session_id to localStorage and restores on mount.
- * @returns Chat state, sendMessage, resetSession, and retry functions
+ * Persists session_id to localStorage and restores on mount; explicit
+ * `initialSessionId` from URL params takes precedence over the stored value.
+ * @param root0 - Hook options.
+ * @param root0.initialSavedAnalysisId - Saved analysis to hydrate into the chat.
+ * @param root0.initialSessionId - Existing assistant session to continue.
+ * @returns Chat state, sendMessage, save/reset/retry functions.
  */
-export const useAssistantChat = (): UseAssistantChatReturn => {
+export const useAssistantChat = ({
+  initialSavedAnalysisId,
+  initialSessionId,
+}: UseAssistantChatOptions = {}): UseAssistantChatReturn => {
   const [messages, setMessages] = useState<ChatMessageDisplay[]>([]);
   const [schema, setSchema] = useState<AnalysisSchema | null>(null);
   const [suggestions, setSuggestions] = useState<SuggestionChip[]>([]);
@@ -45,11 +62,22 @@ export const useAssistantChat = (): UseAssistantChatReturn => {
   const [lastFailedMessage, setLastFailedMessage] = useState<string | null>(
     null
   );
-  const sessionIdRef = useRef<string | null>(null);
+  const [saveLoading, setSaveLoading] = useState(false);
+  const [saveMessage, setSaveMessage] = useState<string | null>(null);
+  const sessionIdRef = useRef<string | null>(initialSessionId ?? null);
   const sendingRef = useRef(false);
 
-  // Restore session from localStorage on mount
+  // Sync the session ref when caller swaps initialSessionId.
   useEffect(() => {
+    if (initialSessionId !== undefined) {
+      sessionIdRef.current = initialSessionId;
+    }
+  }, [initialSessionId]);
+
+  // Restore last session from localStorage on mount, unless an explicit
+  // initialSessionId was provided (URL > localStorage).
+  useEffect(() => {
+    if (initialSessionId) return;
     const storedId = localStorage.getItem(SESSION_KEY);
     if (!storedId) return;
 
@@ -78,7 +106,32 @@ export const useAssistantChat = (): UseAssistantChatReturn => {
     return (): void => {
       cancelled = true;
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only restore
   }, []);
+
+  // Hydrate the chat from a saved analysis when one is requested via URL.
+  useEffect(() => {
+    if (!initialSavedAnalysisId) return;
+
+    let isMounted = true;
+    setError(null);
+
+    brcAPIClient
+      .getSavedAnalysis(initialSavedAnalysisId)
+      .then((savedAnalysis: SavedAnalysisDetail) => {
+        if (!isMounted) return;
+        setMessages(savedAnalysis.messages);
+        setSchema(savedAnalysis.schema);
+      })
+      .catch(() => {
+        if (!isMounted) return;
+        setError("Failed to restore the saved analysis.");
+      });
+
+    return (): void => {
+      isMounted = false;
+    };
+  }, [initialSavedAnalysisId]);
 
   const sendMessage = useCallback(async (message: string): Promise<void> => {
     if (!message.trim() || sendingRef.current) return;
@@ -87,6 +140,7 @@ export const useAssistantChat = (): UseAssistantChatReturn => {
     setLoading(true);
     setError(null);
     setLastFailedMessage(null);
+    setSaveMessage(null);
 
     // Add user message immediately for responsiveness
     setMessages((prev) => [...prev, { content: message, role: "user" }]);
@@ -144,6 +198,29 @@ export const useAssistantChat = (): UseAssistantChatReturn => {
     setHandoffUrl(null);
     setError(null);
     setLastFailedMessage(null);
+    setSaveMessage(null);
+  }, []);
+
+  const saveAnalysis = useCallback(async (): Promise<void> => {
+    if (!sessionIdRef.current) {
+      setSaveMessage("There is no active assistant session to save.");
+      return;
+    }
+
+    setSaveLoading(true);
+    setSaveMessage(null);
+    try {
+      const savedAnalysis = await brcAPIClient.saveAnalysis(
+        sessionIdRef.current
+      );
+      setSaveMessage(
+        savedAnalysis.title ? `Saved: ${savedAnalysis.title}` : "Saved."
+      );
+    } catch {
+      setSaveMessage("Failed to save this analysis.");
+    } finally {
+      setSaveLoading(false);
+    }
   }, []);
 
   return {
@@ -155,6 +232,9 @@ export const useAssistantChat = (): UseAssistantChatReturn => {
     messages,
     onRetry: lastFailedMessage ? retry : undefined,
     resetSession,
+    saveAnalysis,
+    saveLoading,
+    saveMessage,
     schema,
     sendMessage,
     suggestions,

--- a/app/services/brc-api-client.ts
+++ b/app/services/brc-api-client.ts
@@ -1,6 +1,10 @@
 import ky, { HTTPError } from "ky";
 import { API_BASE_URL } from "../config/api";
-import { UserMeResponse, UserPreferences } from "../types/api";
+import {
+  FavoriteResponse,
+  UserMeResponse,
+  UserPreferences,
+} from "../types/api";
 
 const apiClient = ky.create({
   credentials: "include",
@@ -21,6 +25,28 @@ const apiClient = ky.create({
 });
 
 export const brcAPIClient = {
+  createFavorite: async (
+    entity_id: string,
+    entity_type = "assembly"
+  ): Promise<FavoriteResponse> => {
+    return apiClient
+      .post("favorites", { json: { entity_id, entity_type } })
+      .json();
+  },
+
+  deleteFavorite: async (
+    entity_id: string,
+    entity_type = "assembly"
+  ): Promise<void> => {
+    await apiClient.delete(`favorites/${entity_type}/${entity_id}`);
+  },
+
+  getFavorites: async (
+    entity_type = "assembly"
+  ): Promise<FavoriteResponse[]> => {
+    return apiClient.get("favorites", { searchParams: { entity_type } }).json();
+  },
+
   getPreferences: async (): Promise<UserPreferences> => {
     return apiClient.get("user/preferences").json();
   },

--- a/app/services/brc-api-client.ts
+++ b/app/services/brc-api-client.ts
@@ -7,6 +7,8 @@ import {
   SavedAnalysisSummary,
   UserMeResponse,
   UserPreferences,
+  WorkflowRunCreateRequest,
+  WorkflowRunResponse,
 } from "../types/api";
 
 const apiClient = ky.create({
@@ -35,6 +37,12 @@ export const brcAPIClient = {
     return apiClient
       .post("favorites", { json: { entity_id, entity_type } })
       .json();
+  },
+
+  createWorkflowRun: async (
+    payload: WorkflowRunCreateRequest
+  ): Promise<WorkflowRunResponse> => {
+    return apiClient.post("workflow_runs", { json: payload }).json();
   },
 
   deleteFavorite: async (
@@ -68,6 +76,10 @@ export const brcAPIClient = {
 
   getUser: async (): Promise<UserMeResponse> => {
     return apiClient.get("user/me").json();
+  },
+
+  getWorkflowRuns: async (): Promise<WorkflowRunResponse[]> => {
+    return apiClient.get("workflow_runs").json();
   },
 
   restoreSavedAnalysis: async (

--- a/app/services/brc-api-client.ts
+++ b/app/services/brc-api-client.ts
@@ -2,6 +2,9 @@ import ky, { HTTPError } from "ky";
 import { API_BASE_URL } from "../config/api";
 import {
   FavoriteResponse,
+  SavedAnalysisDetail,
+  SavedAnalysisRestoreResponse,
+  SavedAnalysisSummary,
   UserMeResponse,
   UserPreferences,
 } from "../types/api";
@@ -41,6 +44,10 @@ export const brcAPIClient = {
     await apiClient.delete(`favorites/${entity_type}/${entity_id}`);
   },
 
+  deleteSavedAnalysis: async (id: string): Promise<void> => {
+    await apiClient.delete(`saved_analyses/${id}`);
+  },
+
   getFavorites: async (
     entity_type = "assembly"
   ): Promise<FavoriteResponse[]> => {
@@ -51,8 +58,31 @@ export const brcAPIClient = {
     return apiClient.get("user/preferences").json();
   },
 
+  getSavedAnalyses: async (): Promise<SavedAnalysisSummary[]> => {
+    return apiClient.get("saved_analyses").json();
+  },
+
+  getSavedAnalysis: async (id: string): Promise<SavedAnalysisDetail> => {
+    return apiClient.get(`saved_analyses/${id}`).json();
+  },
+
   getUser: async (): Promise<UserMeResponse> => {
     return apiClient.get("user/me").json();
+  },
+
+  restoreSavedAnalysis: async (
+    id: string
+  ): Promise<SavedAnalysisRestoreResponse> => {
+    return apiClient.post(`saved_analyses/${id}/restore`).json();
+  },
+
+  saveAnalysis: async (
+    session_id: string,
+    title?: string
+  ): Promise<SavedAnalysisSummary> => {
+    return apiClient
+      .post("saved_analyses", { json: { session_id, title } })
+      .json();
   },
 
   updatePreferences: async (

--- a/app/services/brc-api-client.ts
+++ b/app/services/brc-api-client.ts
@@ -1,0 +1,37 @@
+import ky, { HTTPError } from "ky";
+import { API_BASE_URL } from "../config/api";
+import { UserMeResponse, UserPreferences } from "../types/api";
+
+const apiClient = ky.create({
+  credentials: "include",
+  hooks: {
+    beforeError: [
+      (error): HTTPError => {
+        const { response } = error;
+        if (response && response.body) {
+          error.name = "APIError";
+          error.message = `${response.status}: ${response.statusText}`;
+        }
+        return error;
+      },
+    ],
+  },
+  prefixUrl: API_BASE_URL,
+  timeout: 30000,
+});
+
+export const brcAPIClient = {
+  getPreferences: async (): Promise<UserPreferences> => {
+    return apiClient.get("user/preferences").json();
+  },
+
+  getUser: async (): Promise<UserMeResponse> => {
+    return apiClient.get("user/me").json();
+  },
+
+  updatePreferences: async (
+    preferences: UserPreferences
+  ): Promise<UserPreferences> => {
+    return apiClient.put("user/preferences", { json: preferences }).json();
+  },
+};

--- a/app/types/api.ts
+++ b/app/types/api.ts
@@ -60,3 +60,19 @@ export interface AssistantInfoResponse {
   model: string | null;
   provider: string | null;
 }
+
+export interface UserPreferences {
+  [key: string]: unknown;
+}
+
+export interface UserMeResponse {
+  email: string | null;
+  email_verified: boolean | null;
+  family_name: string | null;
+  given_name: string | null;
+  name: string | null;
+  preferences: UserPreferences;
+  preferred_username: string | null;
+  realm_roles: string[];
+  sub: string;
+}

--- a/app/types/api.ts
+++ b/app/types/api.ts
@@ -102,3 +102,31 @@ export interface SavedAnalysisDetail extends SavedAnalysisSummary {
 export interface SavedAnalysisRestoreResponse {
   session_id: string;
 }
+
+export interface WorkflowRunCreateRequest {
+  assembly_accession?: string | null;
+  assistant_session_id?: string | null;
+  galaxy_instance_url?: string | null;
+  handoff_url: string;
+  launch_source: string;
+  parameters?: Record<string, unknown>;
+  workflow_id?: string | null;
+  workflow_trs_id: string;
+}
+
+export interface WorkflowRunResponse {
+  assembly_accession: string | null;
+  assistant_session_id: string | null;
+  completed_at: string | null;
+  created_at: string;
+  galaxy_instance_url: string | null;
+  galaxy_invocation_id: string | null;
+  handoff_url: string;
+  id: string;
+  launch_source: string;
+  parameters: Record<string, unknown>;
+  status: string;
+  updated_at: string;
+  workflow_id: string | null;
+  workflow_trs_id: string;
+}

--- a/app/types/api.ts
+++ b/app/types/api.ts
@@ -76,3 +76,9 @@ export interface UserMeResponse {
   realm_roles: string[];
   sub: string;
 }
+
+export interface FavoriteResponse {
+  created_at: string;
+  entity_id: string;
+  entity_type: string;
+}

--- a/app/types/api.ts
+++ b/app/types/api.ts
@@ -82,3 +82,23 @@ export interface FavoriteResponse {
   entity_id: string;
   entity_type: string;
 }
+
+export interface SavedAnalysisSummary {
+  created_at: string;
+  id: string;
+  source_session: string | null;
+  title: string | null;
+  updated_at: string;
+}
+
+export interface SavedAnalysisDetail extends SavedAnalysisSummary {
+  messages: Array<{
+    content: string;
+    role: "user" | "assistant";
+  }>;
+  schema: AnalysisSchema;
+}
+
+export interface SavedAnalysisRestoreResponse {
+  session_id: string;
+}

--- a/app/views/AssistantView/assistantView.tsx
+++ b/app/views/AssistantView/assistantView.tsx
@@ -18,14 +18,10 @@ import {
 import { Headline } from "./components/Headline/headline";
 
 interface Props {
-  initialSavedAnalysisId?: string;
   initialSessionId?: string;
 }
 
-export const AssistantView = ({
-  initialSavedAnalysisId,
-  initialSessionId,
-}: Props): JSX.Element => {
+export const AssistantView = ({ initialSessionId }: Props): JSX.Element => {
   const isAssistantEnabled = useFeatureFlag("assistant");
   const {
     error,
@@ -42,7 +38,6 @@ export const AssistantView = ({
     sendMessage,
     suggestions,
   } = useAssistantChat({
-    initialSavedAnalysisId,
     initialSessionId,
   });
   const [info, setInfo] = useState<AssistantInfoResponse | null>(null);

--- a/app/views/AssistantView/assistantView.tsx
+++ b/app/views/AssistantView/assistantView.tsx
@@ -17,7 +17,15 @@ import {
 } from "./assistantView.styles";
 import { Headline } from "./components/Headline/headline";
 
-export const AssistantView = (): JSX.Element => {
+interface Props {
+  initialSavedAnalysisId?: string;
+  initialSessionId?: string;
+}
+
+export const AssistantView = ({
+  initialSavedAnalysisId,
+  initialSessionId,
+}: Props): JSX.Element => {
   const isAssistantEnabled = useFeatureFlag("assistant");
   const {
     error,
@@ -27,10 +35,16 @@ export const AssistantView = (): JSX.Element => {
     messages,
     onRetry,
     resetSession,
+    saveAnalysis,
+    saveLoading,
+    saveMessage,
     schema,
     sendMessage,
     suggestions,
-  } = useAssistantChat();
+  } = useAssistantChat({
+    initialSavedAnalysisId,
+    initialSessionId,
+  });
   const [info, setInfo] = useState<AssistantInfoResponse | null>(null);
 
   useEffect(() => {
@@ -75,7 +89,10 @@ export const AssistantView = (): JSX.Element => {
               loading={loading}
               messages={messages}
               onRetry={onRetry}
+              onSave={saveAnalysis}
               onSend={sendMessage}
+              saveLabel={saveMessage}
+              saveLoading={saveLoading}
               suggestions={suggestions}
             />
           </ChatColumn>

--- a/app/views/EntityView/assembly/components/Side/brc/side.tsx
+++ b/app/views/EntityView/assembly/components/Side/brc/side.tsx
@@ -1,5 +1,5 @@
-import { Box } from "@mui/material";
 import { BackPageContentSideColumn } from "@databiosphere/findable-ui/lib/components/Layout/components/BackPage/backPageView.styles";
+import { Box } from "@mui/material";
 import { JSX } from "react";
 import { AnalysisPortals } from "../../../../../../components/Entity/components/AnalysisPortals/analysisPortals";
 import { AssemblyFavoriteButton } from "../../../../../../components/Favorites/AssemblyFavoriteButton/assemblyFavoriteButton";

--- a/app/views/EntityView/assembly/components/Side/brc/side.tsx
+++ b/app/views/EntityView/assembly/components/Side/brc/side.tsx
@@ -1,6 +1,8 @@
+import { Box } from "@mui/material";
 import { BackPageContentSideColumn } from "@databiosphere/findable-ui/lib/components/Layout/components/BackPage/backPageView.styles";
 import { JSX } from "react";
 import { AnalysisPortals } from "../../../../../../components/Entity/components/AnalysisPortals/analysisPortals";
+import { AssemblyFavoriteButton } from "../../../../../../components/Favorites/AssemblyFavoriteButton/assemblyFavoriteButton";
 import {
   buildAssemblyDetails,
   buildAssemblyResources,
@@ -19,6 +21,9 @@ export const Side = ({ assembly }: Props): JSX.Element => {
   return (
     <BackPageContentSideColumn>
       <StyledFluidPaper>
+        <Box sx={{ p: 2 }}>
+          <AssemblyFavoriteButton accession={assembly.accession} />
+        </Box>
         <KeyValueSection
           {...buildAssemblyDetails(assembly)}
           title="Assembly Details"

--- a/app/views/EntityView/assembly/components/Side/ga2/side.tsx
+++ b/app/views/EntityView/assembly/components/Side/ga2/side.tsx
@@ -1,5 +1,5 @@
-import { Box } from "@mui/material";
 import { BackPageContentSideColumn } from "@databiosphere/findable-ui/lib/components/Layout/components/BackPage/backPageView.styles";
+import { Box } from "@mui/material";
 import { JSX } from "react";
 import { AnalysisPortals } from "../../../../../../components/Entity/components/AnalysisPortals/analysisPortals";
 import { AssemblyFavoriteButton } from "../../../../../../components/Favorites/AssemblyFavoriteButton/assemblyFavoriteButton";

--- a/app/views/EntityView/assembly/components/Side/ga2/side.tsx
+++ b/app/views/EntityView/assembly/components/Side/ga2/side.tsx
@@ -1,6 +1,8 @@
+import { Box } from "@mui/material";
 import { BackPageContentSideColumn } from "@databiosphere/findable-ui/lib/components/Layout/components/BackPage/backPageView.styles";
 import { JSX } from "react";
 import { AnalysisPortals } from "../../../../../../components/Entity/components/AnalysisPortals/analysisPortals";
+import { AssemblyFavoriteButton } from "../../../../../../components/Favorites/AssemblyFavoriteButton/assemblyFavoriteButton";
 import { buildAssemblyResources } from "../../../../../../viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders";
 import { AssemblyDetails } from "../../../../assembly/components/Side/ga2/components/AssemblyDetails/AssemblyDetails";
 import { StyledFluidPaper } from "../side.styles";
@@ -16,6 +18,9 @@ export const Side = ({ assembly }: Props): JSX.Element => {
   return (
     <BackPageContentSideColumn>
       <StyledFluidPaper>
+        <Box sx={{ p: 2 }}>
+          <AssemblyFavoriteButton accession={assembly.accession} />
+        </Box>
         <AssemblyDetails assembly={assembly} />
         <AnalysisPortals
           {...buildAssemblyResources(assembly)}

--- a/backend/api/.env.example
+++ b/backend/api/.env.example
@@ -15,19 +15,26 @@ REDIS_URL=redis://redis:6379/0
 # Example: Single model (Anthropic Claude)
 AI_API_KEY=your-api-key-here
 AI_API_BASE_URL=https://api.anthropic.com
-AI_PRIMARY_MODEL=claude-3-5-sonnet-20241022
+AI_PRIMARY_MODEL=claude-sonnet-4-6
 
 # Example: Dual model approach (uncomment to use)
 # AI_API_KEY=your-api-key-here
 # AI_API_BASE_URL=https://api.anthropic.com
-# AI_PRIMARY_MODEL=claude-3-5-sonnet-20241022   # Expensive, smart
+# AI_PRIMARY_MODEL=claude-sonnet-4-6            # Expensive, smart
 # AI_SECONDARY_MODEL=claude-haiku-4-5-20251001  # Cheap, fast
 
 # Alternative: Use OPENAI_API_KEY (will be used as fallback if AI_API_KEY not set)
 # OPENAI_API_KEY=sk-your-openai-key-here
 
-# Database Configuration (for future use)
-DATABASE_URL=postgresql://user:pass@localhost/dbname
+# Database Configuration -- required for persistent user data
+# (favorites, saved analyses, workflow runs). Anonymous / non-persistent
+# flows don't touch the DB.
+DATABASE_URL=postgresql+asyncpg://user:pass@localhost/dbname
+
+# Run alembic migrations on app startup. Off by default so prod deploys
+# retain explicit migration control. Enable for local/dev/CI where a
+# one-shot upgrade-on-boot is convenient.
+RUN_MIGRATIONS_ON_STARTUP=false
 
 # External API Configuration
 ENA_API_BASE=https://www.ebi.ac.uk/ena/portal/api

--- a/backend/api/alembic.ini
+++ b/backend/api/alembic.ini
@@ -1,0 +1,36 @@
+[alembic]
+script_location = app/db/migrations
+prepend_sys_path = .
+sqlalchemy.url =
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers = console
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/backend/api/app/api/v1/assistant.py
+++ b/backend/api/app/api/v1/assistant.py
@@ -86,6 +86,11 @@ async def assistant_chat(
     except AssistantTimeoutError as e:
         logger.exception("Assistant chat timed out")
         raise HTTPException(status_code=504, detail=str(e)) from e
+    except PermissionError as e:
+        raise HTTPException(
+            status_code=403,
+            detail="Assistant session belongs to another user",
+        ) from e
     except RuntimeError as e:
         logger.exception("Assistant chat unavailable (RuntimeError)")
         raise HTTPException(status_code=503, detail=str(e)) from e

--- a/backend/api/app/api/v1/assistant.py
+++ b/backend/api/app/api/v1/assistant.py
@@ -57,12 +57,17 @@ async def assistant_chat(
             detail="Analysis assistant is unavailable (LLM not configured)",
         )
 
-    # If an authenticated user is continuing a session that started
-    # anonymously, claim it on their behalf. The signed session cookie
-    # proves the same browser holds the session, so this can't be used
-    # to hijack another user's anonymous session.
-    if current_user and request.session_id:
+    # Continuing an existing session requires proof the same browser holds
+    # it -- possession of the signed session cookie. Session IDs travel in
+    # URLs (e.g. the assistantSessionId handoff param), so knowing the id
+    # alone must not let a caller continue or mutate a session, anonymous or
+    # owned. No-ops in local/dev where SESSION_COOKIE_SECRET is unset.
+    if request.session_id:
         require_session_cookie(request.session_id, session_cookie)
+
+    # If an authenticated user is continuing a session that started
+    # anonymously, claim it on their behalf.
+    if current_user and request.session_id:
         try:
             await agent.session_service.claim_session(
                 request.session_id, current_user.sub

--- a/backend/api/app/api/v1/assistant.py
+++ b/backend/api/app/api/v1/assistant.py
@@ -4,7 +4,11 @@ from typing import Optional
 from fastapi import APIRouter, Cookie, Depends, HTTPException, Response
 
 from app.core.config import DEV_ENVIRONMENTS, SESSION_COOKIE_NAME, get_settings
-from app.core.dependencies import check_rate_limit, get_assistant_agent
+from app.core.dependencies import (
+    check_rate_limit,
+    get_assistant_agent,
+    get_optional_current_user,
+)
 from app.core.session_signing import sign_session_id, verify_session_id
 from app.models.assistant import (
     AssistantInfoResponse,
@@ -12,6 +16,7 @@ from app.models.assistant import (
     ChatResponse,
     SessionRestoreResponse,
 )
+from app.models.user_data import UserMeResponse
 from app.services.assistant_agent import AssistantTimeoutError
 
 logger = logging.getLogger(__name__)
@@ -71,6 +76,7 @@ async def assistant_chat(
     response: Response,
     agent=Depends(get_assistant_agent),
     _rate_limit=Depends(check_rate_limit),
+    current_user: UserMeResponse | None = Depends(get_optional_current_user),
 ):
     """Send a message to the analysis assistant and get a reply.
 
@@ -84,7 +90,11 @@ async def assistant_chat(
         )
 
     try:
-        chat_response = await agent.chat(request.message, request.session_id)
+        chat_response = await agent.chat(
+            request.message,
+            request.session_id,
+            current_user.sub if current_user else None,
+        )
     except AssistantTimeoutError as e:
         logger.exception("Assistant chat timed out")
         raise HTTPException(status_code=504, detail=str(e)) from e

--- a/backend/api/app/api/v1/assistant.py
+++ b/backend/api/app/api/v1/assistant.py
@@ -125,7 +125,9 @@ async def restore_session(
     if state is None:
         raise HTTPException(status_code=404, detail="Session not found or expired")
 
-    is_complete, handoff_url = agent.compute_handoff(state.schema_state)
+    is_complete, handoff_url = agent.compute_handoff(
+        state.schema_state, session_id=state.session_id
+    )
     return SessionRestoreResponse(
         session_id=state.session_id,
         messages=state.messages,

--- a/backend/api/app/api/v1/assistant.py
+++ b/backend/api/app/api/v1/assistant.py
@@ -3,13 +3,13 @@ from typing import Optional
 
 from fastapi import APIRouter, Cookie, Depends, HTTPException, Response
 
-from app.core.config import DEV_ENVIRONMENTS, SESSION_COOKIE_NAME, get_settings
+from app.core.config import SESSION_COOKIE_NAME
 from app.core.dependencies import (
     check_rate_limit,
     get_assistant_agent,
     get_optional_current_user,
 )
-from app.core.session_signing import sign_session_id, verify_session_id
+from app.core.session_signing import require_session_cookie, set_session_cookie
 from app.models.assistant import (
     AssistantInfoResponse,
     ChatRequest,
@@ -22,39 +22,6 @@ from app.services.assistant_agent import AssistantTimeoutError
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
-
-
-def _verify_session_cookie(session_id: str, cookie_value: Optional[str]) -> None:
-    """Raise 403 unless the cookie's HMAC matches session_id.
-
-    If no SESSION_COOKIE_SECRET is configured (legacy/local-dev mode), all
-    requests are allowed -- the binding is opt-in via env var.
-    """
-    settings = get_settings()
-    if not settings.SESSION_COOKIE_SECRET:
-        return
-    if not verify_session_id(
-        session_id, cookie_value or "", settings.SESSION_COOKIE_SECRET
-    ):
-        raise HTTPException(status_code=403, detail="Invalid session cookie")
-
-
-def _set_session_cookie(response: Response, session_id: str) -> None:
-    """Issue an httpOnly Same-Site=Strict cookie binding the session to this client."""
-    settings = get_settings()
-    if not settings.SESSION_COOKIE_SECRET:
-        return
-    # Only allow plain-HTTP cookies in DEV_ENVIRONMENTS. Anywhere else
-    # (staging, prod, anything that could ever see a non-TLS hop) must
-    # mark the cookie Secure so the browser refuses to send it over HTTP.
-    response.set_cookie(
-        key=SESSION_COOKIE_NAME,
-        value=sign_session_id(session_id, settings.SESSION_COOKIE_SECRET),
-        max_age=settings.SESSION_COOKIE_TTL,
-        httponly=True,
-        samesite="strict",
-        secure=settings.ENVIRONMENT.lower() not in DEV_ENVIRONMENTS,
-    )
 
 
 @router.get("/info", response_model=AssistantInfoResponse)
@@ -77,6 +44,7 @@ async def assistant_chat(
     agent=Depends(get_assistant_agent),
     _rate_limit=Depends(check_rate_limit),
     current_user: UserMeResponse | None = Depends(get_optional_current_user),
+    session_cookie: Optional[str] = Cookie(default=None, alias=SESSION_COOKIE_NAME),
 ):
     """Send a message to the analysis assistant and get a reply.
 
@@ -88,6 +56,26 @@ async def assistant_chat(
             status_code=503,
             detail="Analysis assistant is unavailable (LLM not configured)",
         )
+
+    # If an authenticated user is continuing a session that started
+    # anonymously, claim it on their behalf. The signed session cookie
+    # proves the same browser holds the session, so this can't be used
+    # to hijack another user's anonymous session.
+    if current_user and request.session_id:
+        require_session_cookie(request.session_id, session_cookie)
+        try:
+            await agent.session_service.claim_session(
+                request.session_id, current_user.sub
+            )
+        except KeyError:
+            # Session expired between cookie issuance and now -- agent.chat()
+            # will create a fresh one for this user below.
+            pass
+        except PermissionError as e:
+            raise HTTPException(
+                status_code=403,
+                detail="Assistant session belongs to another user",
+            ) from e
 
     try:
         chat_response = await agent.chat(
@@ -105,7 +93,7 @@ async def assistant_chat(
         logger.exception("Assistant chat error")
         raise HTTPException(status_code=500, detail="Internal assistant error") from e
 
-    _set_session_cookie(response, chat_response.session_id)
+    set_session_cookie(response, chat_response.session_id)
     return chat_response
 
 
@@ -116,7 +104,7 @@ async def restore_session(
     agent=Depends(get_assistant_agent),
 ):
     """Restore a previous assistant session (messages, schema, suggestions)."""
-    _verify_session_cookie(session_id, session_cookie)
+    require_session_cookie(session_id, session_cookie)
     try:
         state = await agent.session_service.get_session(session_id)
     except Exception as e:
@@ -145,7 +133,7 @@ async def delete_session(
     agent=Depends(get_assistant_agent),
 ):
     """Delete an assistant session."""
-    _verify_session_cookie(session_id, session_cookie)
+    require_session_cookie(session_id, session_cookie)
     try:
         await agent.session_service.delete_session(session_id)
     except Exception:

--- a/backend/api/app/api/v1/auth.py
+++ b/backend/api/app/api/v1/auth.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Cookie, Depends, Response
 from fastapi.responses import JSONResponse, RedirectResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.config import get_settings
+from app.core.config import SESSION_COOKIE_NAME, get_settings
 from app.core.dependencies import get_auth_service
 from app.db.crud import upsert_user_from_claims
 from app.db.session import get_db_session
@@ -137,10 +137,16 @@ async def logout(
     brc_session: str | None = Cookie(default=None, alias=COOKIE_NAME),
     auth: AuthService = Depends(get_auth_service),
 ) -> JSONResponse:
-    """Clear the user's session from Redis and remove the cookie."""
+    """Clear the user's session from Redis and remove the auth cookie.
+
+    Also clears the assistant session cookie so a shared browser doesn't
+    leave the prior user's assistant session reachable after logout (the
+    restore/delete endpoints gate purely on possession of that cookie).
+    """
     if brc_session:
         await auth.revoke_session_tokens(brc_session)
 
     resp = JSONResponse(content={"message": "Logged out"})
     resp.delete_cookie(COOKIE_NAME, path="/")
+    resp.delete_cookie(SESSION_COOKIE_NAME, path="/")
     return resp

--- a/backend/api/app/api/v1/auth.py
+++ b/backend/api/app/api/v1/auth.py
@@ -2,9 +2,12 @@ import logging
 
 from fastapi import APIRouter, Cookie, Depends, Response
 from fastapi.responses import JSONResponse, RedirectResponse
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import get_settings
 from app.core.dependencies import get_auth_service
+from app.db.crud import upsert_user_from_claims
+from app.db.session import get_db_session
 from app.services.auth_service import COOKIE_NAME, AuthService
 
 logger = logging.getLogger(__name__)
@@ -33,6 +36,7 @@ async def callback(
     error: str = "",
     error_description: str = "",
     auth: AuthService = Depends(get_auth_service),
+    db_session: AsyncSession = Depends(get_db_session),
 ) -> Response:
     """Handle the OIDC callback from Keycloak.
 
@@ -68,6 +72,18 @@ async def callback(
         return JSONResponse(
             status_code=500,
             content={"error": "Token exchange failed"},
+        )
+
+    try:
+        claims = auth.decode_token_claims(
+            token_response.get("id_token") or token_response["access_token"]
+        )
+        await upsert_user_from_claims(db_session, claims)
+    except ValueError as e:
+        logger.error("User provisioning failed: %s", e)
+        return JSONResponse(
+            status_code=500,
+            content={"error": "User provisioning failed"},
         )
 
     session_id = await auth.create_session(token_response)

--- a/backend/api/app/api/v1/favorites.py
+++ b/backend/api/app/api/v1/favorites.py
@@ -1,0 +1,51 @@
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.dependencies import get_current_user_db
+from app.db.crud import delete_favorite, list_favorites_for_user, upsert_favorite
+from app.db.models import User
+from app.db.session import get_db_session
+from app.models.user_data import FavoritePayload, FavoriteResponse
+
+router = APIRouter()
+
+
+@router.get("", response_model=list[FavoriteResponse])
+async def get_favorites(
+    entity_type: str = Query(default="assembly"),
+    current_user_db: User = Depends(get_current_user_db),
+    session: AsyncSession = Depends(get_db_session),
+) -> list[FavoriteResponse]:
+    favorites = await list_favorites_for_user(session, current_user_db)
+    return [
+        FavoriteResponse.model_validate(favorite, from_attributes=True)
+        for favorite in favorites
+        if favorite.entity_type == entity_type
+    ]
+
+
+@router.post("", response_model=FavoriteResponse)
+async def create_favorite(
+    payload: FavoritePayload,
+    current_user_db: User = Depends(get_current_user_db),
+    session: AsyncSession = Depends(get_db_session),
+) -> FavoriteResponse:
+    favorite = await upsert_favorite(
+        session,
+        current_user_db,
+        payload.entity_type,
+        payload.entity_id,
+    )
+    return FavoriteResponse.model_validate(favorite, from_attributes=True)
+
+
+@router.delete("/{entity_type}/{entity_id}", status_code=204)
+async def remove_favorite(
+    entity_type: str,
+    entity_id: str,
+    current_user_db: User = Depends(get_current_user_db),
+    session: AsyncSession = Depends(get_db_session),
+) -> None:
+    deleted = await delete_favorite(session, current_user_db, entity_type, entity_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Favorite not found")

--- a/backend/api/app/api/v1/favorites.py
+++ b/backend/api/app/api/v1/favorites.py
@@ -16,11 +16,12 @@ async def get_favorites(
     current_user_db: User = Depends(get_current_user_db),
     session: AsyncSession = Depends(get_db_session),
 ) -> list[FavoriteResponse]:
-    favorites = await list_favorites_for_user(session, current_user_db)
+    favorites = await list_favorites_for_user(
+        session, current_user_db, entity_type=entity_type
+    )
     return [
         FavoriteResponse.model_validate(favorite, from_attributes=True)
         for favorite in favorites
-        if favorite.entity_type == entity_type
     ]
 
 

--- a/backend/api/app/api/v1/saved_analyses.py
+++ b/backend/api/app/api/v1/saved_analyses.py
@@ -1,7 +1,11 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.dependencies import get_assistant_agent, get_current_user, get_current_user_db
+from app.core.dependencies import (
+    get_assistant_agent,
+    get_current_user,
+    get_current_user_db,
+)
 from app.db.crud import (
     create_saved_analysis,
     delete_saved_analysis,
@@ -23,7 +27,9 @@ router = APIRouter()
 
 
 def _build_default_title(messages: list[ChatMessage]) -> str:
-    first_user_message = next((message for message in messages if message.role == "user"), None)
+    first_user_message = next(
+        (message for message in messages if message.role == "user"), None
+    )
     if first_user_message is None:
         return "Saved analysis"
     return first_user_message.content[:80]
@@ -54,9 +60,13 @@ async def save_analysis_snapshot(
             payload.session_id, current_user.sub
         )
     except KeyError as err:
-        raise HTTPException(status_code=404, detail="Assistant session not found") from err
+        raise HTTPException(
+            status_code=404, detail="Assistant session not found"
+        ) from err
     except PermissionError as err:
-        raise HTTPException(status_code=403, detail="Assistant session does not belong to this user") from err
+        raise HTTPException(
+            status_code=403, detail="Assistant session does not belong to this user"
+        ) from err
 
     saved_analysis = await create_saved_analysis(
         session,
@@ -75,14 +85,18 @@ async def get_saved_analysis_detail(
     current_user_db: User = Depends(get_current_user_db),
     session: AsyncSession = Depends(get_db_session),
 ) -> SavedAnalysisDetail:
-    saved_analysis = await get_saved_analysis(session, current_user_db, saved_analysis_id)
+    saved_analysis = await get_saved_analysis(
+        session, current_user_db, saved_analysis_id
+    )
     if saved_analysis is None:
         raise HTTPException(status_code=404, detail="Saved analysis not found")
 
     return SavedAnalysisDetail(
         created_at=saved_analysis.created_at,
         id=str(saved_analysis.id),
-        messages=[ChatMessage.model_validate(message) for message in saved_analysis.messages],
+        messages=[
+            ChatMessage.model_validate(message) for message in saved_analysis.messages
+        ],
         schema=AnalysisSchema.model_validate(saved_analysis.schema),
         source_session=saved_analysis.source_session,
         title=saved_analysis.title,
@@ -90,7 +104,9 @@ async def get_saved_analysis_detail(
     )
 
 
-@router.post("/{saved_analysis_id}/restore", response_model=SavedAnalysisRestoreResponse)
+@router.post(
+    "/{saved_analysis_id}/restore", response_model=SavedAnalysisRestoreResponse
+)
 async def restore_saved_analysis(
     saved_analysis_id: str,
     current_user: UserMeResponse = Depends(get_current_user),
@@ -98,14 +114,18 @@ async def restore_saved_analysis(
     agent=Depends(get_assistant_agent),
     session: AsyncSession = Depends(get_db_session),
 ) -> SavedAnalysisRestoreResponse:
-    saved_analysis = await get_saved_analysis(session, current_user_db, saved_analysis_id)
+    saved_analysis = await get_saved_analysis(
+        session, current_user_db, saved_analysis_id
+    )
     if saved_analysis is None:
         raise HTTPException(status_code=404, detail="Saved analysis not found")
 
     restored_state = await agent.restore_saved_session(
         owner_keycloak_sub=current_user.sub,
         schema_state=AnalysisSchema.model_validate(saved_analysis.schema),
-        messages=[ChatMessage.model_validate(message) for message in saved_analysis.messages],
+        messages=[
+            ChatMessage.model_validate(message) for message in saved_analysis.messages
+        ],
     )
     return SavedAnalysisRestoreResponse(session_id=restored_state.session_id)
 

--- a/backend/api/app/api/v1/saved_analyses.py
+++ b/backend/api/app/api/v1/saved_analyses.py
@@ -1,7 +1,11 @@
-from fastapi import APIRouter, Depends, HTTPException
+from typing import Optional
+
+from fastapi import APIRouter, Cookie, Depends, HTTPException, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import SESSION_COOKIE_NAME
 from app.core.dependencies import get_assistant_agent, get_current_user_db
+from app.core.session_signing import require_session_cookie, set_session_cookie
 from app.db.crud import (
     create_saved_analysis,
     delete_saved_analysis,
@@ -48,9 +52,14 @@ async def save_analysis_snapshot(
     current_user_db: User = Depends(get_current_user_db),
     agent=Depends(get_assistant_agent),
     session: AsyncSession = Depends(get_db_session),
+    session_cookie: Optional[str] = Cookie(default=None, alias=SESSION_COOKIE_NAME),
 ) -> SavedAnalysisSummary:
+    # Anonymous-then-authenticated flow: the user started a chat logged
+    # out, then signed in to save it. Cookie possession proves it's the
+    # same browser, so claim the session for them before saving.
+    require_session_cookie(payload.session_id, session_cookie)
     try:
-        state = await agent.session_service.require_session(
+        state = await agent.session_service.claim_session(
             payload.session_id, current_user_db.keycloak_sub
         )
     except KeyError as err:
@@ -103,6 +112,7 @@ async def get_saved_analysis_detail(
 )
 async def restore_saved_analysis(
     saved_analysis_id: str,
+    response: Response,
     current_user_db: User = Depends(get_current_user_db),
     agent=Depends(get_assistant_agent),
     session: AsyncSession = Depends(get_db_session),
@@ -120,6 +130,10 @@ async def restore_saved_analysis(
             ChatMessage.model_validate(message) for message in saved_analysis.messages
         ],
     )
+    # Bind the restored session to this browser so the frontend can
+    # immediately call GET /assistant/session/{id} to hydrate computed
+    # handoff state (is_complete, handoff_url, suggestions).
+    set_session_cookie(response, restored_state.session_id)
     return SavedAnalysisRestoreResponse(session_id=restored_state.session_id)
 
 

--- a/backend/api/app/api/v1/saved_analyses.py
+++ b/backend/api/app/api/v1/saved_analyses.py
@@ -1,11 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.dependencies import (
-    get_assistant_agent,
-    get_current_user,
-    get_current_user_db,
-)
+from app.core.dependencies import get_assistant_agent, get_current_user_db
 from app.db.crud import (
     create_saved_analysis,
     delete_saved_analysis,
@@ -20,7 +16,6 @@ from app.models.user_data import (
     SavedAnalysisDetail,
     SavedAnalysisRestoreResponse,
     SavedAnalysisSummary,
-    UserMeResponse,
 )
 
 router = APIRouter()
@@ -50,14 +45,13 @@ async def get_saved_analysis_list(
 @router.post("", response_model=SavedAnalysisSummary)
 async def save_analysis_snapshot(
     payload: SaveAnalysisRequest,
-    current_user: UserMeResponse = Depends(get_current_user),
     current_user_db: User = Depends(get_current_user_db),
     agent=Depends(get_assistant_agent),
     session: AsyncSession = Depends(get_db_session),
 ) -> SavedAnalysisSummary:
     try:
         state = await agent.session_service.require_session(
-            payload.session_id, current_user.sub
+            payload.session_id, current_user_db.keycloak_sub
         )
     except KeyError as err:
         raise HTTPException(
@@ -109,7 +103,6 @@ async def get_saved_analysis_detail(
 )
 async def restore_saved_analysis(
     saved_analysis_id: str,
-    current_user: UserMeResponse = Depends(get_current_user),
     current_user_db: User = Depends(get_current_user_db),
     agent=Depends(get_assistant_agent),
     session: AsyncSession = Depends(get_db_session),
@@ -121,7 +114,7 @@ async def restore_saved_analysis(
         raise HTTPException(status_code=404, detail="Saved analysis not found")
 
     restored_state = await agent.restore_saved_session(
-        owner_keycloak_sub=current_user.sub,
+        owner_keycloak_sub=current_user_db.keycloak_sub,
         schema_state=AnalysisSchema.model_validate(saved_analysis.schema),
         messages=[
             ChatMessage.model_validate(message) for message in saved_analysis.messages

--- a/backend/api/app/api/v1/saved_analyses.py
+++ b/backend/api/app/api/v1/saved_analyses.py
@@ -1,0 +1,121 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.dependencies import get_assistant_agent, get_current_user, get_current_user_db
+from app.db.crud import (
+    create_saved_analysis,
+    delete_saved_analysis,
+    get_saved_analysis,
+    list_saved_analyses_for_user,
+)
+from app.db.models import User
+from app.db.session import get_db_session
+from app.models.assistant import AnalysisSchema, ChatMessage
+from app.models.user_data import (
+    SaveAnalysisRequest,
+    SavedAnalysisDetail,
+    SavedAnalysisRestoreResponse,
+    SavedAnalysisSummary,
+    UserMeResponse,
+)
+
+router = APIRouter()
+
+
+def _build_default_title(messages: list[ChatMessage]) -> str:
+    first_user_message = next((message for message in messages if message.role == "user"), None)
+    if first_user_message is None:
+        return "Saved analysis"
+    return first_user_message.content[:80]
+
+
+@router.get("", response_model=list[SavedAnalysisSummary])
+async def get_saved_analysis_list(
+    current_user_db: User = Depends(get_current_user_db),
+    session: AsyncSession = Depends(get_db_session),
+) -> list[SavedAnalysisSummary]:
+    saved_analyses = await list_saved_analyses_for_user(session, current_user_db)
+    return [
+        SavedAnalysisSummary.model_validate(saved_analysis, from_attributes=True)
+        for saved_analysis in saved_analyses
+    ]
+
+
+@router.post("", response_model=SavedAnalysisSummary)
+async def save_analysis_snapshot(
+    payload: SaveAnalysisRequest,
+    current_user: UserMeResponse = Depends(get_current_user),
+    current_user_db: User = Depends(get_current_user_db),
+    agent=Depends(get_assistant_agent),
+    session: AsyncSession = Depends(get_db_session),
+) -> SavedAnalysisSummary:
+    try:
+        state = await agent.session_service.require_session(
+            payload.session_id, current_user.sub
+        )
+    except KeyError as err:
+        raise HTTPException(status_code=404, detail="Assistant session not found") from err
+    except PermissionError as err:
+        raise HTTPException(status_code=403, detail="Assistant session does not belong to this user") from err
+
+    saved_analysis = await create_saved_analysis(
+        session,
+        current_user_db,
+        title=payload.title or _build_default_title(state.messages),
+        schema=state.schema_state.model_dump(mode="json"),
+        messages=[message.model_dump(mode="json") for message in state.messages],
+        source_session=state.session_id,
+    )
+    return SavedAnalysisSummary.model_validate(saved_analysis, from_attributes=True)
+
+
+@router.get("/{saved_analysis_id}", response_model=SavedAnalysisDetail)
+async def get_saved_analysis_detail(
+    saved_analysis_id: str,
+    current_user_db: User = Depends(get_current_user_db),
+    session: AsyncSession = Depends(get_db_session),
+) -> SavedAnalysisDetail:
+    saved_analysis = await get_saved_analysis(session, current_user_db, saved_analysis_id)
+    if saved_analysis is None:
+        raise HTTPException(status_code=404, detail="Saved analysis not found")
+
+    return SavedAnalysisDetail(
+        created_at=saved_analysis.created_at,
+        id=str(saved_analysis.id),
+        messages=[ChatMessage.model_validate(message) for message in saved_analysis.messages],
+        schema=AnalysisSchema.model_validate(saved_analysis.schema),
+        source_session=saved_analysis.source_session,
+        title=saved_analysis.title,
+        updated_at=saved_analysis.updated_at,
+    )
+
+
+@router.post("/{saved_analysis_id}/restore", response_model=SavedAnalysisRestoreResponse)
+async def restore_saved_analysis(
+    saved_analysis_id: str,
+    current_user: UserMeResponse = Depends(get_current_user),
+    current_user_db: User = Depends(get_current_user_db),
+    agent=Depends(get_assistant_agent),
+    session: AsyncSession = Depends(get_db_session),
+) -> SavedAnalysisRestoreResponse:
+    saved_analysis = await get_saved_analysis(session, current_user_db, saved_analysis_id)
+    if saved_analysis is None:
+        raise HTTPException(status_code=404, detail="Saved analysis not found")
+
+    restored_state = await agent.restore_saved_session(
+        owner_keycloak_sub=current_user.sub,
+        schema_state=AnalysisSchema.model_validate(saved_analysis.schema),
+        messages=[ChatMessage.model_validate(message) for message in saved_analysis.messages],
+    )
+    return SavedAnalysisRestoreResponse(session_id=restored_state.session_id)
+
+
+@router.delete("/{saved_analysis_id}", status_code=204)
+async def remove_saved_analysis(
+    saved_analysis_id: str,
+    current_user_db: User = Depends(get_current_user_db),
+    session: AsyncSession = Depends(get_db_session),
+) -> None:
+    deleted = await delete_saved_analysis(session, current_user_db, saved_analysis_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Saved analysis not found")

--- a/backend/api/app/api/v1/user.py
+++ b/backend/api/app/api/v1/user.py
@@ -1,0 +1,41 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.dependencies import get_current_user, get_current_user_db
+from app.db.models import User
+from app.db.session import get_db_session
+from app.models.user_data import UserMeResponse, UserPreferences
+
+router = APIRouter()
+
+
+@router.get("/me", response_model=UserMeResponse)
+async def user_me(
+    current_user: UserMeResponse = Depends(get_current_user),
+    current_user_db: User = Depends(get_current_user_db),
+) -> UserMeResponse:
+    return current_user.model_copy(
+        update={
+            "preferences": UserPreferences.model_validate(current_user_db.preferences)
+        }
+    )
+
+
+@router.get("/preferences", response_model=UserPreferences)
+async def get_preferences(
+    current_user_db: User = Depends(get_current_user_db),
+) -> UserPreferences:
+    return UserPreferences.model_validate(current_user_db.preferences)
+
+
+@router.put("/preferences", response_model=UserPreferences)
+async def update_preferences(
+    preferences: UserPreferences,
+    current_user_db: User = Depends(get_current_user_db),
+    session: AsyncSession = Depends(get_db_session),
+) -> UserPreferences:
+    current_user_db.preferences = preferences.model_dump(mode="json")
+    session.add(current_user_db)
+    await session.commit()
+    await session.refresh(current_user_db)
+    return UserPreferences.model_validate(current_user_db.preferences)

--- a/backend/api/app/api/v1/user.py
+++ b/backend/api/app/api/v1/user.py
@@ -39,10 +39,10 @@ async def update_preferences(
     current_user_db: User = Depends(get_current_user_db),
     session: AsyncSession = Depends(get_db_session),
 ) -> UserPreferences:
-    # Reject obviously-oversized payloads before they're parsed. The
-    # serialized check below is still authoritative for cases where
-    # Content-Length is missing or lies, but this saves Pydantic from
-    # parsing a pathological 100MB blob in the common case.
+    # Best-effort early rejection from the Content-Length header. FastAPI has
+    # already parsed the body by the time we get here, so this is just a fast
+    # 413 in the common case; the serialized-size check below is authoritative
+    # (Content-Length can be missing or lie).
     content_length = request.headers.get("content-length")
     if content_length is not None:
         try:

--- a/backend/api/app/api/v1/user.py
+++ b/backend/api/app/api/v1/user.py
@@ -1,6 +1,6 @@
 import json
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.dependencies import get_current_user, get_current_user_db
@@ -34,10 +34,25 @@ async def get_preferences(
 
 @router.put("/preferences", response_model=UserPreferences)
 async def update_preferences(
+    request: Request,
     preferences: UserPreferences,
     current_user_db: User = Depends(get_current_user_db),
     session: AsyncSession = Depends(get_db_session),
 ) -> UserPreferences:
+    # Reject obviously-oversized payloads before they're parsed. The
+    # serialized check below is still authoritative for cases where
+    # Content-Length is missing or lies, but this saves Pydantic from
+    # parsing a pathological 100MB blob in the common case.
+    content_length = request.headers.get("content-length")
+    if content_length is not None:
+        try:
+            if int(content_length) > MAX_PREFERENCES_BYTES:
+                raise HTTPException(
+                    status_code=413, detail="Preferences payload too large"
+                )
+        except ValueError:
+            pass
+
     payload = preferences.model_dump(mode="json")
     serialized_payload = json.dumps(payload, separators=(",", ":")).encode("utf-8")
     if len(serialized_payload) > MAX_PREFERENCES_BYTES:

--- a/backend/api/app/api/v1/user.py
+++ b/backend/api/app/api/v1/user.py
@@ -1,4 +1,6 @@
-from fastapi import APIRouter, Depends
+import json
+
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.dependencies import get_current_user, get_current_user_db
@@ -7,6 +9,8 @@ from app.db.session import get_db_session
 from app.models.user_data import UserMeResponse, UserPreferences
 
 router = APIRouter()
+
+MAX_PREFERENCES_BYTES = 16 * 1024
 
 
 @router.get("/me", response_model=UserMeResponse)
@@ -34,7 +38,12 @@ async def update_preferences(
     current_user_db: User = Depends(get_current_user_db),
     session: AsyncSession = Depends(get_db_session),
 ) -> UserPreferences:
-    current_user_db.preferences = preferences.model_dump(mode="json")
+    payload = preferences.model_dump(mode="json")
+    serialized_payload = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    if len(serialized_payload) > MAX_PREFERENCES_BYTES:
+        raise HTTPException(status_code=413, detail="Preferences payload too large")
+
+    current_user_db.preferences = payload
     session.add(current_user_db)
     await session.commit()
     await session.refresh(current_user_db)

--- a/backend/api/app/api/v1/workflow_runs.py
+++ b/backend/api/app/api/v1/workflow_runs.py
@@ -1,11 +1,16 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.dependencies import get_current_user_db, get_optional_current_user_db
+from app.core.dependencies import (
+    get_assistant_agent,
+    get_current_user_db,
+    get_optional_current_user_db,
+)
 from app.db.crud import create_workflow_run, list_workflow_runs_for_user
 from app.db.models import User
 from app.db.session import get_db_session
 from app.models.workflow_runs import WorkflowRunCreateRequest, WorkflowRunResponse
+from app.services.assistant_agent import AssistantAgent
 
 router = APIRouter()
 
@@ -14,8 +19,27 @@ router = APIRouter()
 async def create_tracked_workflow_run(
     payload: WorkflowRunCreateRequest,
     current_user_db: User | None = Depends(get_optional_current_user_db),
+    agent: AssistantAgent = Depends(get_assistant_agent),
     session: AsyncSession = Depends(get_db_session),
 ) -> WorkflowRunResponse:
+    # If the caller claims this run came from an assistant session, the
+    # session must actually exist and either be anonymous or owned by them.
+    # Without this check, a logged-in caller can fabricate runs citing
+    # arbitrary session IDs and pollute the launch-source analytics.
+    if payload.assistant_session_id:
+        assistant_state = await agent.session_service.get_session(
+            payload.assistant_session_id
+        )
+        if assistant_state is None:
+            raise HTTPException(status_code=404, detail="Assistant session not found")
+        owner = assistant_state.owner_keycloak_sub
+        caller_sub = current_user_db.keycloak_sub if current_user_db else None
+        if owner is not None and owner != caller_sub:
+            raise HTTPException(
+                status_code=403,
+                detail="Assistant session belongs to another user",
+            )
+
     workflow_run = await create_workflow_run(
         session,
         current_user_db,

--- a/backend/api/app/api/v1/workflow_runs.py
+++ b/backend/api/app/api/v1/workflow_runs.py
@@ -1,4 +1,6 @@
-from fastapi import APIRouter, Depends, HTTPException
+import json
+
+from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.dependencies import (
@@ -14,14 +16,39 @@ from app.services.assistant_agent import AssistantAgent
 
 router = APIRouter()
 
+# Bound the request body. Anonymous POSTs are allowed (workflow tracking
+# fires from unauthenticated browse flows too), so we don't want a single
+# request to push arbitrarily large JSON through pydantic and into the DB.
+MAX_WORKFLOW_RUN_BYTES = 64 * 1024
+
 
 @router.post("", response_model=WorkflowRunResponse)
 async def create_tracked_workflow_run(
     payload: WorkflowRunCreateRequest,
+    request: Request,
     current_user_db: User | None = Depends(get_optional_current_user_db),
     agent: AssistantAgent = Depends(get_assistant_agent),
     session: AsyncSession = Depends(get_db_session),
 ) -> WorkflowRunResponse:
+    # Reject obviously-oversized payloads early. The serialized check
+    # below is still authoritative (Content-Length can be missing or lie),
+    # but this gives a clearer 413 in the common case.
+    content_length = request.headers.get("content-length")
+    if content_length is not None:
+        try:
+            if int(content_length) > MAX_WORKFLOW_RUN_BYTES:
+                raise HTTPException(
+                    status_code=413, detail="Workflow run payload too large"
+                )
+        except ValueError:
+            pass
+
+    serialized_parameters = json.dumps(payload.parameters, separators=(",", ":"))
+    if len(serialized_parameters.encode("utf-8")) > MAX_WORKFLOW_RUN_BYTES:
+        raise HTTPException(
+            status_code=413, detail="Workflow run parameters payload too large"
+        )
+
     # If the caller claims this run came from an assistant session, the
     # session must actually exist and either be anonymous or owned by them.
     # Without this check, a logged-in caller can fabricate runs citing

--- a/backend/api/app/api/v1/workflow_runs.py
+++ b/backend/api/app/api/v1/workflow_runs.py
@@ -1,0 +1,43 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.dependencies import get_current_user_db, get_optional_current_user_db
+from app.db.crud import create_workflow_run, list_workflow_runs_for_user
+from app.db.models import User
+from app.db.session import get_db_session
+from app.models.workflow_runs import WorkflowRunCreateRequest, WorkflowRunResponse
+
+router = APIRouter()
+
+
+@router.post("", response_model=WorkflowRunResponse)
+async def create_tracked_workflow_run(
+    payload: WorkflowRunCreateRequest,
+    current_user_db: User | None = Depends(get_optional_current_user_db),
+    session: AsyncSession = Depends(get_db_session),
+) -> WorkflowRunResponse:
+    workflow_run = await create_workflow_run(
+        session,
+        current_user_db,
+        workflow_trs_id=payload.workflow_trs_id,
+        workflow_id=payload.workflow_id,
+        galaxy_instance_url=payload.galaxy_instance_url,
+        handoff_url=payload.handoff_url,
+        assembly_accession=payload.assembly_accession,
+        launch_source=payload.launch_source,
+        assistant_session_id=payload.assistant_session_id,
+        parameters=payload.parameters,
+    )
+    return WorkflowRunResponse.model_validate(workflow_run, from_attributes=True)
+
+
+@router.get("", response_model=list[WorkflowRunResponse])
+async def get_workflow_runs(
+    current_user_db: User = Depends(get_current_user_db),
+    session: AsyncSession = Depends(get_db_session),
+) -> list[WorkflowRunResponse]:
+    workflow_runs = await list_workflow_runs_for_user(session, current_user_db)
+    return [
+        WorkflowRunResponse.model_validate(workflow_run, from_attributes=True)
+        for workflow_run in workflow_runs
+    ]

--- a/backend/api/app/api/v1/workflow_runs.py
+++ b/backend/api/app/api/v1/workflow_runs.py
@@ -67,6 +67,18 @@ async def create_tracked_workflow_run(
                 detail="Assistant session belongs to another user",
             )
 
+    # launch_source feeds launch analytics and is otherwise client-reported.
+    # The one label we can verify is "assistant" -- it must be backed by a
+    # real, ownership-checked assistant session (validated above) -- so derive
+    # it instead of trusting the body. Mirrors the frontend, which sets
+    # "assistant" iff there's an assistant session. Other labels pass through.
+    if payload.assistant_session_id:
+        launch_source = "assistant"
+    elif payload.launch_source == "assistant":
+        launch_source = "site"
+    else:
+        launch_source = payload.launch_source
+
     workflow_run = await create_workflow_run(
         session,
         current_user_db,
@@ -75,7 +87,7 @@ async def create_tracked_workflow_run(
         galaxy_instance_url=payload.galaxy_instance_url,
         handoff_url=payload.handoff_url,
         assembly_accession=payload.assembly_accession,
-        launch_source=payload.launch_source,
+        launch_source=launch_source,
         assistant_session_id=payload.assistant_session_id,
         parameters=payload.parameters,
     )

--- a/backend/api/app/core/config.py
+++ b/backend/api/app/core/config.py
@@ -41,11 +41,18 @@ class Settings:
             os.getenv("AI_SKIP_SSL_VERIFY", "false").lower() == "true"
         )
 
-        # Database settings (for future use)
+        # Database settings -- required for persistent user data (favorites,
+        # saved analyses, workflow runs). Anonymous / non-persistent flows
+        # don't touch the DB.
         self.DATABASE_URL: str = os.getenv("DATABASE_URL", "")
         self.DATABASE_ECHO: bool = os.getenv("DATABASE_ECHO", "false").lower() == "true"
         self.DATABASE_POOL_SIZE: int = int(os.getenv("DATABASE_POOL_SIZE", "5"))
         self.DATABASE_MAX_OVERFLOW: int = int(os.getenv("DATABASE_MAX_OVERFLOW", "10"))
+        # Off by default so prod deploys retain explicit migration control.
+        # Enable for local/dev/CI where a one-shot upgrade-on-startup is convenient.
+        self.RUN_MIGRATIONS_ON_STARTUP: bool = (
+            os.getenv("RUN_MIGRATIONS_ON_STARTUP", "false").lower() == "true"
+        )
 
         # ENA API settings
         self.ENA_API_BASE: str = os.getenv(

--- a/backend/api/app/core/config.py
+++ b/backend/api/app/core/config.py
@@ -43,6 +43,9 @@ class Settings:
 
         # Database settings (for future use)
         self.DATABASE_URL: str = os.getenv("DATABASE_URL", "")
+        self.DATABASE_ECHO: bool = os.getenv("DATABASE_ECHO", "false").lower() == "true"
+        self.DATABASE_POOL_SIZE: int = int(os.getenv("DATABASE_POOL_SIZE", "5"))
+        self.DATABASE_MAX_OVERFLOW: int = int(os.getenv("DATABASE_MAX_OVERFLOW", "10"))
 
         # ENA API settings
         self.ENA_API_BASE: str = os.getenv(

--- a/backend/api/app/core/dependencies.py
+++ b/backend/api/app/core/dependencies.py
@@ -1,13 +1,18 @@
 import logging
 from functools import lru_cache
 
-from fastapi import Request
+from fastapi import Cookie, Depends, HTTPException, Request
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.cache import CacheService
 from app.core.config import get_settings
 from app.core.rate_limit import RateLimiter
+from app.db.crud import get_user_by_keycloak_sub
+from app.db.models import User
+from app.db.session import get_db_session
+from app.models.user_data import UserMeResponse
 from app.services.assistant_agent import AssistantAgent
-from app.services.auth_service import AuthService
+from app.services.auth_service import COOKIE_NAME, AuthService
 from app.services.catalog_data import CatalogData
 from app.services.ena_service import ENAService
 
@@ -71,6 +76,40 @@ def get_rate_limiter() -> RateLimiter:
 async def check_rate_limit(request: Request) -> dict:
     rate_limiter = get_rate_limiter()
     return await rate_limiter.check(request)
+
+
+async def get_optional_current_user(
+    brc_session: str | None = Cookie(default=None, alias=COOKIE_NAME),
+    auth: AuthService = Depends(get_auth_service),
+) -> UserMeResponse | None:
+    if not brc_session:
+        return None
+
+    user_info = await auth.get_user_info(brc_session)
+    if not user_info:
+        return None
+
+    return UserMeResponse.model_validate(user_info)
+
+
+async def get_current_user(
+    current_user: UserMeResponse | None = Depends(get_optional_current_user),
+) -> UserMeResponse:
+    if current_user is None:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    return current_user
+
+
+async def get_current_user_db(
+    current_user: UserMeResponse = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db_session),
+) -> User:
+    user = await get_user_by_keycloak_sub(session, current_user.sub)
+    if user is None:
+        raise HTTPException(
+            status_code=503, detail="Authenticated user is not provisioned"
+        )
+    return user
 
 
 def reset_cache_service() -> None:

--- a/backend/api/app/core/dependencies.py
+++ b/backend/api/app/core/dependencies.py
@@ -112,6 +112,15 @@ async def get_current_user_db(
     return user
 
 
+async def get_optional_current_user_db(
+    current_user: UserMeResponse | None = Depends(get_optional_current_user),
+    session: AsyncSession = Depends(get_db_session),
+) -> User | None:
+    if current_user is None:
+        return None
+    return await get_user_by_keycloak_sub(session, current_user.sub)
+
+
 def reset_cache_service() -> None:
     get_cache_service.cache_clear()
 

--- a/backend/api/app/core/session_signing.py
+++ b/backend/api/app/core/session_signing.py
@@ -11,6 +11,11 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+from typing import Optional
+
+from fastapi import HTTPException, Response
+
+from app.core.config import DEV_ENVIRONMENTS, SESSION_COOKIE_NAME, get_settings
 
 
 def sign_session_id(session_id: str, secret: str) -> str:
@@ -29,3 +34,36 @@ def verify_session_id(session_id: str, signature: str, secret: str) -> bool:
         return False
     expected = sign_session_id(session_id, secret)
     return hmac.compare_digest(expected, signature)
+
+
+def require_session_cookie(session_id: str, cookie_value: Optional[str]) -> None:
+    """Raise 403 unless the cookie's HMAC matches session_id.
+
+    If no SESSION_COOKIE_SECRET is configured (legacy/local-dev mode), all
+    requests are allowed -- the binding is opt-in via env var.
+    """
+    settings = get_settings()
+    if not settings.SESSION_COOKIE_SECRET:
+        return
+    if not verify_session_id(
+        session_id, cookie_value or "", settings.SESSION_COOKIE_SECRET
+    ):
+        raise HTTPException(status_code=403, detail="Invalid session cookie")
+
+
+def set_session_cookie(response: Response, session_id: str) -> None:
+    """Issue an httpOnly Same-Site=Strict cookie binding the session to this client."""
+    settings = get_settings()
+    if not settings.SESSION_COOKIE_SECRET:
+        return
+    # Only allow plain-HTTP cookies in DEV_ENVIRONMENTS. Anywhere else
+    # (staging, prod, anything that could ever see a non-TLS hop) must
+    # mark the cookie Secure so the browser refuses to send it over HTTP.
+    response.set_cookie(
+        key=SESSION_COOKIE_NAME,
+        value=sign_session_id(session_id, settings.SESSION_COOKIE_SECRET),
+        max_age=settings.SESSION_COOKIE_TTL,
+        httponly=True,
+        samesite="strict",
+        secure=settings.ENVIRONMENT.lower() not in DEV_ENVIRONMENTS,
+    )

--- a/backend/api/app/db/__init__.py
+++ b/backend/api/app/db/__init__.py
@@ -1,0 +1,1 @@
+"""Database package for persistent app data."""

--- a/backend/api/app/db/crud.py
+++ b/backend/api/app/db/crud.py
@@ -34,11 +34,24 @@ async def upsert_user_from_claims(
             name=claims.get("name"),
         )
         session.add(user)
+        try:
+            await session.commit()
+        except IntegrityError:
+            # Concurrent first-login for the same sub: the other callback
+            # won the INSERT. Recover by loading its row and applying our
+            # claim values, mirroring upsert_favorite's race handling.
+            await session.rollback()
+            user = await get_user_by_keycloak_sub(session, keycloak_sub)
+            if user is None:
+                raise
+            user.email = claims.get("email")
+            user.name = claims.get("name")
+            await session.commit()
     else:
         user.email = claims.get("email")
         user.name = claims.get("name")
+        await session.commit()
 
-    await session.commit()
     await session.refresh(user)
     return user
 

--- a/backend/api/app/db/crud.py
+++ b/backend/api/app/db/crud.py
@@ -6,7 +6,7 @@ from typing import Any
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.db.models import Favorite, SavedAnalysis, User
+from app.db.models import Favorite, SavedAnalysis, User, WorkflowRun
 
 
 async def get_user_by_keycloak_sub(
@@ -152,3 +152,46 @@ async def delete_saved_analysis(
     await session.delete(saved_analysis)
     await session.commit()
     return True
+
+
+async def create_workflow_run(
+    session: AsyncSession,
+    user: User | None,
+    *,
+    workflow_trs_id: str,
+    workflow_id: str | None,
+    galaxy_instance_url: str | None,
+    handoff_url: str,
+    assembly_accession: str | None,
+    launch_source: str,
+    assistant_session_id: str | None,
+    parameters: dict[str, Any],
+    status: str = "handoff_created",
+) -> WorkflowRun:
+    workflow_run = WorkflowRun(
+        user_id=user.id if user is not None else None,
+        workflow_trs_id=workflow_trs_id,
+        workflow_id=workflow_id,
+        galaxy_instance_url=galaxy_instance_url,
+        handoff_url=handoff_url,
+        assembly_accession=assembly_accession,
+        launch_source=launch_source,
+        assistant_session_id=assistant_session_id,
+        parameters=parameters,
+        status=status,
+    )
+    session.add(workflow_run)
+    await session.commit()
+    await session.refresh(workflow_run)
+    return workflow_run
+
+
+async def list_workflow_runs_for_user(
+    session: AsyncSession, user: User
+) -> list[WorkflowRun]:
+    result = await session.execute(
+        select(WorkflowRun)
+        .where(WorkflowRun.user_id == user.id)
+        .order_by(WorkflowRun.created_at.desc())
+    )
+    return list(result.scalars().all())

--- a/backend/api/app/db/crud.py
+++ b/backend/api/app/db/crud.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.models import Favorite, SavedAnalysis, User
+
+
+async def get_user_by_keycloak_sub(
+    session: AsyncSession, keycloak_sub: str
+) -> User | None:
+    result = await session.execute(
+        select(User).where(User.keycloak_sub == keycloak_sub)
+    )
+    return result.scalar_one_or_none()
+
+
+async def upsert_user_from_claims(
+    session: AsyncSession, claims: dict[str, Any]
+) -> User:
+    keycloak_sub = claims.get("sub")
+    if not keycloak_sub:
+        raise ValueError("OIDC claims are missing sub")
+
+    user = await get_user_by_keycloak_sub(session, keycloak_sub)
+    if user is None:
+        user = User(
+            keycloak_sub=keycloak_sub,
+            email=claims.get("email"),
+            name=claims.get("name"),
+        )
+        session.add(user)
+    else:
+        user.email = claims.get("email")
+        user.name = claims.get("name")
+
+    await session.commit()
+    await session.refresh(user)
+    return user
+
+
+async def list_favorites_for_user(session: AsyncSession, user: User) -> list[Favorite]:
+    result = await session.execute(
+        select(Favorite)
+        .where(Favorite.user_id == user.id)
+        .order_by(Favorite.created_at.desc())
+    )
+    return list(result.scalars().all())
+
+
+async def get_favorite(
+    session: AsyncSession, user: User, entity_type: str, entity_id: str
+) -> Favorite | None:
+    result = await session.execute(
+        select(Favorite).where(
+            Favorite.user_id == user.id,
+            Favorite.entity_type == entity_type,
+            Favorite.entity_id == entity_id,
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def upsert_favorite(
+    session: AsyncSession, user: User, entity_type: str, entity_id: str
+) -> Favorite:
+    favorite = await get_favorite(session, user, entity_type, entity_id)
+    if favorite is None:
+        favorite = Favorite(
+            user_id=user.id,
+            entity_type=entity_type,
+            entity_id=entity_id,
+        )
+        session.add(favorite)
+        await session.commit()
+        await session.refresh(favorite)
+    return favorite
+
+
+async def delete_favorite(
+    session: AsyncSession, user: User, entity_type: str, entity_id: str
+) -> bool:
+    favorite = await get_favorite(session, user, entity_type, entity_id)
+    if favorite is None:
+        return False
+
+    await session.delete(favorite)
+    await session.commit()
+    return True
+
+
+async def list_saved_analyses_for_user(
+    session: AsyncSession, user: User
+) -> list[SavedAnalysis]:
+    result = await session.execute(
+        select(SavedAnalysis)
+        .where(SavedAnalysis.user_id == user.id)
+        .order_by(SavedAnalysis.updated_at.desc())
+    )
+    return list(result.scalars().all())
+
+
+async def get_saved_analysis(
+    session: AsyncSession, user: User, saved_analysis_id: str
+) -> SavedAnalysis | None:
+    result = await session.execute(
+        select(SavedAnalysis).where(
+            SavedAnalysis.user_id == user.id,
+            SavedAnalysis.id == saved_analysis_id,
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def create_saved_analysis(
+    session: AsyncSession,
+    user: User,
+    *,
+    title: str | None,
+    schema: dict[str, Any],
+    messages: list[dict[str, Any]],
+    source_session: str | None,
+) -> SavedAnalysis:
+    saved_analysis = SavedAnalysis(
+        user_id=user.id,
+        title=title,
+        schema=schema,
+        messages=messages,
+        source_session=source_session,
+    )
+    session.add(saved_analysis)
+    await session.commit()
+    await session.refresh(saved_analysis)
+    return saved_analysis
+
+
+async def delete_saved_analysis(
+    session: AsyncSession, user: User, saved_analysis_id: str
+) -> bool:
+    saved_analysis = await get_saved_analysis(session, user, saved_analysis_id)
+    if saved_analysis is None:
+        return False
+
+    await session.delete(saved_analysis)
+    await session.commit()
+    return True

--- a/backend/api/app/db/crud.py
+++ b/backend/api/app/db/crud.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import uuid
 from typing import Any
 
 from sqlalchemy import select
@@ -105,10 +106,15 @@ async def list_saved_analyses_for_user(
 async def get_saved_analysis(
     session: AsyncSession, user: User, saved_analysis_id: str
 ) -> SavedAnalysis | None:
+    try:
+        saved_analysis_uuid = uuid.UUID(saved_analysis_id)
+    except ValueError:
+        return None
+
     result = await session.execute(
         select(SavedAnalysis).where(
             SavedAnalysis.user_id == user.id,
-            SavedAnalysis.id == saved_analysis_id,
+            SavedAnalysis.id == saved_analysis_uuid,
         )
     )
     return result.scalar_one_or_none()

--- a/backend/api/app/db/crud.py
+++ b/backend/api/app/db/crud.py
@@ -4,6 +4,7 @@ import uuid
 from typing import Any
 
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.models import Favorite, SavedAnalysis, User, WorkflowRun
@@ -42,12 +43,16 @@ async def upsert_user_from_claims(
     return user
 
 
-async def list_favorites_for_user(session: AsyncSession, user: User) -> list[Favorite]:
-    result = await session.execute(
-        select(Favorite)
-        .where(Favorite.user_id == user.id)
-        .order_by(Favorite.created_at.desc())
-    )
+async def list_favorites_for_user(
+    session: AsyncSession,
+    user: User,
+    entity_type: str | None = None,
+) -> list[Favorite]:
+    stmt = select(Favorite).where(Favorite.user_id == user.id)
+    if entity_type is not None:
+        stmt = stmt.where(Favorite.entity_type == entity_type)
+    stmt = stmt.order_by(Favorite.created_at.desc())
+    result = await session.execute(stmt)
     return list(result.scalars().all())
 
 
@@ -67,16 +72,28 @@ async def get_favorite(
 async def upsert_favorite(
     session: AsyncSession, user: User, entity_type: str, entity_id: str
 ) -> Favorite:
-    favorite = await get_favorite(session, user, entity_type, entity_id)
-    if favorite is None:
-        favorite = Favorite(
-            user_id=user.id,
-            entity_type=entity_type,
-            entity_id=entity_id,
-        )
-        session.add(favorite)
+    existing = await get_favorite(session, user, entity_type, entity_id)
+    if existing is not None:
+        return existing
+
+    # Race window: two concurrent POSTs both pass the SELECT, both INSERT,
+    # one trips the PK. Catching IntegrityError + re-fetching keeps the
+    # endpoint clean (and portable across postgres + sqlite-in-tests).
+    favorite = Favorite(
+        user_id=user.id,
+        entity_type=entity_type,
+        entity_id=entity_id,
+    )
+    session.add(favorite)
+    try:
         await session.commit()
-        await session.refresh(favorite)
+    except IntegrityError:
+        await session.rollback()
+        existing = await get_favorite(session, user, entity_type, entity_id)
+        if existing is not None:
+            return existing
+        raise
+    await session.refresh(favorite)
     return favorite
 
 

--- a/backend/api/app/db/migrations/env.py
+++ b/backend/api/app/db/migrations/env.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import pool
+from sqlalchemy.engine import Connection
+from sqlalchemy.ext.asyncio import async_engine_from_config
+
+from app.core.config import get_settings
+from app.db.models import Base
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+settings = get_settings()
+config.set_main_option("sqlalchemy.url", settings.DATABASE_URL)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    context.configure(
+        url=settings.DATABASE_URL,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def do_run_migrations(connection: Connection) -> None:
+    context.configure(connection=connection, target_metadata=target_metadata)
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+async def run_migrations_online() -> None:
+    connectable = async_engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    async with connectable.connect() as connection:
+        await connection.run_sync(do_run_migrations)
+
+    await connectable.dispose()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    import asyncio
+
+    asyncio.run(run_migrations_online())

--- a/backend/api/app/db/migrations/script.py.mako
+++ b/backend/api/app/db/migrations/script.py.mako
@@ -1,0 +1,17 @@
+"""${message}"""
+
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/backend/api/app/db/migrations/versions/20260419_0001_create_persistent_app_tables.py
+++ b/backend/api/app/db/migrations/versions/20260419_0001_create_persistent_app_tables.py
@@ -1,0 +1,88 @@
+"""create persistent app tables"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "20260419_0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def _uuid_type():
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        return postgresql.UUID(as_uuid=True)
+    return sa.String(length=36)
+
+
+def _json_type():
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        return postgresql.JSONB(astext_type=sa.Text())
+    return sa.JSON()
+
+
+def upgrade() -> None:
+    op.create_table(
+        "users",
+        sa.Column("id", _uuid_type(), primary_key=True, nullable=False),
+        sa.Column("keycloak_sub", sa.Text(), nullable=False),
+        sa.Column("email", sa.Text(), nullable=True),
+        sa.Column("name", sa.Text(), nullable=True),
+        sa.Column(
+            "preferences",
+            _json_type(),
+            nullable=False,
+            server_default=sa.text("'{}'"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_users_keycloak_sub", "users", ["keycloak_sub"], unique=True)
+
+    op.create_table(
+        "favorites",
+        sa.Column("user_id", _uuid_type(), nullable=False),
+        sa.Column("entity_type", sa.String(length=64), nullable=False),
+        sa.Column("entity_id", sa.String(length=255), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("user_id", "entity_type", "entity_id"),
+    )
+
+    op.create_table(
+        "saved_analyses",
+        sa.Column("id", _uuid_type(), primary_key=True, nullable=False),
+        sa.Column("user_id", _uuid_type(), nullable=False),
+        sa.Column("title", sa.Text(), nullable=True),
+        sa.Column("schema", _json_type(), nullable=False),
+        sa.Column("messages", _json_type(), nullable=False),
+        sa.Column("source_session", sa.String(length=255), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+    )
+    op.create_index(
+        "ix_saved_analyses_user_updated_at",
+        "saved_analyses",
+        ["user_id", "updated_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_saved_analyses_user_updated_at", table_name="saved_analyses")
+    op.drop_table("saved_analyses")
+    op.drop_table("favorites")
+    op.drop_index("ix_users_keycloak_sub", table_name="users")
+    op.drop_table("users")

--- a/backend/api/app/db/migrations/versions/20260421_0002_add_workflow_runs_table.py
+++ b/backend/api/app/db/migrations/versions/20260421_0002_add_workflow_runs_table.py
@@ -1,0 +1,62 @@
+"""add workflow runs table"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "20260421_0002"
+down_revision = "20260419_0001"
+branch_labels = None
+depends_on = None
+
+
+def _uuid_type():
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        return postgresql.UUID(as_uuid=True)
+    return sa.String(length=36)
+
+
+def _json_type():
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        return postgresql.JSONB(astext_type=sa.Text())
+    return sa.JSON()
+
+
+def upgrade() -> None:
+    op.create_table(
+        "workflow_runs",
+        sa.Column("id", _uuid_type(), primary_key=True, nullable=False),
+        sa.Column("user_id", _uuid_type(), nullable=True),
+        sa.Column("workflow_trs_id", sa.String(length=255), nullable=False),
+        sa.Column("workflow_id", sa.String(length=255), nullable=True),
+        sa.Column("galaxy_instance_url", sa.Text(), nullable=True),
+        sa.Column("handoff_url", sa.Text(), nullable=False),
+        sa.Column("assembly_accession", sa.String(length=255), nullable=True),
+        sa.Column("launch_source", sa.String(length=64), nullable=False),
+        sa.Column("assistant_session_id", sa.String(length=255), nullable=True),
+        sa.Column("galaxy_invocation_id", sa.String(length=255), nullable=True),
+        sa.Column("status", sa.String(length=64), nullable=False),
+        sa.Column(
+            "parameters",
+            _json_type(),
+            nullable=False,
+            server_default=sa.text("'{}'"),
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="SET NULL"),
+    )
+    op.create_index(
+        "ix_workflow_runs_user_created_at",
+        "workflow_runs",
+        ["user_id", "created_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_workflow_runs_user_created_at", table_name="workflow_runs")
+    op.drop_table("workflow_runs")

--- a/backend/api/app/db/models.py
+++ b/backend/api/app/db/models.py
@@ -123,12 +123,8 @@ class WorkflowRun(Base):
     handoff_url: Mapped[str] = mapped_column(Text, nullable=False)
     assembly_accession: Mapped[str | None] = mapped_column(String(255), nullable=True)
     launch_source: Mapped[str] = mapped_column(String(64), nullable=False)
-    assistant_session_id: Mapped[str | None] = mapped_column(
-        String(255), nullable=True
-    )
-    galaxy_invocation_id: Mapped[str | None] = mapped_column(
-        String(255), nullable=True
-    )
+    assistant_session_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    galaxy_invocation_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
     status: Mapped[str] = mapped_column(String(64), nullable=False)
     parameters: Mapped[dict] = mapped_column(JSON, default=dict, nullable=False)
     created_at: Mapped[datetime] = mapped_column(

--- a/backend/api/app/db/models.py
+++ b/backend/api/app/db/models.py
@@ -112,6 +112,11 @@ class WorkflowRun(Base):
         primary_key=True,
         default=uuid.uuid4,
     )
+    # Intentional: workflow_runs is mixed authenticated + anonymous tracking.
+    # SET NULL on user deletion converts the row to an anonymous record (same
+    # state it would have had if the user wasn't logged in at launch time).
+    # The account history page filters on user_id and won't show the orphan,
+    # but the analytics record is preserved.
     user_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("users.id", ondelete="SET NULL"),

--- a/backend/api/app/db/models.py
+++ b/backend/api/app/db/models.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import JSON, DateTime, ForeignKey, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+
+
+def utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    keycloak_sub: Mapped[str] = mapped_column(Text, unique=True, nullable=False)
+    email: Mapped[str | None] = mapped_column(Text, nullable=True)
+    name: Mapped[str | None] = mapped_column(Text, nullable=True)
+    preferences: Mapped[dict] = mapped_column(JSON, default=dict, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utcnow,
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utcnow,
+        onupdate=utcnow,
+        nullable=False,
+    )
+
+    favorites: Mapped[list[Favorite]] = relationship(
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )
+    saved_analyses: Mapped[list[SavedAnalysis]] = relationship(
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )
+
+
+class Favorite(Base):
+    __tablename__ = "favorites"
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    entity_type: Mapped[str] = mapped_column(String(64), primary_key=True)
+    entity_id: Mapped[str] = mapped_column(String(255), primary_key=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utcnow,
+        nullable=False,
+    )
+
+    user: Mapped[User] = relationship(back_populates="favorites")
+
+
+class SavedAnalysis(Base):
+    __tablename__ = "saved_analyses"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    title: Mapped[str | None] = mapped_column(Text, nullable=True)
+    schema: Mapped[dict] = mapped_column(JSON, nullable=False)
+    messages: Mapped[list] = mapped_column(JSON, nullable=False)
+    source_session: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utcnow,
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utcnow,
+        onupdate=utcnow,
+        nullable=False,
+    )
+
+    user: Mapped[User] = relationship(back_populates="saved_analyses")

--- a/backend/api/app/db/models.py
+++ b/backend/api/app/db/models.py
@@ -48,6 +48,9 @@ class User(Base):
         back_populates="user",
         cascade="all, delete-orphan",
     )
+    workflow_runs: Mapped[list[WorkflowRun]] = relationship(
+        back_populates="user",
+    )
 
 
 class Favorite(Base):
@@ -99,3 +102,49 @@ class SavedAnalysis(Base):
     )
 
     user: Mapped[User] = relationship(back_populates="saved_analyses")
+
+
+class WorkflowRun(Base):
+    __tablename__ = "workflow_runs"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    workflow_trs_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    workflow_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    galaxy_instance_url: Mapped[str | None] = mapped_column(Text, nullable=True)
+    handoff_url: Mapped[str] = mapped_column(Text, nullable=False)
+    assembly_accession: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    launch_source: Mapped[str] = mapped_column(String(64), nullable=False)
+    assistant_session_id: Mapped[str | None] = mapped_column(
+        String(255), nullable=True
+    )
+    galaxy_invocation_id: Mapped[str | None] = mapped_column(
+        String(255), nullable=True
+    )
+    status: Mapped[str] = mapped_column(String(64), nullable=False)
+    parameters: Mapped[dict] = mapped_column(JSON, default=dict, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utcnow,
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utcnow,
+        onupdate=utcnow,
+        nullable=False,
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+
+    user: Mapped[User | None] = relationship(back_populates="workflow_runs")

--- a/backend/api/app/db/session.py
+++ b/backend/api/app/db/session.py
@@ -1,0 +1,75 @@
+from collections.abc import AsyncIterator
+
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from app.core.config import get_settings
+
+_engine: AsyncEngine | None = None
+_session_factory: async_sessionmaker[AsyncSession] | None = None
+
+
+def _is_sqlite(url: str) -> bool:
+    return url.startswith("sqlite")
+
+
+def get_engine() -> AsyncEngine:
+    global _engine, _session_factory
+
+    if _engine is not None:
+        return _engine
+
+    settings = get_settings()
+    if not settings.DATABASE_URL:
+        raise RuntimeError("DATABASE_URL is not configured")
+
+    engine_kwargs: dict[str, object] = {
+        "echo": settings.DATABASE_ECHO,
+        "future": True,
+    }
+    if not _is_sqlite(settings.DATABASE_URL):
+        engine_kwargs["max_overflow"] = settings.DATABASE_MAX_OVERFLOW
+        engine_kwargs["pool_size"] = settings.DATABASE_POOL_SIZE
+
+    _engine = create_async_engine(settings.DATABASE_URL, **engine_kwargs)
+    _session_factory = async_sessionmaker(
+        _engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+    return _engine
+
+
+def get_session_factory() -> async_sessionmaker[AsyncSession]:
+    global _session_factory
+
+    if _session_factory is None:
+        get_engine()
+    if _session_factory is None:
+        raise RuntimeError("Database session factory failed to initialize")
+    return _session_factory
+
+
+async def get_db_session() -> AsyncIterator[AsyncSession]:
+    session_factory = get_session_factory()
+    async with session_factory() as session:
+        yield session
+
+
+async def init_db() -> None:
+    settings = get_settings()
+    if settings.DATABASE_URL:
+        get_engine()
+
+
+async def close_db() -> None:
+    global _engine, _session_factory
+
+    if _engine is not None:
+        await _engine.dispose()
+    _engine = None
+    _session_factory = None

--- a/backend/api/app/db/session.py
+++ b/backend/api/app/db/session.py
@@ -1,5 +1,9 @@
+import logging
 from collections.abc import AsyncIterator
+from pathlib import Path
 
+from alembic import command
+from alembic.config import Config
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
@@ -8,6 +12,8 @@ from sqlalchemy.ext.asyncio import (
 )
 
 from app.core.config import get_settings
+
+logger = logging.getLogger(__name__)
 
 _engine: AsyncEngine | None = None
 _session_factory: async_sessionmaker[AsyncSession] | None = None
@@ -60,10 +66,31 @@ async def get_db_session() -> AsyncIterator[AsyncSession]:
         yield session
 
 
+def _alembic_ini_path() -> Path:
+    # alembic.ini lives at the package root (backend/api/alembic.ini),
+    # two levels above this file (app/db/session.py).
+    return Path(__file__).resolve().parents[2] / "alembic.ini"
+
+
+def _run_migrations_sync(database_url: str) -> None:
+    cfg = Config(str(_alembic_ini_path()))
+    cfg.set_main_option("sqlalchemy.url", database_url)
+    command.upgrade(cfg, "head")
+
+
 async def init_db() -> None:
     settings = get_settings()
-    if settings.DATABASE_URL:
-        get_engine()
+    if not settings.DATABASE_URL:
+        return
+    get_engine()
+    if settings.RUN_MIGRATIONS_ON_STARTUP:
+        # Run alembic in a thread so the sync command doesn't block the
+        # event loop. Idempotent: alembic no-ops when already at head.
+        import asyncio
+
+        logger.info("Running alembic upgrade head on startup")
+        await asyncio.to_thread(_run_migrations_sync, settings.DATABASE_URL)
+        logger.info("Migrations applied")
 
 
 async def close_db() -> None:

--- a/backend/api/app/main.py
+++ b/backend/api/app/main.py
@@ -16,6 +16,7 @@ from app.api.v1 import (
     saved_analyses,
     user,
     version,
+    workflow_runs,
 )
 from app.core.config import get_settings
 from app.core.dependencies import (
@@ -99,6 +100,11 @@ def create_app() -> FastAPI:
         tags=["saved_analyses"],
     )
     app.include_router(user.router, prefix="/api/v1/user", tags=["user"])
+    app.include_router(
+        workflow_runs.router,
+        prefix="/api/v1/workflow_runs",
+        tags=["workflow_runs"],
+    )
 
     app.mount("/api/v1/mcp", mcp_app)
 

--- a/backend/api/app/main.py
+++ b/backend/api/app/main.py
@@ -13,6 +13,7 @@ from app.api.v1 import (
     favorites,
     health,
     links,
+    saved_analyses,
     user,
     version,
 )
@@ -92,6 +93,11 @@ def create_app() -> FastAPI:
     app.include_router(assistant.router, prefix="/api/v1/assistant", tags=["assistant"])
     app.include_router(auth.router, prefix="/api/v1/auth", tags=["auth"])
     app.include_router(favorites.router, prefix="/api/v1/favorites", tags=["favorites"])
+    app.include_router(
+        saved_analyses.router,
+        prefix="/api/v1/saved_analyses",
+        tags=["saved_analyses"],
+    )
     app.include_router(user.router, prefix="/api/v1/user", tags=["user"])
 
     app.mount("/api/v1/mcp", mcp_app)

--- a/backend/api/app/main.py
+++ b/backend/api/app/main.py
@@ -5,7 +5,17 @@ import sentry_sdk
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from app.api.v1 import assistant, auth, cache, ena, health, links, user, version
+from app.api.v1 import (
+    assistant,
+    auth,
+    cache,
+    ena,
+    favorites,
+    health,
+    links,
+    user,
+    version,
+)
 from app.core.config import get_settings
 from app.core.dependencies import (
     get_auth_service,
@@ -81,6 +91,7 @@ def create_app() -> FastAPI:
     app.include_router(ena.router, prefix="/api/v1/ena", tags=["ena"])
     app.include_router(assistant.router, prefix="/api/v1/assistant", tags=["assistant"])
     app.include_router(auth.router, prefix="/api/v1/auth", tags=["auth"])
+    app.include_router(favorites.router, prefix="/api/v1/favorites", tags=["favorites"])
     app.include_router(user.router, prefix="/api/v1/user", tags=["user"])
 
     app.mount("/api/v1/mcp", mcp_app)

--- a/backend/api/app/main.py
+++ b/backend/api/app/main.py
@@ -5,7 +5,7 @@ import sentry_sdk
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from app.api.v1 import assistant, auth, cache, ena, health, links, version
+from app.api.v1 import assistant, auth, cache, ena, health, links, user, version
 from app.core.config import get_settings
 from app.core.dependencies import (
     get_auth_service,
@@ -14,6 +14,7 @@ from app.core.dependencies import (
     get_ena_service,
     reset_all_services,
 )
+from app.db.session import close_db, init_db
 from app.services.mcp_server import create_mcp_server
 
 logger = logging.getLogger(__name__)
@@ -45,10 +46,13 @@ def create_app() -> FastAPI:
             await cache_service.flush_all()
             logger.info("Cache cleared on startup")
 
+            await init_db()
+
             yield
 
             auth_service = get_auth_service()
             await auth_service.close()
+            await close_db()
             await cache_service.close()
             reset_all_services()
             logger.info("All services shut down")
@@ -77,6 +81,7 @@ def create_app() -> FastAPI:
     app.include_router(ena.router, prefix="/api/v1/ena", tags=["ena"])
     app.include_router(assistant.router, prefix="/api/v1/assistant", tags=["assistant"])
     app.include_router(auth.router, prefix="/api/v1/auth", tags=["auth"])
+    app.include_router(user.router, prefix="/api/v1/user", tags=["user"])
 
     app.mount("/api/v1/mcp", mcp_app)
 

--- a/backend/api/app/models/assistant.py
+++ b/backend/api/app/models/assistant.py
@@ -120,6 +120,7 @@ class SessionState(BaseModel):
     """The full state stored in Redis for one assistant session."""
 
     session_id: str
+    owner_keycloak_sub: Optional[str] = None
     schema_state: AnalysisSchema = Field(default_factory=AnalysisSchema)
     messages: List[ChatMessage] = Field(default_factory=list)
     suggestions: List[SuggestionChip] = Field(default_factory=list)

--- a/backend/api/app/models/user_data.py
+++ b/backend/api/app/models/user_data.py
@@ -1,0 +1,54 @@
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.models.assistant import AnalysisSchema, ChatMessage
+
+
+class UserPreferences(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+
+class UserMeResponse(BaseModel):
+    email: str | None = None
+    email_verified: bool | None = None
+    family_name: str | None = None
+    given_name: str | None = None
+    name: str | None = None
+    preferred_username: str | None = None
+    preferences: UserPreferences = Field(default_factory=UserPreferences)
+    realm_roles: list[str] = Field(default_factory=list)
+    sub: str
+
+
+class FavoritePayload(BaseModel):
+    entity_id: str = Field(min_length=1, max_length=255)
+    entity_type: str = Field(min_length=1, max_length=64)
+
+
+class FavoriteResponse(FavoritePayload):
+    created_at: datetime
+
+
+class SaveAnalysisRequest(BaseModel):
+    session_id: str = Field(min_length=1, max_length=255)
+    title: str | None = Field(default=None, max_length=255)
+
+
+class SavedAnalysisSummary(BaseModel):
+    created_at: datetime
+    id: str
+    source_session: str | None = None
+    title: str | None = None
+    updated_at: datetime
+
+
+class SavedAnalysisDetail(SavedAnalysisSummary):
+    messages: list[ChatMessage]
+    schema_state: AnalysisSchema = Field(alias="schema")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class SavedAnalysisRestoreResponse(BaseModel):
+    session_id: str

--- a/backend/api/app/models/user_data.py
+++ b/backend/api/app/models/user_data.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from app.models.assistant import AnalysisSchema, ChatMessage
 
@@ -41,6 +41,11 @@ class SavedAnalysisSummary(BaseModel):
     source_session: str | None = None
     title: str | None = None
     updated_at: datetime
+
+    @field_validator("id", mode="before")
+    @classmethod
+    def _coerce_id_to_str(cls, value):
+        return str(value)
 
 
 class SavedAnalysisDetail(SavedAnalysisSummary):

--- a/backend/api/app/models/workflow_runs.py
+++ b/backend/api/app/models/workflow_runs.py
@@ -1,0 +1,33 @@
+import uuid
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class WorkflowRunCreateRequest(BaseModel):
+    workflow_trs_id: str = Field(min_length=1, max_length=255)
+    workflow_id: str | None = Field(default=None, max_length=255)
+    galaxy_instance_url: str | None = Field(default=None, max_length=2048)
+    handoff_url: str = Field(min_length=1, max_length=8192)
+    assembly_accession: str | None = Field(default=None, max_length=255)
+    launch_source: str = Field(default="site", min_length=1, max_length=64)
+    assistant_session_id: str | None = Field(default=None, max_length=255)
+    parameters: dict[str, Any] = Field(default_factory=dict)
+
+
+class WorkflowRunResponse(BaseModel):
+    id: uuid.UUID
+    workflow_trs_id: str
+    workflow_id: str | None = None
+    galaxy_instance_url: str | None = None
+    handoff_url: str
+    assembly_accession: str | None = None
+    launch_source: str
+    assistant_session_id: str | None = None
+    galaxy_invocation_id: str | None = None
+    status: str
+    parameters: dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime
+    updated_at: datetime
+    completed_at: datetime | None = None

--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -27,6 +27,7 @@ from app.models.assistant import (
     FieldStatus,
     MessageRole,
     SchemaField,
+    SessionState,
     SuggestionChip,
     TokenUsage,
 )
@@ -506,7 +507,10 @@ class AssistantAgent:
             ) from e
 
     async def chat(
-        self, message: str, session_id: Optional[str] = None
+        self,
+        message: str,
+        session_id: Optional[str] = None,
+        owner_keycloak_sub: Optional[str] = None,
     ) -> ChatResponse:
         """Process one user message and return the assistant's reply.
 
@@ -518,9 +522,20 @@ class AssistantAgent:
         # Get or create session
         state = None
         if session_id:
-            state = await self.session_service.get_session(session_id)
+            try:
+                state = await self.session_service.require_session(
+                    session_id, owner_keycloak_sub
+                )
+            except PermissionError as e:
+                raise RuntimeError(
+                    "Assistant session does not belong to this user"
+                ) from e
+            except KeyError:
+                state = None
         if state is None:
-            state = await self.session_service.create_session()
+            state = await self.session_service.create_session(
+                owner_keycloak_sub=owner_keycloak_sub
+            )
 
         # Record user message
         state.messages.append(ChatMessage(role=MessageRole.USER, content=message))
@@ -600,6 +615,19 @@ class AssistantAgent:
             is_complete=is_complete,
             handoff_url=handoff_url,
             token_usage=token_usage,
+        )
+
+    async def restore_saved_session(
+        self,
+        *,
+        owner_keycloak_sub: str,
+        schema_state: AnalysisSchema,
+        messages: list[ChatMessage],
+    ) -> SessionState:
+        return await self.session_service.create_session(
+            owner_keycloak_sub=owner_keycloak_sub,
+            schema_state=schema_state,
+            messages=messages,
         )
 
     def _parse_structured_output(

--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -381,8 +381,18 @@ class AssistantAgent:
         return None
 
     @staticmethod
-    def compute_handoff(schema_state: AnalysisSchema) -> tuple[bool, Optional[str]]:
-        """Compute is_complete and handoff_url from schema state."""
+    def compute_handoff(
+        schema_state: AnalysisSchema,
+        session_id: Optional[str] = None,
+    ) -> tuple[bool, Optional[str]]:
+        """Compute is_complete and handoff_url from schema state.
+
+        When a session_id is supplied, append it as an `assistantSessionId`
+        query param so the Galaxy launch tracker can correlate the run
+        with the assistant session that produced it. Callers that have a
+        session in hand (chat, restore_session) should always pass it;
+        callers that don't (e.g. ad-hoc compute) can leave it unset.
+        """
         handoff_url = None
         if schema_state.is_complete():
             accession = schema_state.assembly.detail or ""
@@ -393,6 +403,11 @@ class AssistantAgent:
                 handoff_url = (
                     f"/data/assemblies/{entity_id}/analyze/workflows/{workflow_id}"
                 )
+                if session_id:
+                    handoff_url = (
+                        f"{handoff_url}?"
+                        f"{urlencode({'assistantSessionId': session_id})}"
+                    )
         return handoff_url is not None, handoff_url
 
     @staticmethod
@@ -610,13 +625,9 @@ class AssistantAgent:
         self._cap_state_messages(state)
         await self.session_service.save_session(state)
 
-        is_complete, handoff_url = self.compute_handoff(schema_state)
-        # Append assistantSessionId query param so the frontend can correlate
-        # a Galaxy handoff back to the assistant session that produced it.
-        if handoff_url:
-            handoff_url = (
-                f"{handoff_url}?{urlencode({'assistantSessionId': state.session_id})}"
-            )
+        is_complete, handoff_url = self.compute_handoff(
+            schema_state, session_id=state.session_id
+        )
 
         return ChatResponse(
             session_id=state.session_id,

--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -72,10 +72,6 @@ def _should_retry_agent_error(exc: BaseException) -> bool:
     return not isinstance(exc, AssistantTimeoutError)
 
 
-def _format_trs_id_for_url(trs_id: str) -> str:
-    return re.sub(r"[^a-zA-Z0-9]", "-", trs_id.removeprefix("#"))
-
-
 SYSTEM_PROMPT = """\
 You are the BRC Analytics Analysis Assistant, an expert in bioinformatics \
 who helps researchers discover data and configure analyses for execution in Galaxy.
@@ -405,8 +401,7 @@ class AssistantAgent:
                 )
                 if session_id:
                     handoff_url = (
-                        f"{handoff_url}?"
-                        f"{urlencode({'assistantSessionId': session_id})}"
+                        f"{handoff_url}?{urlencode({'assistantSessionId': session_id})}"
                     )
         return handoff_url is not None, handoff_url
 

--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -76,6 +76,7 @@ def _should_retry_agent_error(exc: BaseException) -> bool:
 def _format_trs_id_for_url(trs_id: str) -> str:
     return re.sub(r"[^a-zA-Z0-9]", "-", trs_id.removeprefix("#"))
 
+
 SYSTEM_PROMPT = """\
 You are the BRC Analytics Analysis Assistant, an expert in bioinformatics \
 who helps researchers discover data and configure analyses for execution in Galaxy.

--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -72,7 +72,6 @@ def _should_retry_agent_error(exc: BaseException) -> bool:
     return not isinstance(exc, AssistantTimeoutError)
 
 
-
 def _format_trs_id_for_url(trs_id: str) -> str:
     return re.sub(r"[^a-zA-Z0-9]", "-", trs_id.removeprefix("#"))
 
@@ -616,8 +615,7 @@ class AssistantAgent:
         # a Galaxy handoff back to the assistant session that produced it.
         if handoff_url:
             handoff_url = (
-                f"{handoff_url}?"
-                f"{urlencode({'assistantSessionId': state.session_id})}"
+                f"{handoff_url}?{urlencode({'assistantSessionId': state.session_id})}"
             )
 
         return ChatResponse(

--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -538,13 +538,12 @@ class AssistantAgent:
         state = None
         if session_id:
             try:
+                # PermissionError (session owned by a different user) is left
+                # to propagate so the API layer can return a 403 rather than
+                # folding it into the generic 503 RuntimeError path.
                 state = await self.session_service.require_session(
                     session_id, owner_keycloak_sub
                 )
-            except PermissionError as e:
-                raise RuntimeError(
-                    "Assistant session does not belong to this user"
-                ) from e
             except KeyError:
                 state = None
         if state is None:

--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -7,6 +7,7 @@ import logging
 import re
 import time
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlencode
 
 from pydantic_ai import Agent, RunContext, Tool
 from pydantic_ai.messages import ModelMessage, ModelMessagesTypeAdapter
@@ -70,6 +71,10 @@ class AssistantTimeoutError(RuntimeError):
 def _should_retry_agent_error(exc: BaseException) -> bool:
     return not isinstance(exc, AssistantTimeoutError)
 
+
+
+def _format_trs_id_for_url(trs_id: str) -> str:
+    return re.sub(r"[^a-zA-Z0-9]", "-", trs_id.removeprefix("#"))
 
 SYSTEM_PROMPT = """\
 You are the BRC Analytics Analysis Assistant, an expert in bioinformatics \
@@ -606,6 +611,13 @@ class AssistantAgent:
         await self.session_service.save_session(state)
 
         is_complete, handoff_url = self.compute_handoff(schema_state)
+        # Append assistantSessionId query param so the frontend can correlate
+        # a Galaxy handoff back to the assistant session that produced it.
+        if handoff_url:
+            handoff_url = (
+                f"{handoff_url}?"
+                f"{urlencode({'assistantSessionId': state.session_id})}"
+            )
 
         return ChatResponse(
             session_id=state.session_id,

--- a/backend/api/app/services/session_service.py
+++ b/backend/api/app/services/session_service.py
@@ -66,6 +66,30 @@ class SessionService:
 
         return state
 
+    async def claim_session(
+        self, session_id: str, owner_keycloak_sub: str
+    ) -> SessionState:
+        """Stamp owner_keycloak_sub onto an anonymous session.
+
+        Use when an authenticated user touches a session that was started
+        anonymously -- the caller MUST have separately verified possession
+        (e.g. via the signed session cookie) before invoking this.
+
+        Returns the (possibly updated) session. Raises KeyError if the
+        session is missing and PermissionError if it is already owned by
+        a different user.
+        """
+        state = await self.get_session(session_id)
+        if state is None:
+            raise KeyError(session_id)
+        if state.owner_keycloak_sub is None:
+            state.owner_keycloak_sub = owner_keycloak_sub
+            await self._save(state)
+            logger.info("Claimed anonymous assistant session %s for user", session_id)
+        elif state.owner_keycloak_sub != owner_keycloak_sub:
+            raise PermissionError(session_id)
+        return state
+
     async def delete_session(self, session_id: str) -> bool:
         return await self.cache.delete(self._key(session_id))
 

--- a/backend/api/app/services/session_service.py
+++ b/backend/api/app/services/session_service.py
@@ -6,7 +6,7 @@ from typing import Optional
 from pydantic_core import to_json
 
 from app.core.cache import CacheService
-from app.models.assistant import SessionState
+from app.models.assistant import AnalysisSchema, ChatMessage, SessionState
 
 logger = logging.getLogger(__name__)
 
@@ -23,9 +23,20 @@ class SessionService:
     def _key(self, session_id: str) -> str:
         return f"{SESSION_PREFIX}:{session_id}"
 
-    async def create_session(self) -> SessionState:
+    async def create_session(
+        self,
+        owner_keycloak_sub: str | None = None,
+        *,
+        schema_state: AnalysisSchema | None = None,
+        messages: list[ChatMessage] | None = None,
+    ) -> SessionState:
         session_id = uuid.uuid4().hex
-        state = SessionState(session_id=session_id)
+        state = SessionState(
+            session_id=session_id,
+            owner_keycloak_sub=owner_keycloak_sub,
+            schema_state=schema_state or AnalysisSchema(),
+            messages=messages or [],
+        )
         await self._save(state)
         logger.info(f"Created assistant session {session_id}")
         return state
@@ -42,6 +53,18 @@ class SessionService:
 
     async def save_session(self, state: SessionState) -> None:
         await self._save(state)
+
+    async def require_session(
+        self, session_id: str, owner_keycloak_sub: str | None
+    ) -> SessionState:
+        state = await self.get_session(session_id)
+        if state is None:
+            raise KeyError(session_id)
+
+        if state.owner_keycloak_sub != owner_keycloak_sub:
+            raise PermissionError(session_id)
+
+        return state
 
     async def delete_session(self, session_id: str) -> bool:
         return await self.cache.delete(self._key(session_id))

--- a/backend/api/pyproject.toml
+++ b/backend/api/pyproject.toml
@@ -8,6 +8,9 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
+    "aiosqlite>=0.21.0",
+    "alembic>=1.13.2",
+    "asyncpg>=0.29.0",
     "fastapi>=0.116.1",
     "fastmcp>=3.0.0",
     "httpx>=0.28.1",
@@ -15,6 +18,7 @@ dependencies = [
     "pydantic-ai==1.68.0",
     "python-dotenv>=1.1.1",
     "redis>=6.4.0",
+    "sqlalchemy[asyncio]>=2.0.36",
     "tenacity>=8.2.0",
     "pyjwt>=2.9.0",
     "sentry-sdk[fastapi]==2.55.0",
@@ -36,4 +40,3 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["app"]
-

--- a/backend/api/tests/test_assistant_agent.py
+++ b/backend/api/tests/test_assistant_agent.py
@@ -1,7 +1,8 @@
 """Tests for AssistantAgent parsing and schema update logic."""
 
 import asyncio
-from unittest.mock import MagicMock
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from pydantic_ai.messages import (
@@ -15,8 +16,12 @@ from pydantic_ai.messages import (
 
 from app.models.assistant import (
     AnalysisSchema,
+    ChatMessage,
     FieldStatus,
+    MessageRole,
     SchemaField,
+    SessionState,
+    SuggestionChip,
 )
 from app.services.assistant_agent import (
     MAX_HISTORY_MESSAGES,
@@ -608,6 +613,7 @@ class TestTruncateHistory:
         assert result == []
 
 
+<<<<<<< HEAD
 # ---------- get_provider ----------
 
 
@@ -736,3 +742,65 @@ class TestUserInputFencing:
         from app.services.assistant_agent import SYSTEM_PROMPT
 
         assert "<user_input>" in SYSTEM_PROMPT
+
+
+@pytest.mark.asyncio
+async def test_chat_handoff_url_carries_assistant_session_id(agent):
+    state = SessionState(
+        session_id="assistant-session-123",
+        schema_state=AnalysisSchema(),
+        messages=[],
+    )
+
+    agent.agent = object()
+    agent.session_service = SimpleNamespace(
+        create_session=AsyncMock(return_value=state),
+        require_session=AsyncMock(),
+        save_session=AsyncMock(),
+    )
+    agent._run_agent_with_retry = AsyncMock(
+        return_value=SimpleNamespace(
+            output=(
+                "Ready to go.\n"
+                'SCHEMA_UPDATE: {"organism": "Plasmodium falciparum", '
+                '"assembly": "GCF_000001405.40", '
+                '"analysis_type": "Variant calling", '
+                '"workflow": "Haploid variant workflow (varcall-haploid)", '
+                '"data_source": "ENA", '
+                '"data_characteristics": "Paired-end reads"}'
+            ),
+            usage=lambda: SimpleNamespace(
+                input_tokens=1,
+                output_tokens=1,
+                requests=1,
+                tool_calls=0,
+                total_tokens=2,
+            ),
+            all_messages=lambda: [],
+        )
+    )
+    agent.catalog.workflows_by_category = [
+        {
+            "category": "VARIANT_CALLING",
+            "workflows": [
+                {
+                    "iwcId": "varcall-haploid",
+                    "trsId": "#workflow/github.com/iwc/varcall-haploid/main",
+                }
+            ],
+        }
+    ]
+
+    response = await agent.chat("Help me configure this analysis")
+
+    assert response.is_complete is True
+    # URL shape produced by main's compute_handoff (sanitized accession +
+    # /analyze/workflows/ segment), with brc-db's assistantSessionId query
+    # param appended.
+    assert (
+        response.handoff_url
+        == "/data/assemblies/GCF_000001405_40/analyze/workflows/workflow-github-com-iwc-varcall-haploid-main?assistantSessionId=assistant-session-123"
+    )
+    assert state.messages[-1] == ChatMessage(
+        role=MessageRole.ASSISTANT, content="Ready to go."
+    )

--- a/backend/api/tests/test_assistant_agent.py
+++ b/backend/api/tests/test_assistant_agent.py
@@ -613,7 +613,6 @@ class TestTruncateHistory:
         assert result == []
 
 
-<<<<<<< HEAD
 # ---------- get_provider ----------
 
 

--- a/backend/api/tests/test_assistant_endpoints.py
+++ b/backend/api/tests/test_assistant_endpoints.py
@@ -122,6 +122,30 @@ class TestSessionCookieBinding:
         resp = client.delete("/api/v1/assistant/session/sess-abc")
         assert resp.status_code == 204
 
+    def test_logout_clears_assistant_session_cookie(self, client):
+        # A shared browser must not keep the prior user's assistant session
+        # reachable after logout -- the restore/delete endpoints gate purely
+        # on possession of this cookie.
+        # Key the override on the reference the route actually captured at
+        # import (monkeypatching app.core.dependencies doesn't rebind it).
+        from app.api.v1 import auth as auth_module
+
+        fake_auth = MagicMock()
+        fake_auth.revoke_session_tokens = AsyncMock()
+        client.app.dependency_overrides[auth_module.get_auth_service] = (
+            lambda: fake_auth
+        )
+
+        client.cookies.set("brc_assistant_session", sign_session_id("sess-abc", SECRET))
+        resp = client.post("/api/v1/auth/logout")
+        assert resp.status_code == 200, resp.text
+        cleared = [
+            h
+            for h in resp.headers.get_list("set-cookie")
+            if h.startswith("brc_assistant_session=") and "Max-Age=0" in h
+        ]
+        assert cleared, resp.headers.get_list("set-cookie")
+
 
 class TestAnonymousSessionClaim:
     """When an authenticated user continues a session started anonymously,

--- a/backend/api/tests/test_assistant_endpoints.py
+++ b/backend/api/tests/test_assistant_endpoints.py
@@ -14,6 +14,7 @@ from app.models.assistant import (
     ChatResponse,
     SessionState,
 )
+from app.models.user_data import UserMeResponse
 from tests.test_catalog_data import SAMPLE_ORGANISMS, SAMPLE_WORKFLOWS
 
 SECRET = "test-secret-aaaaaaaaaaaaaaaaaaaa"
@@ -120,3 +121,94 @@ class TestSessionCookieBinding:
         client.cookies.set("brc_assistant_session", sign_session_id("sess-abc", SECRET))
         resp = client.delete("/api/v1/assistant/session/sess-abc")
         assert resp.status_code == 204
+
+
+class TestAnonymousSessionClaim:
+    """When an authenticated user continues a session started anonymously,
+    /chat should claim it on their behalf (gated on cookie possession)."""
+
+    def _override_user(self, app, sub):
+        from app.core.dependencies import get_optional_current_user
+
+        async def _current_user():
+            return UserMeResponse(sub=sub)
+
+        app.dependency_overrides[get_optional_current_user] = _current_user
+
+    def test_authenticated_chat_claims_anonymous_session(
+        self, app_with_stubbed_agent, client
+    ):
+        agent = app_with_stubbed_agent.dependency_overrides[
+            __import__(
+                "app.core.dependencies", fromlist=["get_assistant_agent"]
+            ).get_assistant_agent
+        ]()
+        agent.session_service.claim_session = AsyncMock(
+            return_value=SessionState(
+                session_id="sess-abc", owner_keycloak_sub="user-a"
+            )
+        )
+        self._override_user(app_with_stubbed_agent, "user-a")
+        client.cookies.set("brc_assistant_session", sign_session_id("sess-abc", SECRET))
+
+        resp = client.post(
+            "/api/v1/assistant/chat",
+            json={"message": "hello", "session_id": "sess-abc"},
+        )
+
+        assert resp.status_code == 200, resp.text
+        agent.session_service.claim_session.assert_awaited_once_with(
+            "sess-abc", "user-a"
+        )
+
+    def test_authenticated_chat_without_cookie_is_rejected(
+        self, app_with_stubbed_agent, client
+    ):
+        self._override_user(app_with_stubbed_agent, "user-a")
+        # No cookie set -- claim attempt should fail at the cookie check.
+        resp = client.post(
+            "/api/v1/assistant/chat",
+            json={"message": "hello", "session_id": "sess-abc"},
+        )
+        assert resp.status_code == 403
+
+    def test_authenticated_chat_rejects_claim_when_owned_by_other_user(
+        self, app_with_stubbed_agent, client
+    ):
+        agent = app_with_stubbed_agent.dependency_overrides[
+            __import__(
+                "app.core.dependencies", fromlist=["get_assistant_agent"]
+            ).get_assistant_agent
+        ]()
+        agent.session_service.claim_session = AsyncMock(
+            side_effect=PermissionError("sess-abc")
+        )
+        self._override_user(app_with_stubbed_agent, "user-b")
+        client.cookies.set("brc_assistant_session", sign_session_id("sess-abc", SECRET))
+
+        resp = client.post(
+            "/api/v1/assistant/chat",
+            json={"message": "hello", "session_id": "sess-abc"},
+        )
+
+        assert resp.status_code == 403
+        assert "another user" in resp.json()["detail"]
+
+    def test_anonymous_chat_does_not_attempt_claim(
+        self, app_with_stubbed_agent, client
+    ):
+        agent = app_with_stubbed_agent.dependency_overrides[
+            __import__(
+                "app.core.dependencies", fromlist=["get_assistant_agent"]
+            ).get_assistant_agent
+        ]()
+        agent.session_service.claim_session = AsyncMock()
+        # No authenticated-user override -- caller is anonymous.
+
+        resp = client.post(
+            "/api/v1/assistant/chat",
+            json={"message": "hello", "session_id": "sess-abc"},
+        )
+
+        assert resp.status_code == 200, resp.text
+        agent.session_service.claim_session.assert_not_awaited()

--- a/backend/api/tests/test_assistant_endpoints.py
+++ b/backend/api/tests/test_assistant_endpoints.py
@@ -194,6 +194,25 @@ class TestAnonymousSessionClaim:
         assert resp.status_code == 403
         assert "another user" in resp.json()["detail"]
 
+    def test_chat_maps_permission_error_to_403(self, app_with_stubbed_agent, client):
+        # An anonymous caller citing a session owned by someone else skips the
+        # claim block and hits agent.chat(), which raises PermissionError from
+        # require_session(). That must surface as 403, not the generic 503.
+        agent = app_with_stubbed_agent.dependency_overrides[
+            __import__(
+                "app.core.dependencies", fromlist=["get_assistant_agent"]
+            ).get_assistant_agent
+        ]()
+        agent.chat = AsyncMock(side_effect=PermissionError("sess-abc"))
+
+        resp = client.post(
+            "/api/v1/assistant/chat",
+            json={"message": "hello", "session_id": "sess-abc"},
+        )
+
+        assert resp.status_code == 403
+        assert "another user" in resp.json()["detail"]
+
     def test_anonymous_chat_does_not_attempt_claim(
         self, app_with_stubbed_agent, client
     ):

--- a/backend/api/tests/test_assistant_endpoints.py
+++ b/backend/api/tests/test_assistant_endpoints.py
@@ -146,6 +146,23 @@ class TestSessionCookieBinding:
         ]
         assert cleared, resp.headers.get_list("set-cookie")
 
+    def test_anonymous_chat_with_session_id_requires_cookie(self, client):
+        # Continuing a session by id must require the signed cookie even for
+        # anonymous callers -- session ids leak via URLs (assistantSessionId).
+        resp = client.post(
+            "/api/v1/assistant/chat",
+            json={"message": "hello", "session_id": "sess-abc"},
+        )
+        assert resp.status_code == 403
+
+    def test_anonymous_chat_with_session_id_and_valid_cookie_succeeds(self, client):
+        client.cookies.set("brc_assistant_session", sign_session_id("sess-abc", SECRET))
+        resp = client.post(
+            "/api/v1/assistant/chat",
+            json={"message": "hello", "session_id": "sess-abc"},
+        )
+        assert resp.status_code == 200, resp.text
+
 
 class TestAnonymousSessionClaim:
     """When an authenticated user continues a session started anonymously,
@@ -219,15 +236,17 @@ class TestAnonymousSessionClaim:
         assert "another user" in resp.json()["detail"]
 
     def test_chat_maps_permission_error_to_403(self, app_with_stubbed_agent, client):
-        # An anonymous caller citing a session owned by someone else skips the
-        # claim block and hits agent.chat(), which raises PermissionError from
-        # require_session(). That must surface as 403, not the generic 503.
+        # An anonymous caller holding the session cookie but citing a session
+        # owned by someone else skips the claim block and hits agent.chat(),
+        # which raises PermissionError from require_session(). That must
+        # surface as 403, not the generic 503.
         agent = app_with_stubbed_agent.dependency_overrides[
             __import__(
                 "app.core.dependencies", fromlist=["get_assistant_agent"]
             ).get_assistant_agent
         ]()
         agent.chat = AsyncMock(side_effect=PermissionError("sess-abc"))
+        client.cookies.set("brc_assistant_session", sign_session_id("sess-abc", SECRET))
 
         resp = client.post(
             "/api/v1/assistant/chat",
@@ -246,7 +265,10 @@ class TestAnonymousSessionClaim:
             ).get_assistant_agent
         ]()
         agent.session_service.claim_session = AsyncMock()
-        # No authenticated-user override -- caller is anonymous.
+        # No authenticated-user override -- caller is anonymous. Continuing a
+        # session still requires the cookie, but an anonymous caller never
+        # triggers a claim.
+        client.cookies.set("brc_assistant_session", sign_session_id("sess-abc", SECRET))
 
         resp = client.post(
             "/api/v1/assistant/chat",

--- a/backend/api/tests/test_db_persistence.py
+++ b/backend/api/tests/test_db_persistence.py
@@ -2,9 +2,13 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from app.db.crud import (
+    create_saved_analysis,
     delete_favorite,
+    delete_saved_analysis,
+    get_saved_analysis,
     get_user_by_keycloak_sub,
     list_favorites_for_user,
+    list_saved_analyses_for_user,
     upsert_favorite,
     upsert_user_from_claims,
 )
@@ -78,3 +82,37 @@ async def test_favorite_crud_round_trip():
 
         assert deleted is True
         assert favorites_after_delete == []
+
+
+@pytest.mark.asyncio
+async def test_saved_analysis_crud_round_trip():
+    async with await _create_session() as session:
+        user = await upsert_user_from_claims(
+            session,
+            {
+                "sub": "kc-789",
+                "email": "saved@example.com",
+                "name": "Saved User",
+            },
+        )
+
+        saved_analysis = await create_saved_analysis(
+            session,
+            user,
+            title="Saved analysis title",
+            schema={"organism": {"status": "filled", "value": "Influenza A", "detail": None}},
+            messages=[{"role": "user", "content": "Help me analyze influenza"}],
+            source_session="session-123",
+        )
+        saved_analyses = await list_saved_analyses_for_user(session, user)
+        fetched = await get_saved_analysis(session, user, str(saved_analysis.id))
+
+        assert len(saved_analyses) == 1
+        assert fetched is not None
+        assert fetched.title == "Saved analysis title"
+
+        deleted = await delete_saved_analysis(session, user, str(saved_analysis.id))
+        saved_analyses_after_delete = await list_saved_analyses_for_user(session, user)
+
+        assert deleted is True
+        assert saved_analyses_after_delete == []

--- a/backend/api/tests/test_db_persistence.py
+++ b/backend/api/tests/test_db_persistence.py
@@ -100,7 +100,9 @@ async def test_saved_analysis_crud_round_trip():
             session,
             user,
             title="Saved analysis title",
-            schema={"organism": {"status": "filled", "value": "Influenza A", "detail": None}},
+            schema={
+                "organism": {"status": "filled", "value": "Influenza A", "detail": None}
+            },
             messages=[{"role": "user", "content": "Help me analyze influenza"}],
             source_session="session-123",
         )

--- a/backend/api/tests/test_db_persistence.py
+++ b/backend/api/tests/test_db_persistence.py
@@ -1,0 +1,49 @@
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.db.crud import get_user_by_keycloak_sub, upsert_user_from_claims
+from app.db.models import Base
+
+
+async def _create_session() -> AsyncSession:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+
+    session_factory = async_sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
+    return session_factory()
+
+
+@pytest.mark.asyncio
+async def test_upsert_user_from_claims_creates_and_updates_user():
+    async with await _create_session() as session:
+        user = await upsert_user_from_claims(
+            session,
+            {
+                "sub": "kc-123",
+                "email": "first@example.com",
+                "name": "First User",
+            },
+        )
+
+        assert user.keycloak_sub == "kc-123"
+        assert user.email == "first@example.com"
+        assert user.name == "First User"
+
+        updated_user = await upsert_user_from_claims(
+            session,
+            {
+                "sub": "kc-123",
+                "email": "updated@example.com",
+                "name": "Updated User",
+            },
+        )
+
+        fetched = await get_user_by_keycloak_sub(session, "kc-123")
+
+        assert fetched is not None
+        assert updated_user.id == user.id
+        assert fetched.email == "updated@example.com"
+        assert fetched.name == "Updated User"

--- a/backend/api/tests/test_db_persistence.py
+++ b/backend/api/tests/test_db_persistence.py
@@ -1,7 +1,13 @@
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
-from app.db.crud import get_user_by_keycloak_sub, upsert_user_from_claims
+from app.db.crud import (
+    delete_favorite,
+    get_user_by_keycloak_sub,
+    list_favorites_for_user,
+    upsert_favorite,
+    upsert_user_from_claims,
+)
 from app.db.models import Base
 
 
@@ -47,3 +53,28 @@ async def test_upsert_user_from_claims_creates_and_updates_user():
         assert updated_user.id == user.id
         assert fetched.email == "updated@example.com"
         assert fetched.name == "Updated User"
+
+
+@pytest.mark.asyncio
+async def test_favorite_crud_round_trip():
+    async with await _create_session() as session:
+        user = await upsert_user_from_claims(
+            session,
+            {
+                "sub": "kc-456",
+                "email": "fav@example.com",
+                "name": "Favorite User",
+            },
+        )
+
+        favorite = await upsert_favorite(session, user, "assembly", "GCF_000001405.40")
+        favorites = await list_favorites_for_user(session, user)
+
+        assert favorite.entity_id == "GCF_000001405.40"
+        assert [item.entity_id for item in favorites] == ["GCF_000001405.40"]
+
+        deleted = await delete_favorite(session, user, "assembly", "GCF_000001405.40")
+        favorites_after_delete = await list_favorites_for_user(session, user)
+
+        assert deleted is True
+        assert favorites_after_delete == []

--- a/backend/api/tests/test_db_persistence.py
+++ b/backend/api/tests/test_db_persistence.py
@@ -3,12 +3,14 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 
 from app.db.crud import (
     create_saved_analysis,
+    create_workflow_run,
     delete_favorite,
     delete_saved_analysis,
     get_saved_analysis,
     get_user_by_keycloak_sub,
     list_favorites_for_user,
     list_saved_analyses_for_user,
+    list_workflow_runs_for_user,
     upsert_favorite,
     upsert_user_from_claims,
 )
@@ -118,3 +120,49 @@ async def test_saved_analysis_crud_round_trip():
 
         assert deleted is True
         assert saved_analyses_after_delete == []
+
+
+@pytest.mark.asyncio
+async def test_workflow_run_round_trip_with_and_without_user():
+    async with await _create_session() as session:
+        user = await upsert_user_from_claims(
+            session,
+            {
+                "sub": "kc-999",
+                "email": "runs@example.com",
+                "name": "Workflow Runner",
+            },
+        )
+
+        anonymous_run = await create_workflow_run(
+            session,
+            None,
+            workflow_trs_id="#workflow/github.com/iwc/rnaseq-pe/main",
+            workflow_id=None,
+            galaxy_instance_url="https://usegalaxy.org",
+            handoff_url="https://usegalaxy.org/workflow_landings/anonymous",
+            assembly_accession="GCF_000001405.40",
+            launch_source="site",
+            assistant_session_id=None,
+            parameters={"reference_assembly": "GCF_000001405.40"},
+        )
+        user_run = await create_workflow_run(
+            session,
+            user,
+            workflow_trs_id="#workflow/github.com/iwc/varcall-haploid/main",
+            workflow_id=None,
+            galaxy_instance_url="https://usegalaxy.org",
+            handoff_url="https://usegalaxy.org/workflow_landings/user",
+            assembly_accession="GCF_000001405.40",
+            launch_source="assistant",
+            assistant_session_id="assistant-session-1",
+            parameters={"read_runs_single": ["SRR000001"]},
+        )
+
+        workflow_runs = await list_workflow_runs_for_user(session, user)
+
+        assert anonymous_run.user_id is None
+        assert user_run.user_id == user.id
+        assert len(workflow_runs) == 1
+        assert workflow_runs[0].assistant_session_id == "assistant-session-1"
+        assert workflow_runs[0].workflow_trs_id.endswith("varcall-haploid/main")

--- a/backend/api/tests/test_session_service.py
+++ b/backend/api/tests/test_session_service.py
@@ -1,0 +1,38 @@
+import pytest
+
+from app.models.assistant import AnalysisSchema, ChatMessage, MessageRole
+from app.services.session_service import SessionService
+
+
+class FakeCache:
+    def __init__(self):
+        self.values: dict[str, dict] = {}
+
+    async def delete(self, key: str) -> bool:
+        return self.values.pop(key, None) is not None
+
+    async def get(self, key: str):
+        return self.values.get(key)
+
+    async def set(self, key: str, value, ttl: int = 3600) -> bool:
+        self.values[key] = value
+        return True
+
+
+@pytest.mark.asyncio
+async def test_require_session_rejects_wrong_owner():
+    cache = FakeCache()
+    service = SessionService(cache)
+
+    state = await service.create_session(
+        owner_keycloak_sub="user-a",
+        schema_state=AnalysisSchema(),
+        messages=[ChatMessage(role=MessageRole.USER, content="hello")],
+    )
+
+    with pytest.raises(PermissionError):
+        await service.require_session(state.session_id, "user-b")
+
+    loaded = await service.require_session(state.session_id, "user-a")
+
+    assert loaded.owner_keycloak_sub == "user-a"

--- a/backend/api/tests/test_session_service.py
+++ b/backend/api/tests/test_session_service.py
@@ -36,3 +36,48 @@ async def test_require_session_rejects_wrong_owner():
     loaded = await service.require_session(state.session_id, "user-a")
 
     assert loaded.owner_keycloak_sub == "user-a"
+
+
+@pytest.mark.asyncio
+async def test_claim_session_stamps_owner_on_anonymous_session():
+    cache = FakeCache()
+    service = SessionService(cache)
+
+    state = await service.create_session()
+    assert state.owner_keycloak_sub is None
+
+    claimed = await service.claim_session(state.session_id, "user-a")
+    assert claimed.owner_keycloak_sub == "user-a"
+
+    # Round-trip through cache: ownership must persist.
+    reloaded = await service.get_session(state.session_id)
+    assert reloaded.owner_keycloak_sub == "user-a"
+
+
+@pytest.mark.asyncio
+async def test_claim_session_is_noop_when_already_owned_by_caller():
+    cache = FakeCache()
+    service = SessionService(cache)
+
+    state = await service.create_session(owner_keycloak_sub="user-a")
+    claimed = await service.claim_session(state.session_id, "user-a")
+    assert claimed.owner_keycloak_sub == "user-a"
+
+
+@pytest.mark.asyncio
+async def test_claim_session_rejects_when_owned_by_other_user():
+    cache = FakeCache()
+    service = SessionService(cache)
+
+    state = await service.create_session(owner_keycloak_sub="user-a")
+    with pytest.raises(PermissionError):
+        await service.claim_session(state.session_id, "user-b")
+
+
+@pytest.mark.asyncio
+async def test_claim_session_raises_keyerror_for_missing_session():
+    cache = FakeCache()
+    service = SessionService(cache)
+
+    with pytest.raises(KeyError):
+        await service.claim_session("does-not-exist", "user-a")

--- a/backend/api/tests/test_user_persistence_api.py
+++ b/backend/api/tests/test_user_persistence_api.py
@@ -1,0 +1,246 @@
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.core.config import get_settings
+from app.db.crud import (
+    create_saved_analysis,
+    get_user_by_keycloak_sub,
+    upsert_favorite,
+    upsert_user_from_claims,
+)
+from app.db.models import Base
+from app.db.session import get_db_session
+from app.models.assistant import AnalysisSchema, ChatMessage, MessageRole, SessionState
+from tests.test_catalog_data import SAMPLE_ORGANISMS, SAMPLE_WORKFLOWS
+
+
+class FakeSessionService:
+    def __init__(self):
+        self.sessions: dict[str, SessionState] = {}
+
+    async def require_session(
+        self, session_id: str, owner_keycloak_sub: str | None
+    ) -> SessionState:
+        state = self.sessions.get(session_id)
+        if state is None:
+            raise KeyError(session_id)
+        if state.owner_keycloak_sub != owner_keycloak_sub:
+            raise PermissionError(session_id)
+        return state
+
+
+class FakeAssistantAgent:
+    def __init__(self):
+        self.session_service = FakeSessionService()
+
+    async def restore_saved_session(
+        self,
+        *,
+        owner_keycloak_sub: str,
+        schema_state: AnalysisSchema,
+        messages: list[ChatMessage],
+    ) -> SessionState:
+        session_id = uuid4().hex
+        state = SessionState(
+            session_id=session_id,
+            owner_keycloak_sub=owner_keycloak_sub,
+            schema_state=schema_state,
+            messages=messages,
+        )
+        self.session_service.sessions[session_id] = state
+        return state
+
+
+def _write_catalog(tmp_path: Path) -> None:
+    (tmp_path / "organisms.json").write_text(json.dumps(SAMPLE_ORGANISMS))
+    (tmp_path / "workflows.json").write_text(json.dumps(SAMPLE_WORKFLOWS))
+
+
+async def _create_schema(database_url: str) -> None:
+    engine = create_async_engine(database_url)
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+    await engine.dispose()
+
+
+@pytest.fixture()
+def persistence_app(tmp_path, monkeypatch):
+    _write_catalog(tmp_path)
+    database_url = f"sqlite+aiosqlite:///{tmp_path / 'app.db'}"
+
+    monkeypatch.setenv("CATALOG_PATH", str(tmp_path))
+    monkeypatch.setenv("DATABASE_URL", database_url)
+
+    from app.core import dependencies
+
+    get_settings.cache_clear()
+    dependencies.reset_all_services()
+
+    fake_cache = MagicMock()
+    fake_cache.flush_all = AsyncMock()
+    fake_cache.close = AsyncMock()
+    fake_auth = MagicMock()
+    fake_auth.close = AsyncMock()
+    fake_llm = MagicMock()
+
+    get_cache_service = MagicMock(return_value=fake_cache)
+    get_cache_service.cache_clear = MagicMock()
+    get_auth_service = MagicMock(return_value=fake_auth)
+    get_auth_service.cache_clear = MagicMock()
+    get_llm_service = MagicMock(return_value=fake_llm)
+    get_llm_service.cache_clear = MagicMock()
+
+    monkeypatch.setattr(
+        dependencies, "get_cache_service", get_cache_service
+    )
+    monkeypatch.setattr(
+        dependencies, "get_auth_service", get_auth_service
+    )
+    monkeypatch.setattr(
+        dependencies, "get_llm_service", get_llm_service
+    )
+
+    asyncio.run(_create_schema(database_url))
+
+    from app.db.session import get_session_factory
+    from app.main import create_app
+
+    app = create_app()
+    session_factory = get_session_factory()
+    current_sub = {"value": "user-a"}
+    agent = FakeAssistantAgent()
+
+    async def override_get_db_session():
+        async with session_factory() as session:
+            yield session
+
+    async def override_get_current_user_db():
+        async with session_factory() as session:
+            user = await get_user_by_keycloak_sub(session, current_sub["value"])
+            if user is None:
+                raise AssertionError(f"Missing test user for {current_sub['value']}")
+            return user
+
+    app.dependency_overrides[get_db_session] = override_get_db_session
+    app.dependency_overrides[dependencies.get_current_user_db] = (
+        override_get_current_user_db
+    )
+    app.dependency_overrides[dependencies.get_assistant_agent] = lambda: agent
+
+    yield app, session_factory, current_sub, agent
+
+
+@pytest.fixture()
+def persistence_client(persistence_app):
+    app, session_factory, current_sub, agent = persistence_app
+
+    async def seed_users() -> None:
+        async with session_factory() as session:
+            await upsert_user_from_claims(
+                session,
+                {"sub": "user-a", "email": "a@example.com", "name": "User A"},
+            )
+            await upsert_user_from_claims(
+                session,
+                {"sub": "user-b", "email": "b@example.com", "name": "User B"},
+            )
+
+    asyncio.run(seed_users())
+
+    with TestClient(app) as client:
+        yield client, session_factory, current_sub, agent
+
+
+def test_favorites_are_scoped_to_current_user(persistence_client):
+    client, session_factory, current_sub, _agent = persistence_client
+
+    async def seed_favorite() -> None:
+        async with session_factory() as session:
+            user_a = await get_user_by_keycloak_sub(session, "user-a")
+            assert user_a is not None
+            await upsert_favorite(session, user_a, "assembly", "GCF_000001405.40")
+
+    asyncio.run(seed_favorite())
+
+    current_sub["value"] = "user-b"
+    response = client.get("/api/v1/favorites")
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+    delete_response = client.delete("/api/v1/favorites/assembly/GCF_000001405.40")
+    assert delete_response.status_code == 404
+
+
+def test_saved_analyses_are_scoped_to_current_user(persistence_client):
+    client, session_factory, current_sub, _agent = persistence_client
+
+    async def seed_saved_analysis() -> str:
+        async with session_factory() as session:
+            user_a = await get_user_by_keycloak_sub(session, "user-a")
+            assert user_a is not None
+            saved_analysis = await create_saved_analysis(
+                session,
+                user_a,
+                title="User A analysis",
+                schema=AnalysisSchema().model_dump(mode="json"),
+                messages=[
+                    ChatMessage(
+                        role=MessageRole.USER, content="analyze plasmodium"
+                    ).model_dump(mode="json")
+                ],
+                source_session="session-a",
+            )
+            return str(saved_analysis.id)
+
+    saved_analysis_id = asyncio.run(seed_saved_analysis())
+
+    current_sub["value"] = "user-b"
+
+    detail_response = client.get(f"/api/v1/saved_analyses/{saved_analysis_id}")
+    restore_response = client.post(
+        f"/api/v1/saved_analyses/{saved_analysis_id}/restore"
+    )
+    delete_response = client.delete(f"/api/v1/saved_analyses/{saved_analysis_id}")
+
+    assert detail_response.status_code == 404
+    assert restore_response.status_code == 404
+    assert delete_response.status_code == 404
+
+
+def test_saved_analysis_snapshot_rejects_cross_user_session(persistence_client):
+    client, _session_factory, current_sub, agent = persistence_client
+
+    agent.session_service.sessions["session-user-a"] = SessionState(
+        session_id="session-user-a",
+        owner_keycloak_sub="user-a",
+        messages=[ChatMessage(role=MessageRole.USER, content="save me")],
+        schema_state=AnalysisSchema(),
+    )
+
+    current_sub["value"] = "user-b"
+    response = client.post(
+        "/api/v1/saved_analyses",
+        json={"session_id": "session-user-a"},
+    )
+
+    assert response.status_code == 403
+
+
+def test_preferences_payload_is_bounded(persistence_client):
+    client, _session_factory, current_sub, _agent = persistence_client
+
+    current_sub["value"] = "user-a"
+    response = client.put(
+        "/api/v1/user/preferences",
+        json={"blob": "x" * (20 * 1024)},
+    )
+
+    assert response.status_code == 413

--- a/backend/api/tests/test_user_persistence_api.py
+++ b/backend/api/tests/test_user_persistence_api.py
@@ -9,7 +9,8 @@ from fastapi.testclient import TestClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
-from app.core.config import get_settings
+from app.core.config import SESSION_COOKIE_NAME, get_settings
+from app.core.session_signing import sign_session_id
 from app.db.crud import (
     create_saved_analysis,
     get_user_by_keycloak_sub,
@@ -277,6 +278,48 @@ def test_preferences_payload_is_bounded(persistence_client):
     )
 
     assert response.status_code == 413
+
+
+def test_saved_analysis_snapshot_enforces_session_cookie_when_secret_set(
+    persistence_client, monkeypatch
+):
+    """With SESSION_COOKIE_SECRET configured, saving an anonymous session
+    requires a valid signed cookie -- knowing the session_id is not enough.
+
+    The companion test (test_saved_analysis_snapshot_claims_anonymous_session)
+    succeeds cookieless only because its fixture leaves the secret unset; this
+    one pins the gate so it can't be silently dropped from the save endpoint.
+    """
+    client, _session_factory, current_sub, agent = persistence_client
+
+    secret = "test-cookie-secret"
+    monkeypatch.setenv("SESSION_COOKIE_SECRET", secret)
+    get_settings.cache_clear()
+
+    agent.session_service.sessions["session-anon"] = SessionState(
+        session_id="session-anon",
+        owner_keycloak_sub=None,
+        messages=[ChatMessage(role=MessageRole.USER, content="hello")],
+        schema_state=AnalysisSchema(),
+    )
+    current_sub["value"] = "user-a"
+
+    # No cookie -> rejected, session stays anonymous (gate runs before claim).
+    missing = client.post("/api/v1/saved_analyses", json={"session_id": "session-anon"})
+    assert missing.status_code == 403
+    assert agent.session_service.sessions["session-anon"].owner_keycloak_sub is None
+
+    # Wrong signature -> rejected.
+    client.cookies.set(SESSION_COOKIE_NAME, "not-a-valid-signature")
+    wrong = client.post("/api/v1/saved_analyses", json={"session_id": "session-anon"})
+    assert wrong.status_code == 403
+    client.cookies.clear()
+
+    # Valid signed cookie -> the session is claimed and saved.
+    client.cookies.set(SESSION_COOKIE_NAME, sign_session_id("session-anon", secret))
+    ok = client.post("/api/v1/saved_analyses", json={"session_id": "session-anon"})
+    assert ok.status_code == 200
+    assert agent.session_service.sessions["session-anon"].owner_keycloak_sub == "user-a"
 
 
 def test_upsert_user_recovers_from_concurrent_insert_race(persistence_app, monkeypatch):

--- a/backend/api/tests/test_user_persistence_api.py
+++ b/backend/api/tests/test_user_persistence_api.py
@@ -97,15 +97,9 @@ def persistence_app(tmp_path, monkeypatch):
     get_llm_service = MagicMock(return_value=fake_llm)
     get_llm_service.cache_clear = MagicMock()
 
-    monkeypatch.setattr(
-        dependencies, "get_cache_service", get_cache_service
-    )
-    monkeypatch.setattr(
-        dependencies, "get_auth_service", get_auth_service
-    )
-    monkeypatch.setattr(
-        dependencies, "get_llm_service", get_llm_service
-    )
+    monkeypatch.setattr(dependencies, "get_cache_service", get_cache_service)
+    monkeypatch.setattr(dependencies, "get_auth_service", get_auth_service)
+    monkeypatch.setattr(dependencies, "get_llm_service", get_llm_service)
 
     asyncio.run(_create_schema(database_url))
 

--- a/backend/api/tests/test_user_persistence_api.py
+++ b/backend/api/tests/test_user_persistence_api.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 
 import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from app.core.config import get_settings
@@ -15,7 +16,7 @@ from app.db.crud import (
     upsert_favorite,
     upsert_user_from_claims,
 )
-from app.db.models import Base
+from app.db.models import Base, User
 from app.db.session import get_db_session
 from app.models.assistant import AnalysisSchema, ChatMessage, MessageRole, SessionState
 from tests.test_catalog_data import SAMPLE_ORGANISMS, SAMPLE_WORKFLOWS
@@ -276,3 +277,58 @@ def test_preferences_payload_is_bounded(persistence_client):
     )
 
     assert response.status_code == 413
+
+
+def test_upsert_user_recovers_from_concurrent_insert_race(persistence_app, monkeypatch):
+    """A second concurrent first-login for the same sub must not 500.
+
+    Two OIDC callbacks for a brand-new user can both miss the SELECT and
+    both INSERT; the loser trips the unique keycloak_sub constraint. The
+    upsert must recover (rollback, refetch, apply claims) the way
+    upsert_favorite does, instead of letting the IntegrityError surface.
+    """
+    _app, session_factory, _current_sub, _agent = persistence_app
+
+    from app.db import crud
+
+    real_lookup = crud.get_user_by_keycloak_sub
+    lookup_calls = {"count": 0}
+
+    async def lookup_missing_first(session, keycloak_sub):
+        # Simulate losing the race: the first SELECT runs before the other
+        # transaction commits, so it sees no existing row.
+        lookup_calls["count"] += 1
+        if lookup_calls["count"] == 1:
+            return None
+        return await real_lookup(session, keycloak_sub)
+
+    async def scenario() -> None:
+        # First login lands the row normally (real lookup, not patched yet).
+        async with session_factory() as session:
+            await upsert_user_from_claims(
+                session,
+                {"sub": "racer", "email": "racer@example.com", "name": "Racer"},
+            )
+
+        # Second concurrent login: forced SELECT-miss -> INSERT -> row already
+        # exists -> IntegrityError -> must recover instead of raising.
+        monkeypatch.setattr(crud, "get_user_by_keycloak_sub", lookup_missing_first)
+        async with session_factory() as session:
+            user = await upsert_user_from_claims(
+                session,
+                {"sub": "racer", "email": "updated@example.com", "name": "Racer Two"},
+            )
+        assert user is not None
+        assert user.keycloak_sub == "racer"
+
+        # Exactly one row, and the recovering call applied its field updates.
+        monkeypatch.setattr(crud, "get_user_by_keycloak_sub", real_lookup)
+        async with session_factory() as session:
+            rows = await session.execute(
+                select(User).where(User.keycloak_sub == "racer")
+            )
+            users = list(rows.scalars().all())
+        assert len(users) == 1
+        assert users[0].email == "updated@example.com"
+
+    asyncio.run(scenario())

--- a/backend/api/tests/test_user_persistence_api.py
+++ b/backend/api/tests/test_user_persistence_api.py
@@ -102,18 +102,14 @@ def persistence_app(tmp_path, monkeypatch):
     fake_cache.close = AsyncMock()
     fake_auth = MagicMock()
     fake_auth.close = AsyncMock()
-    fake_llm = MagicMock()
 
     get_cache_service = MagicMock(return_value=fake_cache)
     get_cache_service.cache_clear = MagicMock()
     get_auth_service = MagicMock(return_value=fake_auth)
     get_auth_service.cache_clear = MagicMock()
-    get_llm_service = MagicMock(return_value=fake_llm)
-    get_llm_service.cache_clear = MagicMock()
 
     monkeypatch.setattr(dependencies, "get_cache_service", get_cache_service)
     monkeypatch.setattr(dependencies, "get_auth_service", get_auth_service)
-    monkeypatch.setattr(dependencies, "get_llm_service", get_llm_service)
 
     asyncio.run(_create_schema(database_url))
 

--- a/backend/api/tests/test_user_persistence_api.py
+++ b/backend/api/tests/test_user_persistence_api.py
@@ -35,6 +35,18 @@ class FakeSessionService:
             raise PermissionError(session_id)
         return state
 
+    async def claim_session(
+        self, session_id: str, owner_keycloak_sub: str
+    ) -> SessionState:
+        state = self.sessions.get(session_id)
+        if state is None:
+            raise KeyError(session_id)
+        if state.owner_keycloak_sub is None:
+            state.owner_keycloak_sub = owner_keycloak_sub
+        elif state.owner_keycloak_sub != owner_keycloak_sub:
+            raise PermissionError(session_id)
+        return state
+
 
 class FakeAssistantAgent:
     def __init__(self):
@@ -226,6 +238,32 @@ def test_saved_analysis_snapshot_rejects_cross_user_session(persistence_client):
     )
 
     assert response.status_code == 403
+
+
+def test_saved_analysis_snapshot_claims_anonymous_session(persistence_client):
+    """An authenticated user can save an anonymous session they started.
+
+    Mirrors the chat flow where someone starts a session logged out, then
+    signs in before saving. The save endpoint claims the session for them.
+    """
+    client, _session_factory, current_sub, agent = persistence_client
+
+    agent.session_service.sessions["session-anon"] = SessionState(
+        session_id="session-anon",
+        owner_keycloak_sub=None,
+        messages=[ChatMessage(role=MessageRole.USER, content="hello")],
+        schema_state=AnalysisSchema(),
+    )
+
+    current_sub["value"] = "user-a"
+    response = client.post(
+        "/api/v1/saved_analyses",
+        json={"session_id": "session-anon"},
+    )
+
+    assert response.status_code == 200
+    # Session should now be owned by user-a.
+    assert agent.session_service.sessions["session-anon"].owner_keycloak_sub == "user-a"
 
 
 def test_preferences_payload_is_bounded(persistence_client):

--- a/backend/api/tests/test_user_persistence_api.py
+++ b/backend/api/tests/test_user_persistence_api.py
@@ -117,7 +117,7 @@ def persistence_app(tmp_path, monkeypatch):
 
     asyncio.run(_create_schema(database_url))
 
-    from app.db.session import get_session_factory
+    from app.db.session import close_db, get_session_factory
     from app.main import create_app
 
     app = create_app()
@@ -143,6 +143,12 @@ def persistence_app(tmp_path, monkeypatch):
     app.dependency_overrides[dependencies.get_assistant_agent] = lambda: agent
 
     yield app, session_factory, current_sub, agent
+
+    # Dispose the global engine the fixture created. Client-based tests get
+    # this via the app lifespan shutdown, but persistence_app used directly
+    # (e.g. the concurrent-insert race test) would otherwise leak the cached
+    # engine/session factory into the next test.
+    asyncio.run(close_db())
 
 
 @pytest.fixture()

--- a/backend/api/tests/test_workflow_runs_api.py
+++ b/backend/api/tests/test_workflow_runs_api.py
@@ -44,18 +44,14 @@ def workflow_runs_client(tmp_path, monkeypatch):
     fake_cache.close = AsyncMock()
     fake_auth = MagicMock()
     fake_auth.close = AsyncMock()
-    fake_llm = MagicMock()
 
     get_cache_service = MagicMock(return_value=fake_cache)
     get_cache_service.cache_clear = MagicMock()
     get_auth_service = MagicMock(return_value=fake_auth)
     get_auth_service.cache_clear = MagicMock()
-    get_llm_service = MagicMock(return_value=fake_llm)
-    get_llm_service.cache_clear = MagicMock()
 
     monkeypatch.setattr(dependencies, "get_cache_service", get_cache_service)
     monkeypatch.setattr(dependencies, "get_auth_service", get_auth_service)
-    monkeypatch.setattr(dependencies, "get_llm_service", get_llm_service)
 
     # Mock the agent so the workflow_runs endpoint's assistant-session
     # validation has a controllable session_service. Each test reconfigures

--- a/backend/api/tests/test_workflow_runs_api.py
+++ b/backend/api/tests/test_workflow_runs_api.py
@@ -217,6 +217,25 @@ def test_workflow_run_rejects_session_owned_by_other_user(workflow_runs_client):
     assert "another user" in response.json()["detail"]
 
 
+def test_workflow_run_rejects_oversized_parameters(workflow_runs_client):
+    """An unauthenticated client can POST workflow runs, so we cap the
+    parameters dict to keep one request from forcing a huge JSON parse +
+    DB write."""
+    client, _current_sub, _session_service = workflow_runs_client
+    # ~100KB of junk inside parameters; cap is 64KB.
+    blob = "x" * (100 * 1024)
+    response = client.post(
+        "/api/v1/workflow_runs",
+        json={
+            "workflow_trs_id": "#workflow/github.com/iwc/rnaseq-pe/main",
+            "handoff_url": "https://usegalaxy.org/workflow_landings/abc",
+            "launch_source": "site",
+            "parameters": {"blob": blob},
+        },
+    )
+    assert response.status_code == 413
+
+
 def test_workflow_run_accepts_anonymous_assistant_session(workflow_runs_client):
     client, current_sub, session_service = workflow_runs_client
     current_sub["value"] = "user-a"

--- a/backend/api/tests/test_workflow_runs_api.py
+++ b/backend/api/tests/test_workflow_runs_api.py
@@ -261,3 +261,24 @@ def test_workflow_run_accepts_anonymous_assistant_session(workflow_runs_client):
 
     assert response.status_code == 200
     assert response.json()["assistant_session_id"] == "session-anon"
+
+
+def test_workflow_run_corrects_mislabeled_launch_source(workflow_runs_client):
+    # A hand-crafted request claims launch_source="assistant" but sends no
+    # assistant_session_id. The server derives launch_source from the (absent)
+    # session, so it's stored as "site" instead of polluting assistant analytics.
+    client, current_sub, _session_service = workflow_runs_client
+    current_sub["value"] = None
+
+    response = client.post(
+        "/api/v1/workflow_runs",
+        json={
+            "workflow_trs_id": "#workflow/github.com/iwc/rnaseq-pe/main",
+            "handoff_url": "https://usegalaxy.org/workflow_landings/abc",
+            "launch_source": "assistant",
+            "parameters": {},
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["launch_source"] == "site"

--- a/backend/api/tests/test_workflow_runs_api.py
+++ b/backend/api/tests/test_workflow_runs_api.py
@@ -57,6 +57,14 @@ def workflow_runs_client(tmp_path, monkeypatch):
     monkeypatch.setattr(dependencies, "get_auth_service", get_auth_service)
     monkeypatch.setattr(dependencies, "get_llm_service", get_llm_service)
 
+    # Mock the agent so the workflow_runs endpoint's assistant-session
+    # validation has a controllable session_service. Each test reconfigures
+    # fake_session_service.get_session as needed.
+    fake_session_service = MagicMock()
+    fake_session_service.get_session = AsyncMock(return_value=None)
+    fake_agent = MagicMock()
+    fake_agent.session_service = fake_session_service
+
     asyncio.run(_create_schema(database_url))
 
     from app.db.session import get_session_factory
@@ -91,6 +99,7 @@ def workflow_runs_client(tmp_path, monkeypatch):
     app.dependency_overrides[dependencies.get_optional_current_user_db] = (
         override_get_optional_current_user_db
     )
+    app.dependency_overrides[dependencies.get_assistant_agent] = lambda: fake_agent
 
     async def seed_users() -> None:
         async with session_factory() as session:
@@ -106,11 +115,17 @@ def workflow_runs_client(tmp_path, monkeypatch):
     asyncio.run(seed_users())
 
     with TestClient(app) as client:
-        yield client, current_sub
+        yield client, current_sub, fake_session_service
+
+
+def _make_session_state(session_id: str, owner_sub: str | None):
+    from app.models.assistant import SessionState
+
+    return SessionState(session_id=session_id, owner_keycloak_sub=owner_sub)
 
 
 def test_workflow_run_creation_allows_anonymous_tracking(workflow_runs_client):
-    client, current_sub = workflow_runs_client
+    client, current_sub, _session_service = workflow_runs_client
     current_sub["value"] = None
 
     response = client.post(
@@ -133,7 +148,7 @@ def test_workflow_run_creation_allows_anonymous_tracking(workflow_runs_client):
 
 
 def test_workflow_runs_are_scoped_to_current_user(workflow_runs_client):
-    client, current_sub = workflow_runs_client
+    client, current_sub, _session_service = workflow_runs_client
 
     current_sub["value"] = "user-a"
     create_response = client.post(
@@ -143,8 +158,7 @@ def test_workflow_runs_are_scoped_to_current_user(workflow_runs_client):
             "galaxy_instance_url": "https://usegalaxy.org",
             "handoff_url": "https://usegalaxy.org/workflow_landings/user-a",
             "assembly_accession": "GCF_000001405.40",
-            "launch_source": "assistant",
-            "assistant_session_id": "assistant-session-a",
+            "launch_source": "site",
             "parameters": {"reference_assembly": "GCF_000001405.40"},
         },
     )
@@ -155,3 +169,76 @@ def test_workflow_runs_are_scoped_to_current_user(workflow_runs_client):
 
     assert list_response.status_code == 200
     assert list_response.json() == []
+
+
+def test_workflow_run_rejects_unknown_assistant_session(workflow_runs_client):
+    client, current_sub, session_service = workflow_runs_client
+    current_sub["value"] = "user-a"
+    session_service.get_session = AsyncMock(return_value=None)
+
+    response = client.post(
+        "/api/v1/workflow_runs",
+        json={
+            "workflow_trs_id": "#workflow/github.com/iwc/rnaseq-pe/main",
+            "galaxy_instance_url": "https://usegalaxy.org",
+            "handoff_url": "https://usegalaxy.org/workflow_landings/abc",
+            "assembly_accession": "GCF_000001405.40",
+            "launch_source": "assistant",
+            "assistant_session_id": "no-such-session",
+            "parameters": {},
+        },
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Assistant session not found"
+
+
+def test_workflow_run_rejects_session_owned_by_other_user(workflow_runs_client):
+    client, current_sub, session_service = workflow_runs_client
+    current_sub["value"] = "user-b"
+    session_service.get_session = AsyncMock(
+        return_value=_make_session_state("session-x", owner_sub="user-a")
+    )
+
+    response = client.post(
+        "/api/v1/workflow_runs",
+        json={
+            "workflow_trs_id": "#workflow/github.com/iwc/rnaseq-pe/main",
+            "galaxy_instance_url": "https://usegalaxy.org",
+            "handoff_url": "https://usegalaxy.org/workflow_landings/abc",
+            "assembly_accession": "GCF_000001405.40",
+            "launch_source": "assistant",
+            "assistant_session_id": "session-x",
+            "parameters": {},
+        },
+    )
+
+    assert response.status_code == 403
+    assert "another user" in response.json()["detail"]
+
+
+def test_workflow_run_accepts_anonymous_assistant_session(workflow_runs_client):
+    client, current_sub, session_service = workflow_runs_client
+    current_sub["value"] = "user-a"
+    # Anonymous assistant session (owner_keycloak_sub is None) is allowed
+    # to be claimed by any authenticated user -- mirrors the chat flow
+    # where an unauth user starts a session, then logs in mid-conversation.
+    session_service.get_session = AsyncMock(
+        return_value=_make_session_state("session-anon", owner_sub=None)
+    )
+
+    response = client.post(
+        "/api/v1/workflow_runs",
+        json={
+            "workflow_trs_id": "#workflow/github.com/iwc/rnaseq-pe/main",
+            "galaxy_instance_url": "https://usegalaxy.org",
+            "handoff_url": "https://usegalaxy.org/workflow_landings/abc",
+            "assembly_accession": "GCF_000001405.40",
+            "launch_source": "assistant",
+            "assistant_session_id": "session-anon",
+            "parameters": {},
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["assistant_session_id"] == "session-anon"

--- a/backend/api/tests/test_workflow_runs_api.py
+++ b/backend/api/tests/test_workflow_runs_api.py
@@ -1,0 +1,157 @@
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from app.core.config import get_settings
+from app.db.crud import get_user_by_keycloak_sub, upsert_user_from_claims
+from app.db.models import Base
+from app.db.session import get_db_session
+from tests.test_catalog_data import SAMPLE_ORGANISMS, SAMPLE_WORKFLOWS
+
+
+def _write_catalog(tmp_path: Path) -> None:
+    (tmp_path / "organisms.json").write_text(json.dumps(SAMPLE_ORGANISMS))
+    (tmp_path / "workflows.json").write_text(json.dumps(SAMPLE_WORKFLOWS))
+
+
+async def _create_schema(database_url: str) -> None:
+    engine = create_async_engine(database_url)
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+    await engine.dispose()
+
+
+@pytest.fixture()
+def workflow_runs_client(tmp_path, monkeypatch):
+    _write_catalog(tmp_path)
+    database_url = f"sqlite+aiosqlite:///{tmp_path / 'app.db'}"
+
+    monkeypatch.setenv("CATALOG_PATH", str(tmp_path))
+    monkeypatch.setenv("DATABASE_URL", database_url)
+
+    from app.core import dependencies
+
+    get_settings.cache_clear()
+    dependencies.reset_all_services()
+
+    fake_cache = MagicMock()
+    fake_cache.flush_all = AsyncMock()
+    fake_cache.close = AsyncMock()
+    fake_auth = MagicMock()
+    fake_auth.close = AsyncMock()
+    fake_llm = MagicMock()
+
+    get_cache_service = MagicMock(return_value=fake_cache)
+    get_cache_service.cache_clear = MagicMock()
+    get_auth_service = MagicMock(return_value=fake_auth)
+    get_auth_service.cache_clear = MagicMock()
+    get_llm_service = MagicMock(return_value=fake_llm)
+    get_llm_service.cache_clear = MagicMock()
+
+    monkeypatch.setattr(dependencies, "get_cache_service", get_cache_service)
+    monkeypatch.setattr(dependencies, "get_auth_service", get_auth_service)
+    monkeypatch.setattr(dependencies, "get_llm_service", get_llm_service)
+
+    asyncio.run(_create_schema(database_url))
+
+    from app.db.session import get_session_factory
+    from app.main import create_app
+
+    app = create_app()
+    session_factory = get_session_factory()
+    current_sub = {"value": None}
+
+    async def override_get_db_session():
+        async with session_factory() as session:
+            yield session
+
+    async def override_get_current_user_db():
+        if current_sub["value"] is None:
+            raise AssertionError("Authenticated user requested without a current_sub")
+        async with session_factory() as session:
+            user = await get_user_by_keycloak_sub(session, current_sub["value"])
+            if user is None:
+                raise AssertionError(f"Missing test user for {current_sub['value']}")
+            return user
+
+    async def override_get_optional_current_user_db():
+        if current_sub["value"] is None:
+            return None
+        return await override_get_current_user_db()
+
+    app.dependency_overrides[get_db_session] = override_get_db_session
+    app.dependency_overrides[dependencies.get_current_user_db] = (
+        override_get_current_user_db
+    )
+    app.dependency_overrides[dependencies.get_optional_current_user_db] = (
+        override_get_optional_current_user_db
+    )
+
+    async def seed_users() -> None:
+        async with session_factory() as session:
+            await upsert_user_from_claims(
+                session,
+                {"sub": "user-a", "email": "a@example.com", "name": "User A"},
+            )
+            await upsert_user_from_claims(
+                session,
+                {"sub": "user-b", "email": "b@example.com", "name": "User B"},
+            )
+
+    asyncio.run(seed_users())
+
+    with TestClient(app) as client:
+        yield client, current_sub
+
+
+def test_workflow_run_creation_allows_anonymous_tracking(workflow_runs_client):
+    client, current_sub = workflow_runs_client
+    current_sub["value"] = None
+
+    response = client.post(
+        "/api/v1/workflow_runs",
+        json={
+            "workflow_trs_id": "#workflow/github.com/iwc/rnaseq-pe/main",
+            "galaxy_instance_url": "https://usegalaxy.org",
+            "handoff_url": "https://usegalaxy.org/workflow_landings/abc123",
+            "assembly_accession": "GCF_000001405.40",
+            "launch_source": "site",
+            "parameters": {"read_runs_single": ["SRR000001"]},
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["launch_source"] == "site"
+    assert body["assistant_session_id"] is None
+    assert body["status"] == "handoff_created"
+
+
+def test_workflow_runs_are_scoped_to_current_user(workflow_runs_client):
+    client, current_sub = workflow_runs_client
+
+    current_sub["value"] = "user-a"
+    create_response = client.post(
+        "/api/v1/workflow_runs",
+        json={
+            "workflow_trs_id": "#workflow/github.com/iwc/varcall-haploid/main",
+            "galaxy_instance_url": "https://usegalaxy.org",
+            "handoff_url": "https://usegalaxy.org/workflow_landings/user-a",
+            "assembly_accession": "GCF_000001405.40",
+            "launch_source": "assistant",
+            "assistant_session_id": "assistant-session-a",
+            "parameters": {"reference_assembly": "GCF_000001405.40"},
+        },
+    )
+    assert create_response.status_code == 200
+
+    current_sub["value"] = "user-b"
+    list_response = client.get("/api/v1/workflow_runs")
+
+    assert list_response.status_code == 200
+    assert list_response.json() == []

--- a/backend/api/uv.lock
+++ b/backend/api/uv.lock
@@ -100,6 +100,29 @@ wheels = [
 ]
 
 [[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
+
+[[package]]
+name = "alembic"
+version = "1.18.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mako" },
+    { name = "sqlalchemy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/13/8b084e0f2efb0275a1d534838844926f798bd766566b1375174e2448cd31/alembic-1.18.4.tar.gz", hash = "sha256:cb6e1fd84b6174ab8dbb2329f86d631ba9559dd78df550b57804d607672cedbc", size = 2056725, upload-time = "2026-02-10T16:00:47.195Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl", hash = "sha256:a5ed4adcf6d8a4cb575f3d759f071b03cd6e5c7618eb796cb52497be25bfe19a", size = 263893, upload-time = "2026-02-10T16:00:49.997Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -157,6 +180,46 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/16/0f/861e168fc813c56a78b35f3c30d91c6757d1fd185af1110f1aec784b35d0/argcomplete-3.6.2.tar.gz", hash = "sha256:d0519b1bc867f5f4f4713c41ad0aba73a4a5f007449716b16f385f2166dc6adf", size = 73403, upload-time = "2025-04-03T04:57:03.52Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/da/e42d7a9d8dd33fa775f467e4028a47936da2f01e4b0e561f9ba0d74cb0ca/argcomplete-3.6.2-py3-none-any.whl", hash = "sha256:65b3133a29ad53fb42c48cf5114752c7ab66c1c38544fdf6460f450c09b42591", size = 43708, upload-time = "2025-04-03T04:57:01.591Z" },
+]
+
+[[package]]
+name = "asyncpg"
+version = "0.31.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/cc/d18065ce2380d80b1bcce927c24a2642efd38918e33fd724bc4bca904877/asyncpg-0.31.0.tar.gz", hash = "sha256:c989386c83940bfbd787180f2b1519415e2d3d6277a70d9d0f0145ac73500735", size = 993667, upload-time = "2025-11-24T23:27:00.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/a6/59d0a146e61d20e18db7396583242e32e0f120693b67a8de43f1557033e2/asyncpg-0.31.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b44c31e1efc1c15188ef183f287c728e2046abb1d26af4d20858215d50d91fad", size = 662042, upload-time = "2025-11-24T23:25:49.578Z" },
+    { url = "https://files.pythonhosted.org/packages/36/01/ffaa189dcb63a2471720615e60185c3f6327716fdc0fc04334436fbb7c65/asyncpg-0.31.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0c89ccf741c067614c9b5fc7f1fc6f3b61ab05ae4aaa966e6fd6b93097c7d20d", size = 638504, upload-time = "2025-11-24T23:25:51.501Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/62/3f699ba45d8bd24c5d65392190d19656d74ff0185f42e19d0bbd973bb371/asyncpg-0.31.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:12b3b2e39dc5470abd5e98c8d3373e4b1d1234d9fbdedf538798b2c13c64460a", size = 3426241, upload-time = "2025-11-24T23:25:53.278Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d1/a867c2150f9c6e7af6462637f613ba67f78a314b00db220cd26ff559d532/asyncpg-0.31.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:aad7a33913fb8bcb5454313377cc330fbb19a0cd5faa7272407d8a0c4257b671", size = 3520321, upload-time = "2025-11-24T23:25:54.982Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1a/cce4c3f246805ecd285a3591222a2611141f1669d002163abef999b60f98/asyncpg-0.31.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3df118d94f46d85b2e434fd62c84cb66d5834d5a890725fe625f498e72e4d5ec", size = 3316685, upload-time = "2025-11-24T23:25:57.43Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ae/0fc961179e78cc579e138fad6eb580448ecae64908f95b8cb8ee2f241f67/asyncpg-0.31.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bd5b6efff3c17c3202d4b37189969acf8927438a238c6257f66be3c426beba20", size = 3471858, upload-time = "2025-11-24T23:25:59.636Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b2/b20e09670be031afa4cbfabd645caece7f85ec62d69c312239de568e058e/asyncpg-0.31.0-cp312-cp312-win32.whl", hash = "sha256:027eaa61361ec735926566f995d959ade4796f6a49d3bde17e5134b9964f9ba8", size = 527852, upload-time = "2025-11-24T23:26:01.084Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/f0/f2ed1de154e15b107dc692262395b3c17fc34eafe2a78fc2115931561730/asyncpg-0.31.0-cp312-cp312-win_amd64.whl", hash = "sha256:72d6bdcbc93d608a1158f17932de2321f68b1a967a13e014998db87a72ed3186", size = 597175, upload-time = "2025-11-24T23:26:02.564Z" },
+    { url = "https://files.pythonhosted.org/packages/95/11/97b5c2af72a5d0b9bc3fa30cd4b9ce22284a9a943a150fdc768763caf035/asyncpg-0.31.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c204fab1b91e08b0f47e90a75d1b3c62174dab21f670ad6c5d0f243a228f015b", size = 661111, upload-time = "2025-11-24T23:26:04.467Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/71/157d611c791a5e2d0423f09f027bd499935f0906e0c2a416ce712ba51ef3/asyncpg-0.31.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:54a64f91839ba59008eccf7aad2e93d6e3de688d796f35803235ea1c4898ae1e", size = 636928, upload-time = "2025-11-24T23:26:05.944Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/fc/9e3486fb2bbe69d4a867c0b76d68542650a7ff1574ca40e84c3111bb0c6e/asyncpg-0.31.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0e0822b1038dc7253b337b0f3f676cadc4ac31b126c5d42691c39691962e403", size = 3424067, upload-time = "2025-11-24T23:26:07.957Z" },
+    { url = "https://files.pythonhosted.org/packages/12/c6/8c9d076f73f07f995013c791e018a1cd5f31823c2a3187fc8581706aa00f/asyncpg-0.31.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bef056aa502ee34204c161c72ca1f3c274917596877f825968368b2c33f585f4", size = 3518156, upload-time = "2025-11-24T23:26:09.591Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3b/60683a0baf50fbc546499cfb53132cb6835b92b529a05f6a81471ab60d0c/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0bfbcc5b7ffcd9b75ab1558f00db2ae07db9c80637ad1b2469c43df79d7a5ae2", size = 3319636, upload-time = "2025-11-24T23:26:11.168Z" },
+    { url = "https://files.pythonhosted.org/packages/50/dc/8487df0f69bd398a61e1792b3cba0e47477f214eff085ba0efa7eac9ce87/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:22bc525ebbdc24d1261ecbf6f504998244d4e3be1721784b5f64664d61fbe602", size = 3472079, upload-time = "2025-11-24T23:26:13.164Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a1/c5bbeeb8531c05c89135cb8b28575ac2fac618bcb60119ee9696c3faf71c/asyncpg-0.31.0-cp313-cp313-win32.whl", hash = "sha256:f890de5e1e4f7e14023619399a471ce4b71f5418cd67a51853b9910fdfa73696", size = 527606, upload-time = "2025-11-24T23:26:14.78Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/b25ccb84a246b470eb943b0107c07edcae51804912b824054b3413995a10/asyncpg-0.31.0-cp313-cp313-win_amd64.whl", hash = "sha256:dc5f2fa9916f292e5c5c8b2ac2813763bcd7f58e130055b4ad8a0531314201ab", size = 596569, upload-time = "2025-11-24T23:26:16.189Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/36/e9450d62e84a13aea6580c83a47a437f26c7ca6fa0f0fd40b6670793ea30/asyncpg-0.31.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f6b56b91bb0ffc328c4e3ed113136cddd9deefdf5f79ab448598b9772831df44", size = 660867, upload-time = "2025-11-24T23:26:17.631Z" },
+    { url = "https://files.pythonhosted.org/packages/82/4b/1d0a2b33b3102d210439338e1beea616a6122267c0df459ff0265cd5807a/asyncpg-0.31.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:334dec28cf20d7f5bb9e45b39546ddf247f8042a690bff9b9573d00086e69cb5", size = 638349, upload-time = "2025-11-24T23:26:19.689Z" },
+    { url = "https://files.pythonhosted.org/packages/41/aa/e7f7ac9a7974f08eff9183e392b2d62516f90412686532d27e196c0f0eeb/asyncpg-0.31.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98cc158c53f46de7bb677fd20c417e264fc02b36d901cc2a43bd6cb0dc6dbfd2", size = 3410428, upload-time = "2025-11-24T23:26:21.275Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/de/bf1b60de3dede5c2731e6788617a512bc0ebd9693eac297ee74086f101d7/asyncpg-0.31.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9322b563e2661a52e3cdbc93eed3be7748b289f792e0011cb2720d278b366ce2", size = 3471678, upload-time = "2025-11-24T23:26:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/46/78/fc3ade003e22d8bd53aaf8f75f4be48f0b460fa73738f0391b9c856a9147/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19857a358fc811d82227449b7ca40afb46e75b33eb8897240c3839dd8b744218", size = 3313505, upload-time = "2025-11-24T23:26:25.235Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e9/73eb8a6789e927816f4705291be21f2225687bfa97321e40cd23055e903a/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ba5f8886e850882ff2c2ace5732300e99193823e8107e2c53ef01c1ebfa1e85d", size = 3434744, upload-time = "2025-11-24T23:26:26.944Z" },
+    { url = "https://files.pythonhosted.org/packages/08/4b/f10b880534413c65c5b5862f79b8e81553a8f364e5238832ad4c0af71b7f/asyncpg-0.31.0-cp314-cp314-win32.whl", hash = "sha256:cea3a0b2a14f95834cee29432e4ddc399b95700eb1d51bbc5bfee8f31fa07b2b", size = 532251, upload-time = "2025-11-24T23:26:28.404Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/2d/7aa40750b7a19efa5d66e67fc06008ca0f27ba1bd082e457ad82f59aba49/asyncpg-0.31.0-cp314-cp314-win_amd64.whl", hash = "sha256:04d19392716af6b029411a0264d92093b6e5e8285ae97a39957b9a9c14ea72be", size = 604901, upload-time = "2025-11-24T23:26:30.34Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/fe/b9dfe349b83b9dee28cc42360d2c86b2cdce4cb551a2c2d27e156bcac84d/asyncpg-0.31.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bdb957706da132e982cc6856bb2f7b740603472b54c3ebc77fe60ea3e57e1bd2", size = 702280, upload-time = "2025-11-24T23:26:32Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/81/e6be6e37e560bd91e6c23ea8a6138a04fd057b08cf63d3c5055c98e81c1d/asyncpg-0.31.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6d11b198111a72f47154fa03b85799f9be63701e068b43f84ac25da0bda9cb31", size = 682931, upload-time = "2025-11-24T23:26:33.572Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/45/6009040da85a1648dd5bc75b3b0a062081c483e75a1a29041ae63a0bf0dc/asyncpg-0.31.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18c83b03bc0d1b23e6230f5bf8d4f217dc9bc08644ce0502a9d91dc9e634a9c7", size = 3581608, upload-time = "2025-11-24T23:26:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/06/2e3d4d7608b0b2b3adbee0d0bd6a2d29ca0fc4d8a78f8277df04e2d1fd7b/asyncpg-0.31.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e009abc333464ff18b8f6fd146addffd9aaf63e79aa3bb40ab7a4c332d0c5e9e", size = 3498738, upload-time = "2025-11-24T23:26:37.275Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/aa/7d75ede780033141c51d83577ea23236ba7d3a23593929b32b49db8ed36e/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3b1fbcb0e396a5ca435a8826a87e5c2c2cc0c8c68eb6fadf82168056b0e53a8c", size = 3401026, upload-time = "2025-11-24T23:26:39.423Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/7a/15e37d45e7f7c94facc1e9148c0e455e8f33c08f0b8a0b1deb2c5171771b/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8df714dba348efcc162d2adf02d213e5fab1bd9f557e1305633e851a61814a7a", size = 3429426, upload-time = "2025-11-24T23:26:41.032Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d5/71437c5f6ae5f307828710efbe62163974e71237d5d46ebd2869ea052d10/asyncpg-0.31.0-cp314-cp314t-win32.whl", hash = "sha256:1b41f1afb1033f2b44f3234993b15096ddc9cd71b21a42dbd87fc6a57b43d65d", size = 614495, upload-time = "2025-11-24T23:26:42.659Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d7/8fb3044eaef08a310acfe23dae9a8e2e07d305edc29a53497e52bc76eca7/asyncpg-0.31.0-cp314-cp314t-win_amd64.whl", hash = "sha256:bd4107bb7cdd0e9e65fae66a62afd3a249663b844fa34d479f6d5b3bef9c04c3", size = 706062, upload-time = "2025-11-24T23:26:44.086Z" },
 ]
 
 [[package]]
@@ -222,6 +285,9 @@ name = "brc-analytics-backend"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "aiosqlite" },
+    { name = "alembic" },
+    { name = "asyncpg" },
     { name = "fastapi" },
     { name = "fastmcp" },
     { name = "httpx" },
@@ -231,6 +297,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "redis" },
     { name = "sentry-sdk", extra = ["fastapi"] },
+    { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "tenacity" },
     { name = "uvicorn" },
 ]
@@ -246,6 +313,9 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiosqlite", specifier = ">=0.21.0" },
+    { name = "alembic", specifier = ">=1.13.2" },
+    { name = "asyncpg", specifier = ">=0.29.0" },
     { name = "fastapi", specifier = ">=0.116.1" },
     { name = "fastmcp", specifier = ">=3.0.0" },
     { name = "httpx", specifier = ">=0.28.1" },
@@ -260,6 +330,7 @@ requires-dist = [
     { name = "redis", specifier = ">=6.4.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.13.0" },
     { name = "sentry-sdk", extras = ["fastapi"], specifier = "==2.55.0" },
+    { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.36" },
     { name = "tenacity", specifier = ">=8.2.0" },
     { name = "uvicorn", specifier = ">=0.35.0" },
 ]
@@ -803,6 +874,53 @@ wheels = [
 ]
 
 [[package]]
+name = "greenlet"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/94/a5935717b307d7c71fe877b52b884c6af707d2d2090db118a03fbd799369/greenlet-3.4.0.tar.gz", hash = "sha256:f50a96b64dafd6169e595a5c56c9146ef80333e67d4476a65a9c55f400fc22ff", size = 195913, upload-time = "2026-04-08T17:08:00.863Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/8b/3669ad3b3f247a791b2b4aceb3aa5a31f5f6817bf547e4e1ff712338145a/greenlet-3.4.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:1a54a921561dd9518d31d2d3db4d7f80e589083063ab4d3e2e950756ef809e1a", size = 286902, upload-time = "2026-04-08T15:52:12.138Z" },
+    { url = "https://files.pythonhosted.org/packages/38/3e/3c0e19b82900873e2d8469b590a6c4b3dfd2b316d0591f1c26b38a4879a5/greenlet-3.4.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16dec271460a9a2b154e3b1c2fa1050ce6280878430320e85e08c166772e3f97", size = 606099, upload-time = "2026-04-08T16:24:38.408Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/33/99fef65e7754fc76a4ed14794074c38c9ed3394a5bd129d7f61b705f3168/greenlet-3.4.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:90036ce224ed6fe75508c1907a77e4540176dcf0744473627785dd519c6f9996", size = 618837, upload-time = "2026-04-08T16:30:58.298Z" },
+    { url = "https://files.pythonhosted.org/packages/44/57/eae2cac10421feae6c0987e3dc106c6d86262b1cb379e171b017aba893a6/greenlet-3.4.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6f0def07ec9a71d72315cf26c061aceee53b306c36ed38c35caba952ea1b319d", size = 624901, upload-time = "2026-04-08T16:40:38.981Z" },
+    { url = "https://files.pythonhosted.org/packages/36/f7/229f3aed6948faa20e0616a0b8568da22e365ede6a54d7d369058b128afd/greenlet-3.4.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a1c4f6b453006efb8310affb2d132832e9bbb4fc01ce6df6b70d810d38f1f6dc", size = 615062, upload-time = "2026-04-08T15:56:33.766Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/8a/0e73c9b94f31d1cc257fe79a0eff621674141cdae7d6d00f40de378a1e42/greenlet-3.4.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:0e1254cf0cbaa17b04320c3a78575f29f3c161ef38f59c977108f19ffddaf077", size = 423927, upload-time = "2026-04-08T16:43:05.293Z" },
+    { url = "https://files.pythonhosted.org/packages/08/97/d988180011aa40135c46cd0d0cf01dd97f7162bae14139b4a3ef54889ba5/greenlet-3.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9b2d9a138ffa0e306d0e2b72976d2fb10b97e690d40ab36a472acaab0838e2de", size = 1573511, upload-time = "2026-04-08T16:26:20.058Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/0f/a5a26fe152fb3d12e6a474181f6e9848283504d0afd095f353d85726374b/greenlet-3.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8424683caf46eb0eb6f626cb95e008e8cc30d0cb675bdfa48200925c79b38a08", size = 1640396, upload-time = "2026-04-08T15:57:30.88Z" },
+    { url = "https://files.pythonhosted.org/packages/42/cf/bb2c32d9a100e36ee9f6e38fad6b1e082b8184010cb06259b49e1266ca01/greenlet-3.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:a0a53fb071531d003b075c444014ff8f8b1a9898d36bb88abd9ac7b3524648a2", size = 238892, upload-time = "2026-04-08T17:03:10.094Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/47/6c41314bac56e71436ce551c7fbe3cc830ed857e6aa9708dbb9c65142eb6/greenlet-3.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:f38b81880ba28f232f1f675893a39cf7b6db25b31cc0a09bb50787ecf957e85e", size = 235599, upload-time = "2026-04-08T15:52:54.3Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/75/7e9cd1126a1e1f0cd67b0eda02e5221b28488d352684704a78ed505bd719/greenlet-3.4.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:43748988b097f9c6f09364f260741aa73c80747f63389824435c7a50bfdfd5c1", size = 285856, upload-time = "2026-04-08T15:52:45.82Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/c4/3e2df392e5cb199527c4d9dbcaa75c14edcc394b45040f0189f649631e3c/greenlet-3.4.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5566e4e2cd7a880e8c27618e3eab20f3494452d12fd5129edef7b2f7aa9a36d1", size = 610208, upload-time = "2026-04-08T16:24:39.674Z" },
+    { url = "https://files.pythonhosted.org/packages/da/af/750cdfda1d1bd30a6c28080245be8d0346e669a98fdbae7f4102aa95fff3/greenlet-3.4.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1054c5a3c78e2ab599d452f23f7adafef55062a783a8e241d24f3b633ba6ff82", size = 621269, upload-time = "2026-04-08T16:30:59.767Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/93/c8c508d68ba93232784bbc1b5474d92371f2897dfc6bc281b419f2e0d492/greenlet-3.4.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:98eedd1803353daf1cd9ef23eef23eda5a4d22f99b1f998d273a8b78b70dd47f", size = 628455, upload-time = "2026-04-08T16:40:40.698Z" },
+    { url = "https://files.pythonhosted.org/packages/54/78/0cbc693622cd54ebe25207efbb3a0eb07c2639cb8594f6e3aaaa0bb077a8/greenlet-3.4.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f82cb6cddc27dd81c96b1506f4aa7def15070c3b2a67d4e46fd19016aacce6cf", size = 617549, upload-time = "2026-04-08T15:56:34.893Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/46/cfaaa0ade435a60550fd83d07dfd5c41f873a01da17ede5c4cade0b9bab8/greenlet-3.4.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:b7857e2202aae67bc5725e0c1f6403c20a8ff46094ece015e7d474f5f7020b55", size = 426238, upload-time = "2026-04-08T16:43:06.865Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/c0/8966767de01343c1ff47e8b855dc78e7d1a8ed2b7b9c83576a57e289f81d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:227a46251ecba4ff46ae742bc5ce95c91d5aceb4b02f885487aff269c127a729", size = 1575310, upload-time = "2026-04-08T16:26:21.671Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/38/bcdc71ba05e9a5fda87f63ffc2abcd1f15693b659346df994a48c968003d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5b99e87be7eba788dd5b75ba1cde5639edffdec5f91fe0d734a249535ec3408c", size = 1640435, upload-time = "2026-04-08T15:57:32.572Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/c2/19b664b7173b9e4ef5f77e8cef9f14c20ec7fce7920dc1ccd7afd955d093/greenlet-3.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:849f8bc17acd6295fcb5de8e46d55cc0e52381c56eaf50a2afd258e97bc65940", size = 238760, upload-time = "2026-04-08T17:04:03.878Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/96/795619651d39c7fbd809a522f881aa6f0ead504cc8201c3a5b789dfaef99/greenlet-3.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:9390ad88b652b1903814eaabd629ca184db15e0eeb6fe8a390bbf8b9106ae15a", size = 235498, upload-time = "2026-04-08T17:05:00.584Z" },
+    { url = "https://files.pythonhosted.org/packages/78/02/bde66806e8f169cf90b14d02c500c44cdbe02c8e224c9c67bafd1b8cadd1/greenlet-3.4.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:10a07aca6babdd18c16a3f4f8880acfffc2b88dfe431ad6aa5f5740759d7d75e", size = 286291, upload-time = "2026-04-08T17:09:34.307Z" },
+    { url = "https://files.pythonhosted.org/packages/05/1f/39da1c336a87d47c58352fb8a78541ce63d63ae57c5b9dae1fe02801bbc2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:076e21040b3a917d3ce4ad68fb5c3c6b32f1405616c4a57aa83120979649bd3d", size = 656749, upload-time = "2026-04-08T16:24:41.721Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/6c/90ee29a4ee27af7aa2e2ec408799eeb69ee3fcc5abcecac6ddd07a5cd0f2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e82689eea4a237e530bb5cb41b180ef81fa2160e1f89422a67be7d90da67f615", size = 669084, upload-time = "2026-04-08T16:31:01.372Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/4a/74078d3936712cff6d3c91a930016f476ce4198d84e224fe6d81d3e02880/greenlet-3.4.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:06c2d3b89e0c62ba50bd7adf491b14f39da9e7e701647cb7b9ff4c99bee04b19", size = 673405, upload-time = "2026-04-08T16:40:42.527Z" },
+    { url = "https://files.pythonhosted.org/packages/07/49/d4cad6e5381a50947bb973d2f6cf6592621451b09368b8c20d9b8af49c5b/greenlet-3.4.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4df3b0b2289ec686d3c821a5fee44259c05cfe824dd5e6e12c8e5f5df23085cf", size = 665621, upload-time = "2026-04-08T15:56:35.995Z" },
+    { url = "https://files.pythonhosted.org/packages/79/3e/df8a83ab894751bc31e1106fdfaa80ca9753222f106b04de93faaa55feb7/greenlet-3.4.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:070b8bac2ff3b4d9e0ff36a0d19e42103331d9737e8504747cd1e659f76297bd", size = 471670, upload-time = "2026-04-08T16:43:08.512Z" },
+    { url = "https://files.pythonhosted.org/packages/37/31/d1edd54f424761b5d47718822f506b435b6aab2f3f93b465441143ea5119/greenlet-3.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8bff29d586ea415688f4cec96a591fcc3bf762d046a796cdadc1fdb6e7f2d5bf", size = 1622259, upload-time = "2026-04-08T16:26:23.201Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c6/6d3f9cdcb21c4e12a79cb332579f1c6aa1af78eb68059c5a957c7812d95e/greenlet-3.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8a569c2fb840c53c13a2b8967c63621fafbd1a0e015b9c82f408c33d626a2fda", size = 1686916, upload-time = "2026-04-08T15:57:34.282Z" },
+    { url = "https://files.pythonhosted.org/packages/63/45/c1ca4a1ad975de4727e52d3ffe641ae23e1d7a8ffaa8ff7a0477e1827b92/greenlet-3.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:207ba5b97ea8b0b60eb43ffcacf26969dd83726095161d676aac03ff913ee50d", size = 239821, upload-time = "2026-04-08T17:03:48.423Z" },
+    { url = "https://files.pythonhosted.org/packages/71/c4/6f621023364d7e85a4769c014c8982f98053246d142420e0328980933ceb/greenlet-3.4.0-cp314-cp314-win_arm64.whl", hash = "sha256:f8296d4e2b92af34ebde81085a01690f26a51eb9ac09a0fcadb331eb36dbc802", size = 236932, upload-time = "2026-04-08T17:04:33.551Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/8f/18d72b629783f5e8d045a76f5325c1e938e659a9e4da79c7dcd10169a48d/greenlet-3.4.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:d70012e51df2dbbccfaf63a40aaf9b40c8bed37c3e3a38751c926301ce538ece", size = 294681, upload-time = "2026-04-08T15:52:35.778Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ad/5fa86ec46769c4153820d58a04062285b3b9e10ba3d461ee257b68dcbf53/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a58bec0751f43068cd40cff31bb3ca02ad6000b3a51ca81367af4eb5abc480c8", size = 658899, upload-time = "2026-04-08T16:24:43.32Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f0/4e8174ca0e87ae748c409f055a1ba161038c43cc0a5a6f1433a26ac2e5bf/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:05fa0803561028f4b2e3b490ee41216a842eaee11aed004cc343a996d9523aa2", size = 665284, upload-time = "2026-04-08T16:31:02.833Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/92/466b0d9afd44b8af623139a3599d651c7564fa4152f25f117e1ee5949ffb/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c4cd56a9eb7a6444edbc19062f7b6fbc8f287c663b946e3171d899693b1c19fa", size = 665872, upload-time = "2026-04-08T16:40:43.912Z" },
+    { url = "https://files.pythonhosted.org/packages/19/da/991cf7cd33662e2df92a1274b7eb4d61769294d38a1bba8a45f31364845e/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e60d38719cb80b3ab5e85f9f1aed4960acfde09868af6762ccb27b260d68f4ed", size = 661861, upload-time = "2026-04-08T15:56:37.269Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/14/3395a7ef3e260de0325152ddfe19dffb3e49fe10873b94654352b53ad48e/greenlet-3.4.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:1f85f204c4d54134ae850d401fa435c89cd667d5ce9dc567571776b45941af72", size = 489237, upload-time = "2026-04-08T16:43:09.993Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c5/6c2c708e14db3d9caea4b459d8464f58c32047451142fe2cfd90e7458f41/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f50c804733b43eded05ae694691c9aa68bca7d0a867d67d4a3f514742a2d53f", size = 1622182, upload-time = "2026-04-08T16:26:24.777Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/4c/50c5fed19378e11a29fabab1f6be39ea95358f4a0a07e115a51ca93385d8/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2d4f0635dc4aa638cda4b2f5a07ae9a2cff9280327b581a3fcb6f317b4fbc38a", size = 1685050, upload-time = "2026-04-08T15:57:36.453Z" },
+    { url = "https://files.pythonhosted.org/packages/db/72/85ae954d734703ab48e622c59d4ce35d77ce840c265814af9c078cacc7aa/greenlet-3.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1a4a48f24681300c640f143ba7c404270e1ebbbcf34331d7104a4ff40f8ea705", size = 245554, upload-time = "2026-04-08T17:03:50.044Z" },
+]
+
+[[package]]
 name = "griffelib"
 version = "2.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1205,6 +1323,18 @@ wheels = [
 ]
 
 [[package]]
+name = "mako"
+version = "1.3.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/8a/805404d0c0b9f3d7a326475ca008db57aea9c5c9f2e1e39ed0faa335571c/mako-1.3.11.tar.gz", hash = "sha256:071eb4ab4c5010443152255d77db7faa6ce5916f35226eb02dc34479b6858069", size = 399811, upload-time = "2026-04-14T20:19:51.493Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/a5/19d7aaa7e433713ffe881df33705925a196afb9532efc8475d26593921a6/mako-1.3.11-py3-none-any.whl", hash = "sha256:e372c6e333cf004aa736a15f425087ec977e1fcbd2966aae7f17c8dc1da27a77", size = 78503, upload-time = "2026-04-14T20:19:53.233Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1214,6 +1344,69 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
 ]
 
 [[package]]
@@ -2400,6 +2593,57 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sqlalchemy"
+version = "2.0.49"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/45/461788f35e0364a8da7bda51a1fe1b09762d0c32f12f63727998d85a873b/sqlalchemy-2.0.49.tar.gz", hash = "sha256:d15950a57a210e36dd4cec1aac22787e2a4d57ba9318233e2ef8b2daf9ff2d5f", size = 9898221, upload-time = "2026-04-03T16:38:11.704Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/b3/2de412451330756aaaa72d27131db6dde23995efe62c941184e15242a5fa/sqlalchemy-2.0.49-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4bbccb45260e4ff1b7db0be80a9025bb1e6698bdb808b83fff0000f7a90b2c0b", size = 2157681, upload-time = "2026-04-03T16:53:07.132Z" },
+    { url = "https://files.pythonhosted.org/packages/50/84/b2a56e2105bd11ebf9f0b93abddd748e1a78d592819099359aa98134a8bf/sqlalchemy-2.0.49-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fb37f15714ec2652d574f021d479e78cd4eb9d04396dca36568fdfffb3487982", size = 3338976, upload-time = "2026-04-03T17:07:40Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fa/65fcae2ed62f84ab72cf89536c7c3217a156e71a2c111b1305ab6f0690e2/sqlalchemy-2.0.49-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3bb9ec6436a820a4c006aad1ac351f12de2f2dbdaad171692ee457a02429b672", size = 3351937, upload-time = "2026-04-03T17:12:23.374Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/2f/6fd118563572a7fe475925742eb6b3443b2250e346a0cc27d8d408e73773/sqlalchemy-2.0.49-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8d6efc136f44a7e8bc8088507eaabbb8c2b55b3dbb63fe102c690da0ddebe55e", size = 3281646, upload-time = "2026-04-03T17:07:41.949Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/d7/410f4a007c65275b9cf82354adb4bb8ba587b176d0a6ee99caa16fe638f8/sqlalchemy-2.0.49-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e06e617e3d4fd9e51d385dfe45b077a41e9d1b033a7702551e3278ac597dc750", size = 3316695, upload-time = "2026-04-03T17:12:25.642Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/95/81f594aa60ded13273a844539041ccf1e66c5a7bed0a8e27810a3b52d522/sqlalchemy-2.0.49-cp312-cp312-win32.whl", hash = "sha256:83101a6930332b87653886c01d1ee7e294b1fe46a07dd9a2d2b4f91bcc88eec0", size = 2117483, upload-time = "2026-04-03T17:05:40.896Z" },
+    { url = "https://files.pythonhosted.org/packages/47/9e/fd90114059175cac64e4fafa9bf3ac20584384d66de40793ae2e2f26f3bb/sqlalchemy-2.0.49-cp312-cp312-win_amd64.whl", hash = "sha256:618a308215b6cececb6240b9abde545e3acdabac7ae3e1d4e666896bf5ba44b4", size = 2144494, upload-time = "2026-04-03T17:05:42.282Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/81/81755f50eb2478eaf2049728491d4ea4f416c1eb013338682173259efa09/sqlalchemy-2.0.49-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:df2d441bacf97022e81ad047e1597552eb3f83ca8a8f1a1fdd43cd7fe3898120", size = 2154547, upload-time = "2026-04-03T16:53:08.64Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/bc/3494270da80811d08bcfa247404292428c4fe16294932bce5593f215cad9/sqlalchemy-2.0.49-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8e20e511dc15265fb433571391ba313e10dd8ea7e509d51686a51313b4ac01a2", size = 3280782, upload-time = "2026-04-03T17:07:43.508Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/f5/038741f5e747a5f6ea3e72487211579d8cbea5eb9827a9cbd61d0108c4bd/sqlalchemy-2.0.49-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:47604cb2159f8bbd5a1ab48a714557156320f20871ee64d550d8bf2683d980d3", size = 3297156, upload-time = "2026-04-03T17:12:27.697Z" },
+    { url = "https://files.pythonhosted.org/packages/88/50/a6af0ff9dc954b43a65ca9b5367334e45d99684c90a3d3413fc19a02d43c/sqlalchemy-2.0.49-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:22d8798819f86720bc646ab015baff5ea4c971d68121cb36e2ebc2ee43ead2b7", size = 3228832, upload-time = "2026-04-03T17:07:45.38Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/d1/5f6bdad8de0bf546fc74370939621396515e0cdb9067402d6ba1b8afbe9a/sqlalchemy-2.0.49-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9b1c058c171b739e7c330760044803099c7fff11511e3ab3573e5327116a9c33", size = 3267000, upload-time = "2026-04-03T17:12:29.657Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/30/ad62227b4a9819a5e1c6abff77c0f614fa7c9326e5a3bdbee90f7139382b/sqlalchemy-2.0.49-cp313-cp313-win32.whl", hash = "sha256:a143af2ea6672f2af3f44ed8f9cd020e9cc34c56f0e8db12019d5d9ecf41cb3b", size = 2115641, upload-time = "2026-04-03T17:05:43.989Z" },
+    { url = "https://files.pythonhosted.org/packages/17/3a/7215b1b7d6d49dc9a87211be44562077f5f04f9bb5a59552c1c8e2d98173/sqlalchemy-2.0.49-cp313-cp313-win_amd64.whl", hash = "sha256:12b04d1db2663b421fe072d638a138460a51d5a862403295671c4f3987fb9148", size = 2141498, upload-time = "2026-04-03T17:05:45.7Z" },
+    { url = "https://files.pythonhosted.org/packages/28/4b/52a0cb2687a9cd1648252bb257be5a1ba2c2ded20ba695c65756a55a15a4/sqlalchemy-2.0.49-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:24bd94bb301ec672d8f0623eba9226cc90d775d25a0c92b5f8e4965d7f3a1518", size = 3560807, upload-time = "2026-04-03T16:58:31.666Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d8/fda95459204877eed0458550d6c7c64c98cc50c2d8d618026737de9ed41a/sqlalchemy-2.0.49-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a51d3db74ba489266ef55c7a4534eb0b8db9a326553df481c11e5d7660c8364d", size = 3527481, upload-time = "2026-04-03T17:06:00.155Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0a/2aac8b78ac6487240cf7afef8f203ca783e8796002dc0cf65c4ee99ff8bb/sqlalchemy-2.0.49-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:55250fe61d6ebfd6934a272ee16ef1244e0f16b7af6cd18ab5b1fc9f08631db0", size = 3468565, upload-time = "2026-04-03T16:58:33.414Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/3d/ce71cfa82c50a373fd2148b3c870be05027155ce791dc9a5dcf439790b8b/sqlalchemy-2.0.49-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:46796877b47034b559a593d7e4b549aba151dae73f9e78212a3478161c12ab08", size = 3477769, upload-time = "2026-04-03T17:06:02.787Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e8/0a9f5c1f7c6f9ca480319bf57c2d7423f08d31445974167a27d14483c948/sqlalchemy-2.0.49-cp313-cp313t-win32.whl", hash = "sha256:9c4969a86e41454f2858256c39bdfb966a20961e9b58bf8749b65abf447e9a8d", size = 2143319, upload-time = "2026-04-03T17:02:04.328Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/51/fb5240729fbec73006e137c4f7a7918ffd583ab08921e6ff81a999d6517a/sqlalchemy-2.0.49-cp313-cp313t-win_amd64.whl", hash = "sha256:b9870d15ef00e4d0559ae10ee5bc71b654d1f20076dbe8bc7ed19b4c0625ceba", size = 2175104, upload-time = "2026-04-03T17:02:05.989Z" },
+    { url = "https://files.pythonhosted.org/packages/55/33/bf28f618c0a9597d14e0b9ee7d1e0622faff738d44fe986ee287cdf1b8d0/sqlalchemy-2.0.49-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:233088b4b99ebcbc5258c755a097aa52fbf90727a03a5a80781c4b9c54347a2e", size = 2156356, upload-time = "2026-04-03T16:53:09.914Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a7/5f476227576cb8644650eff68cc35fa837d3802b997465c96b8340ced1e2/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:57ca426a48eb2c682dae8204cd89ea8ab7031e2675120a47924fabc7caacbc2a", size = 3276486, upload-time = "2026-04-03T17:07:46.9Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/84/efc7c0bf3a1c5eef81d397f6fddac855becdbb11cb38ff957888603014a7/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:685e93e9c8f399b0c96a624799820176312f5ceef958c0f88215af4013d29066", size = 3281479, upload-time = "2026-04-03T17:12:32.226Z" },
+    { url = "https://files.pythonhosted.org/packages/91/68/bb406fa4257099c67bd75f3f2261b129c63204b9155de0d450b37f004698/sqlalchemy-2.0.49-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9e0400fa22f79acc334d9a6b185dc00a44a8e6578aa7e12d0ddcd8434152b187", size = 3226269, upload-time = "2026-04-03T17:07:48.678Z" },
+    { url = "https://files.pythonhosted.org/packages/67/84/acb56c00cca9f251f437cb49e718e14f7687505749ea9255d7bd8158a6df/sqlalchemy-2.0.49-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a05977bffe9bffd2229f477fa75eabe3192b1b05f408961d1bebff8d1cd4d401", size = 3248260, upload-time = "2026-04-03T17:12:34.381Z" },
+    { url = "https://files.pythonhosted.org/packages/56/19/6a20ea25606d1efd7bd1862149bb2a22d1451c3f851d23d887969201633f/sqlalchemy-2.0.49-cp314-cp314-win32.whl", hash = "sha256:0f2fa354ba106eafff2c14b0cc51f22801d1e8b2e4149342023bd6f0955de5f5", size = 2118463, upload-time = "2026-04-03T17:05:47.093Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4f/8297e4ed88e80baa1f5aa3c484a0ee29ef3c69c7582f206c916973b75057/sqlalchemy-2.0.49-cp314-cp314-win_amd64.whl", hash = "sha256:77641d299179c37b89cf2343ca9972c88bb6eef0d5fc504a2f86afd15cd5adf5", size = 2144204, upload-time = "2026-04-03T17:05:48.694Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/33/95e7216df810c706e0cd3655a778604bbd319ed4f43333127d465a46862d/sqlalchemy-2.0.49-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c1dc3368794d522f43914e03312202523cc89692f5389c32bea0233924f8d977", size = 3565474, upload-time = "2026-04-03T16:58:35.128Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/a4/ed7b18d8ccf7f954a83af6bb73866f5bc6f5636f44c7731fbb741f72cc4f/sqlalchemy-2.0.49-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c821c47ecfe05cc32140dcf8dc6fd5d21971c86dbd56eabfe5ba07a64910c01", size = 3530567, upload-time = "2026-04-03T17:06:04.587Z" },
+    { url = "https://files.pythonhosted.org/packages/73/a3/20faa869c7e21a827c4a2a42b41353a54b0f9f5e96df5087629c306df71e/sqlalchemy-2.0.49-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9c04bff9a5335eb95c6ecf1c117576a0aa560def274876fd156cfe5510fccc61", size = 3474282, upload-time = "2026-04-03T16:58:37.131Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/50/276b9a007aa0764304ad467eceb70b04822dc32092492ee5f322d559a4dc/sqlalchemy-2.0.49-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7f605a456948c35260e7b2a39f8952a26f077fd25653c37740ed186b90aaa68a", size = 3480406, upload-time = "2026-04-03T17:06:07.176Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/c3/c80fcdb41905a2df650c2a3e0337198b6848876e63d66fe9188ef9003d24/sqlalchemy-2.0.49-cp314-cp314t-win32.whl", hash = "sha256:6270d717b11c5476b0cbb21eedc8d4dbb7d1a956fd6c15a23e96f197a6193158", size = 2149151, upload-time = "2026-04-03T17:02:07.281Z" },
+    { url = "https://files.pythonhosted.org/packages/05/52/9f1a62feab6ed368aff068524ff414f26a6daebc7361861035ae00b05530/sqlalchemy-2.0.49-cp314-cp314t-win_amd64.whl", hash = "sha256:275424295f4256fd301744b8f335cff367825d270f155d522b30c7bf49903ee7", size = 2184178, upload-time = "2026-04-03T17:02:08.623Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/30/8519fdde58a7bdf155b714359791ad1dc018b47d60269d5d160d311fdc36/sqlalchemy-2.0.49-py3-none-any.whl", hash = "sha256:ec44cfa7ef1a728e88ad41674de50f6db8cfdb3e2af84af86e0041aaf02d43d0", size = 1942158, upload-time = "2026-04-03T16:53:44.135Z" },
+]
+
+[package.optional-dependencies]
+asyncio = [
+    { name = "greenlet" },
 ]
 
 [[package]]

--- a/docker-compose.auth.yml
+++ b/docker-compose.auth.yml
@@ -63,6 +63,9 @@ services:
       - "8000:8000"
     environment:
       DATABASE_URL: postgresql+asyncpg://brc:brc@brc-app-db:5432/brc_app
+      # Create the persistent app tables on boot; without this the
+      # favorites/saved-analyses/workflow-runs endpoints 500 on a fresh stack.
+      RUN_MIGRATIONS_ON_STARTUP: "true"
       REDIS_URL: redis://redis:6379/0
       KEYCLOAK_ISSUER_URL: http://keycloak:8180/realms/galaxy
       KEYCLOAK_CLIENT_ID: brc-analytics

--- a/docker-compose.auth.yml
+++ b/docker-compose.auth.yml
@@ -62,6 +62,7 @@ services:
     ports:
       - "8000:8000"
     environment:
+      DATABASE_URL: postgresql+asyncpg://brc:brc@brc-app-db:5432/brc_app
       REDIS_URL: redis://redis:6379/0
       KEYCLOAK_ISSUER_URL: http://keycloak:8180/realms/galaxy
       KEYCLOAK_CLIENT_ID: brc-analytics
@@ -73,6 +74,8 @@ services:
     volumes:
       - ./catalog:/catalog:ro
     depends_on:
+      brc-app-db:
+        condition: service_healthy
       redis:
         condition: service_healthy
       keycloak:
@@ -94,6 +97,20 @@ services:
       timeout: 5s
       retries: 3
       start_period: 10s
+
+  brc-app-db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: brc_app
+      POSTGRES_USER: brc
+      POSTGRES_PASSWORD: brc
+    volumes:
+      - brc_app_db_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U brc -d brc_app"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   galaxy-postgres:
     image: postgres:16-alpine
@@ -144,6 +161,7 @@ services:
 
 volumes:
   keycloak_db_data:
+  brc_app_db_data:
   redis_data:
   galaxy_pg_data:
   galaxy_data:

--- a/pages/account/preferences.tsx
+++ b/pages/account/preferences.tsx
@@ -89,9 +89,9 @@ export default function PreferencesPage(): JSX.Element {
     return (
       <Stack spacing={3}>
         <Typography variant="body1">
-          This page currently acts as a JSON-backed placeholder for account
-          preferences. Saving `{}` is valid and confirms the persistent user
-          settings path works end to end.
+          Preferences are saved to your account as JSON. Specific settings will
+          appear here as they are added; until then you can edit the raw object
+          directly.
         </Typography>
         {error && <Alert severity="error">{error}</Alert>}
         {saveMessage && <Alert severity="success">{saveMessage}</Alert>}
@@ -141,7 +141,7 @@ export default function PreferencesPage(): JSX.Element {
       <SectionHero
         breadcrumbs={BREADCRUMBS}
         head="Preferences"
-        subHead="Persistent account-backed preferences are available here. V1 keeps the schema intentionally open so the API wire is in place before product-specific toggles are added."
+        subHead="Preferences are saved to your BRC account. Specific settings will be added here over time."
       />
       <Box sx={{ maxWidth: 960, mx: "auto", px: 3, py: 6, width: "100%" }}>
         {renderContent()}

--- a/pages/account/preferences.tsx
+++ b/pages/account/preferences.tsx
@@ -1,3 +1,4 @@
+import { Breadcrumb } from "@databiosphere/findable-ui/lib/components/common/Breadcrumbs/breadcrumbs";
 import {
   Alert,
   Box,
@@ -7,7 +8,6 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
-import { Breadcrumb } from "@databiosphere/findable-ui/lib/components/common/Breadcrumbs/breadcrumbs";
 import { JSX, useEffect, useState } from "react";
 import { SectionHero } from "../../app/components/Layout/components/AppLayout/components/Section/components/SectionHero/sectionHero";
 import { useAuth } from "../../app/providers/authentication";

--- a/pages/account/preferences.tsx
+++ b/pages/account/preferences.tsx
@@ -33,6 +33,11 @@ export default function PreferencesPage(): JSX.Element {
   const [saveMessage, setSaveMessage] = useState<string | null>(null);
 
   useEffect(() => {
+    // Clear any prior status so a stale error/success banner can't linger
+    // across a re-load or a sign-out/in.
+    setError(null);
+    setSaveMessage(null);
+
     if (!isAuthenticated) {
       setIsLoadingPreferences(false);
       return;

--- a/pages/account/preferences.tsx
+++ b/pages/account/preferences.tsx
@@ -1,0 +1,151 @@
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { Breadcrumb } from "@databiosphere/findable-ui/lib/components/common/Breadcrumbs/breadcrumbs";
+import { JSX, useEffect, useState } from "react";
+import { SectionHero } from "../../app/components/Layout/components/AppLayout/components/Section/components/SectionHero/sectionHero";
+import { useAuth } from "../../app/providers/authentication";
+import { brcAPIClient } from "../../app/services/brc-api-client";
+
+const BREADCRUMBS: Breadcrumb[] = [
+  {
+    path: "/",
+    text: "Home",
+  },
+  {
+    path: "/account/preferences",
+    text: "Preferences",
+  },
+];
+
+export default function PreferencesPage(): JSX.Element {
+  const { isAuthenticated, isConfigured, isLoading, login } = useAuth();
+  const [editorValue, setEditorValue] = useState("{}");
+  const [error, setError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isLoadingPreferences, setIsLoadingPreferences] = useState(true);
+  const [saveMessage, setSaveMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      setIsLoadingPreferences(false);
+      return;
+    }
+
+    let isMounted = true;
+    setIsLoadingPreferences(true);
+
+    brcAPIClient
+      .getPreferences()
+      .then((preferences) => {
+        if (!isMounted) return;
+        setEditorValue(JSON.stringify(preferences, null, 2));
+      })
+      .catch(() => {
+        if (!isMounted) return;
+        setError("Failed to load preferences.");
+      })
+      .finally(() => {
+        if (!isMounted) return;
+        setIsLoadingPreferences(false);
+      });
+
+    return (): void => {
+      isMounted = false;
+    };
+  }, [isAuthenticated]);
+
+  function renderContent(): JSX.Element {
+    if (!isConfigured || isLoading || isLoadingPreferences) {
+      return (
+        <Stack alignItems="center" py={6}>
+          <CircularProgress />
+        </Stack>
+      );
+    }
+
+    if (!isAuthenticated) {
+      return (
+        <Stack spacing={2}>
+          <Typography variant="h5">Sign in required</Typography>
+          <Typography variant="body1">
+            Preferences are tied to your BRC Analytics account session.
+          </Typography>
+          <Box>
+            <Button onClick={login} variant="contained">
+              Sign In
+            </Button>
+          </Box>
+        </Stack>
+      );
+    }
+
+    return (
+      <Stack spacing={3}>
+        <Typography variant="body1">
+          This page currently acts as a JSON-backed placeholder for account
+          preferences. Saving `{}` is valid and confirms the persistent user
+          settings path works end to end.
+        </Typography>
+        {error && <Alert severity="error">{error}</Alert>}
+        {saveMessage && <Alert severity="success">{saveMessage}</Alert>}
+        <TextField
+          fullWidth
+          minRows={14}
+          multiline
+          onChange={(event) => setEditorValue(event.target.value)}
+          value={editorValue}
+        />
+        <Box>
+          <Button disabled={isSaving} onClick={handleSave} variant="contained">
+            {isSaving ? "Saving..." : "Save Preferences"}
+          </Button>
+        </Box>
+      </Stack>
+    );
+  }
+
+  async function handleSave(): Promise<void> {
+    let parsed: Record<string, unknown>;
+
+    setError(null);
+    setSaveMessage(null);
+
+    try {
+      parsed = JSON.parse(editorValue) as Record<string, unknown>;
+    } catch {
+      setError("Preferences must be valid JSON.");
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      const saved = await brcAPIClient.updatePreferences(parsed);
+      setEditorValue(JSON.stringify(saved, null, 2));
+      setSaveMessage("Preferences saved.");
+    } catch {
+      setError("Failed to save preferences.");
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <>
+      <SectionHero
+        breadcrumbs={BREADCRUMBS}
+        head="Preferences"
+        subHead="Persistent account-backed preferences are available here. V1 keeps the schema intentionally open so the API wire is in place before product-specific toggles are added."
+      />
+      <Box sx={{ maxWidth: 960, mx: "auto", px: 3, py: 6, width: "100%" }}>
+        {renderContent()}
+      </Box>
+    </>
+  );
+}

--- a/pages/account/workflow-runs.tsx
+++ b/pages/account/workflow-runs.tsx
@@ -1,3 +1,4 @@
+import { Breadcrumb } from "@databiosphere/findable-ui/lib/components/common/Breadcrumbs/breadcrumbs";
 import {
   Box,
   Button,
@@ -6,7 +7,6 @@ import {
   Stack,
   Typography,
 } from "@mui/material";
-import { Breadcrumb } from "@databiosphere/findable-ui/lib/components/common/Breadcrumbs/breadcrumbs";
 import { JSX, useEffect, useState } from "react";
 import { SectionHero } from "../../app/components/Layout/components/AppLayout/components/Section/components/SectionHero/sectionHero";
 import { useAuth } from "../../app/providers/authentication";

--- a/pages/account/workflow-runs.tsx
+++ b/pages/account/workflow-runs.tsx
@@ -1,5 +1,6 @@
 import { Breadcrumb } from "@databiosphere/findable-ui/lib/components/common/Breadcrumbs/breadcrumbs";
 import {
+  Alert,
   Box,
   Button,
   CircularProgress,
@@ -33,22 +34,33 @@ export default function WorkflowRunsPage(): JSX.Element {
   } = useAuth();
   const [isLoading, setIsLoading] = useState(true);
   const [workflowRuns, setWorkflowRuns] = useState<WorkflowRunResponse[]>([]);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!isAuthenticated || !isConfigured) {
       setWorkflowRuns([]);
+      setError(null);
       setIsLoading(false);
       return;
     }
 
     let isMounted = true;
     setIsLoading(true);
+    setError(null);
 
     brcAPIClient
       .getWorkflowRuns()
       .then((response) => {
         if (!isMounted) return;
         setWorkflowRuns(response);
+      })
+      .catch((err) => {
+        if (!isMounted) return;
+        // Surface load failures so the empty-state copy doesn't
+        // falsely claim there are no runs.
+        setError(
+          err instanceof Error ? err.message : "Failed to load workflow runs."
+        );
       })
       .finally(() => {
         if (!isMounted) return;
@@ -84,6 +96,10 @@ export default function WorkflowRunsPage(): JSX.Element {
           </Box>
         </Stack>
       );
+    }
+
+    if (error) {
+      return <Alert severity="error">{error}</Alert>;
     }
 
     if (workflowRuns.length === 0) {

--- a/pages/account/workflow-runs.tsx
+++ b/pages/account/workflow-runs.tsx
@@ -1,0 +1,155 @@
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Link,
+  Stack,
+  Typography,
+} from "@mui/material";
+import { Breadcrumb } from "@databiosphere/findable-ui/lib/components/common/Breadcrumbs/breadcrumbs";
+import { JSX, useEffect, useState } from "react";
+import { SectionHero } from "../../app/components/Layout/components/AppLayout/components/Section/components/SectionHero/sectionHero";
+import { useAuth } from "../../app/providers/authentication";
+import { brcAPIClient } from "../../app/services/brc-api-client";
+import { WorkflowRunResponse } from "../../app/types/api";
+
+const BREADCRUMBS: Breadcrumb[] = [
+  {
+    path: "/",
+    text: "Home",
+  },
+  {
+    path: "/account/workflow-runs",
+    text: "Workflow Runs",
+  },
+];
+
+export default function WorkflowRunsPage(): JSX.Element {
+  const {
+    isAuthenticated,
+    isConfigured,
+    isLoading: isAuthLoading,
+    login,
+  } = useAuth();
+  const [isLoading, setIsLoading] = useState(true);
+  const [workflowRuns, setWorkflowRuns] = useState<WorkflowRunResponse[]>([]);
+
+  useEffect(() => {
+    if (!isAuthenticated || !isConfigured) {
+      setWorkflowRuns([]);
+      setIsLoading(false);
+      return;
+    }
+
+    let isMounted = true;
+    setIsLoading(true);
+
+    brcAPIClient
+      .getWorkflowRuns()
+      .then((response) => {
+        if (!isMounted) return;
+        setWorkflowRuns(response);
+      })
+      .finally(() => {
+        if (!isMounted) return;
+        setIsLoading(false);
+      });
+
+    return (): void => {
+      isMounted = false;
+    };
+  }, [isAuthenticated, isConfigured]);
+
+  function renderContent(): JSX.Element {
+    if (!isConfigured || isAuthLoading || isLoading) {
+      return (
+        <Stack alignItems="center" py={6}>
+          <CircularProgress />
+        </Stack>
+      );
+    }
+
+    if (!isAuthenticated) {
+      return (
+        <Stack spacing={2}>
+          <Typography variant="h5">Sign in required</Typography>
+          <Typography variant="body1">
+            Workflow run history is attached to your authenticated BRC Analytics
+            account when available.
+          </Typography>
+          <Box>
+            <Button onClick={login} variant="contained">
+              Sign In
+            </Button>
+          </Box>
+        </Stack>
+      );
+    }
+
+    if (workflowRuns.length === 0) {
+      return (
+        <Typography variant="body1">
+          You have not launched any tracked workflow handoffs yet.
+        </Typography>
+      );
+    }
+
+    return (
+      <Stack spacing={2}>
+        {workflowRuns.map((workflowRun) => (
+          <Box
+            key={workflowRun.id}
+            sx={{
+              border: (theme) => `1px solid ${theme.palette.divider}`,
+              borderRadius: 2,
+              p: 3,
+            }}
+          >
+            <Stack spacing={1}>
+              <Typography component="h2" variant="h6">
+                {workflowRun.workflow_trs_id}
+              </Typography>
+              {workflowRun.assembly_accession && (
+                <Typography color="text.secondary" variant="body2">
+                  Assembly: {workflowRun.assembly_accession}
+                </Typography>
+              )}
+              <Typography color="text.secondary" variant="body2">
+                Source: {workflowRun.launch_source}
+              </Typography>
+              <Typography color="text.secondary" variant="body2">
+                Status: {workflowRun.status}
+              </Typography>
+              <Typography color="text.secondary" variant="body2">
+                Tracked {new Date(workflowRun.created_at).toLocaleString()}
+              </Typography>
+              <Box>
+                <Link
+                  href={workflowRun.handoff_url}
+                  rel="noreferrer"
+                  target="_blank"
+                  underline="hover"
+                >
+                  Open Galaxy Handoff URL
+                </Link>
+              </Box>
+            </Stack>
+          </Box>
+        ))}
+      </Stack>
+    );
+  }
+
+  return (
+    <>
+      <SectionHero
+        breadcrumbs={BREADCRUMBS}
+        head="Workflow Runs"
+        subHead="Workflow handoffs are tracked here once they are associated with your account. Anonymous launches are still recorded in the database, but only authenticated runs are listed on this page."
+      />
+      <Box sx={{ maxWidth: 960, mx: "auto", px: 3, py: 6, width: "100%" }}>
+        {renderContent()}
+      </Box>
+    </>
+  );
+}

--- a/pages/account/workflow-runs.tsx
+++ b/pages/account/workflow-runs.tsx
@@ -161,7 +161,7 @@ export default function WorkflowRunsPage(): JSX.Element {
       <SectionHero
         breadcrumbs={BREADCRUMBS}
         head="Workflow Runs"
-        subHead="Workflow handoffs are tracked here once they are associated with your account. Anonymous launches are still recorded in the database, but only authenticated runs are listed on this page."
+        subHead="Workflow handoffs are tracked here once they are associated with your account. Anonymous launches are still recorded, but only authenticated runs are listed on this page."
       />
       <Box sx={{ maxWidth: 960, mx: "auto", px: 3, py: 6, width: "100%" }}>
         {renderContent()}

--- a/pages/assistant/index.tsx
+++ b/pages/assistant/index.tsx
@@ -1,11 +1,25 @@
 import { GetStaticProps } from "next";
+import { useRouter } from "next/router";
 import { JSX } from "react";
 import { BRC_PAGE_META } from "../../app/common/meta/brc/constants";
 import { StyledPagesMain } from "../../app/components/Layout/components/Main/main.styles";
 import { AssistantView } from "../../app/views/AssistantView/assistantView";
 
 export const Assistant = (): JSX.Element => {
-  return <AssistantView />;
+  const { query } = useRouter();
+  const initialSavedAnalysisId =
+    typeof query.savedAnalysisId === "string"
+      ? query.savedAnalysisId
+      : undefined;
+  const initialSessionId =
+    typeof query.sessionId === "string" ? query.sessionId : undefined;
+
+  return (
+    <AssistantView
+      initialSavedAnalysisId={initialSavedAnalysisId}
+      initialSessionId={initialSessionId}
+    />
+  );
 };
 
 export const getStaticProps: GetStaticProps = async () => {

--- a/pages/assistant/index.tsx
+++ b/pages/assistant/index.tsx
@@ -7,19 +7,10 @@ import { AssistantView } from "../../app/views/AssistantView/assistantView";
 
 export const Assistant = (): JSX.Element => {
   const { query } = useRouter();
-  const initialSavedAnalysisId =
-    typeof query.savedAnalysisId === "string"
-      ? query.savedAnalysisId
-      : undefined;
   const initialSessionId =
     typeof query.sessionId === "string" ? query.sessionId : undefined;
 
-  return (
-    <AssistantView
-      initialSavedAnalysisId={initialSavedAnalysisId}
-      initialSessionId={initialSessionId}
-    />
-  );
+  return <AssistantView initialSessionId={initialSessionId} />;
 };
 
 export const getStaticProps: GetStaticProps = async () => {

--- a/pages/assistant/saved.tsx
+++ b/pages/assistant/saved.tsx
@@ -1,3 +1,4 @@
+import { Breadcrumb } from "@databiosphere/findable-ui/lib/components/common/Breadcrumbs/breadcrumbs";
 import {
   Box,
   Button,
@@ -5,7 +6,6 @@ import {
   Stack,
   Typography,
 } from "@mui/material";
-import { Breadcrumb } from "@databiosphere/findable-ui/lib/components/common/Breadcrumbs/breadcrumbs";
 import { useRouter } from "next/router";
 import { JSX, useEffect, useState } from "react";
 import { SectionHero } from "../../app/components/Layout/components/AppLayout/components/Section/components/SectionHero/sectionHero";

--- a/pages/assistant/saved.tsx
+++ b/pages/assistant/saved.tsx
@@ -1,8 +1,17 @@
-import { Box, Button, Stack, Typography } from "@mui/material";
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Stack,
+  Typography,
+} from "@mui/material";
 import { Breadcrumb } from "@databiosphere/findable-ui/lib/components/common/Breadcrumbs/breadcrumbs";
-import { JSX } from "react";
+import { useRouter } from "next/router";
+import { JSX, useEffect, useState } from "react";
 import { SectionHero } from "../../app/components/Layout/components/AppLayout/components/Section/components/SectionHero/sectionHero";
 import { useAuth } from "../../app/providers/authentication";
+import { brcAPIClient } from "../../app/services/brc-api-client";
+import { SavedAnalysisSummary } from "../../app/types/api";
 
 const BREADCRUMBS: Breadcrumb[] = [
   {
@@ -20,30 +29,141 @@ const BREADCRUMBS: Breadcrumb[] = [
 ];
 
 export default function SavedAnalysesPage(): JSX.Element {
-  const { isAuthenticated, isConfigured, isLoading, login } = useAuth();
+  const {
+    isAuthenticated,
+    isConfigured,
+    isLoading: isAuthLoading,
+    login,
+  } = useAuth();
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(true);
+  const [savedAnalyses, setSavedAnalyses] = useState<SavedAnalysisSummary[]>(
+    []
+  );
+
+  useEffect(() => {
+    if (!isAuthenticated || !isConfigured) {
+      setSavedAnalyses([]);
+      setIsLoading(false);
+      return;
+    }
+
+    let isMounted = true;
+    setIsLoading(true);
+
+    brcAPIClient
+      .getSavedAnalyses()
+      .then((response) => {
+        if (!isMounted) return;
+        setSavedAnalyses(response);
+      })
+      .finally(() => {
+        if (!isMounted) return;
+        setIsLoading(false);
+      });
+
+    return (): void => {
+      isMounted = false;
+    };
+  }, [isAuthenticated, isConfigured]);
+
+  async function handleDelete(id: string): Promise<void> {
+    await brcAPIClient.deleteSavedAnalysis(id);
+    setSavedAnalyses((current) => current.filter((item) => item.id !== id));
+  }
+
+  async function handleRestore(id: string): Promise<void> {
+    const restored = await brcAPIClient.restoreSavedAnalysis(id);
+    await router.push({
+      pathname: "/assistant",
+      query: {
+        savedAnalysisId: id,
+        sessionId: restored.session_id,
+      },
+    });
+  }
+
+  function renderContent(): JSX.Element {
+    if (!isConfigured || isAuthLoading || isLoading) {
+      return (
+        <Stack alignItems="center" py={6}>
+          <CircularProgress />
+        </Stack>
+      );
+    }
+
+    if (!isAuthenticated) {
+      return (
+        <Stack spacing={2}>
+          <Typography variant="h5">Sign in required</Typography>
+          <Typography variant="body1">
+            Saved analyses are tied to your authenticated session.
+          </Typography>
+          <Box>
+            <Button onClick={login} variant="contained">
+              Sign In
+            </Button>
+          </Box>
+        </Stack>
+      );
+    }
+
+    if (savedAnalyses.length === 0) {
+      return (
+        <Typography variant="body1">
+          You have not saved any assistant analyses yet.
+        </Typography>
+      );
+    }
+
+    return (
+      <Stack spacing={2}>
+        {savedAnalyses.map((savedAnalysis) => (
+          <Box
+            key={savedAnalysis.id}
+            sx={{
+              border: (theme) => `1px solid ${theme.palette.divider}`,
+              borderRadius: 2,
+              p: 3,
+            }}
+          >
+            <Stack spacing={1.5}>
+              <Typography component="h2" variant="h6">
+                {savedAnalysis.title ?? "Saved analysis"}
+              </Typography>
+              <Typography color="text.secondary" variant="body2">
+                Saved {new Date(savedAnalysis.updated_at).toLocaleString()}
+              </Typography>
+              <Stack direction="row" spacing={1}>
+                <Button
+                  onClick={() => void handleRestore(savedAnalysis.id)}
+                  variant="contained"
+                >
+                  Restore
+                </Button>
+                <Button
+                  onClick={() => void handleDelete(savedAnalysis.id)}
+                  variant="outlined"
+                >
+                  Delete
+                </Button>
+              </Stack>
+            </Stack>
+          </Box>
+        ))}
+      </Stack>
+    );
+  }
 
   return (
     <>
       <SectionHero
         breadcrumbs={BREADCRUMBS}
         head="Saved Analyses"
-        subHead="Persistent assistant snapshots will appear here once the snapshot and restore flow is wired in."
+        subHead="Saved assistant sessions are restored into a fresh working session so the snapshot stays immutable."
       />
       <Box sx={{ maxWidth: 960, mx: "auto", px: 3, py: 6, width: "100%" }}>
-        <Stack spacing={2}>
-          <Typography variant="body1">
-            This route is intentionally present before the saved-analyses
-            feature is complete so the authenticated account menu has a stable
-            destination.
-          </Typography>
-          {isConfigured && !isLoading && !isAuthenticated && (
-            <Box>
-              <Button onClick={login} variant="contained">
-                Sign In
-              </Button>
-            </Box>
-          )}
-        </Stack>
+        {renderContent()}
       </Box>
     </>
   );

--- a/pages/assistant/saved.tsx
+++ b/pages/assistant/saved.tsx
@@ -97,10 +97,7 @@ export default function SavedAnalysesPage(): JSX.Element {
       const restored = await brcAPIClient.restoreSavedAnalysis(id);
       await router.push({
         pathname: "/assistant",
-        query: {
-          savedAnalysisId: id,
-          sessionId: restored.session_id,
-        },
+        query: { sessionId: restored.session_id },
       });
     } catch (err) {
       setError(

--- a/pages/assistant/saved.tsx
+++ b/pages/assistant/saved.tsx
@@ -1,0 +1,50 @@
+import { Box, Button, Stack, Typography } from "@mui/material";
+import { Breadcrumb } from "@databiosphere/findable-ui/lib/components/common/Breadcrumbs/breadcrumbs";
+import { JSX } from "react";
+import { SectionHero } from "../../app/components/Layout/components/AppLayout/components/Section/components/SectionHero/sectionHero";
+import { useAuth } from "../../app/providers/authentication";
+
+const BREADCRUMBS: Breadcrumb[] = [
+  {
+    path: "/",
+    text: "Home",
+  },
+  {
+    path: "/assistant",
+    text: "Assistant",
+  },
+  {
+    path: "/assistant/saved",
+    text: "Saved Analyses",
+  },
+];
+
+export default function SavedAnalysesPage(): JSX.Element {
+  const { isAuthenticated, isConfigured, isLoading, login } = useAuth();
+
+  return (
+    <>
+      <SectionHero
+        breadcrumbs={BREADCRUMBS}
+        head="Saved Analyses"
+        subHead="Persistent assistant snapshots will appear here once the snapshot and restore flow is wired in."
+      />
+      <Box sx={{ maxWidth: 960, mx: "auto", px: 3, py: 6, width: "100%" }}>
+        <Stack spacing={2}>
+          <Typography variant="body1">
+            This route is intentionally present before the saved-analyses
+            feature is complete so the authenticated account menu has a stable
+            destination.
+          </Typography>
+          {isConfigured && !isLoading && !isAuthenticated && (
+            <Box>
+              <Button onClick={login} variant="contained">
+                Sign In
+              </Button>
+            </Box>
+          )}
+        </Stack>
+      </Box>
+    </>
+  );
+}

--- a/pages/assistant/saved.tsx
+++ b/pages/assistant/saved.tsx
@@ -1,5 +1,6 @@
 import { Breadcrumb } from "@databiosphere/findable-ui/lib/components/common/Breadcrumbs/breadcrumbs";
 import {
+  Alert,
   Box,
   Button,
   CircularProgress,
@@ -40,22 +41,33 @@ export default function SavedAnalysesPage(): JSX.Element {
   const [savedAnalyses, setSavedAnalyses] = useState<SavedAnalysisSummary[]>(
     []
   );
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!isAuthenticated || !isConfigured) {
       setSavedAnalyses([]);
+      setError(null);
       setIsLoading(false);
       return;
     }
 
     let isMounted = true;
     setIsLoading(true);
+    setError(null);
 
     brcAPIClient
       .getSavedAnalyses()
       .then((response) => {
         if (!isMounted) return;
         setSavedAnalyses(response);
+      })
+      .catch((err) => {
+        if (!isMounted) return;
+        // Surface load failures so the empty-state copy doesn't
+        // falsely claim "you have not saved any analyses yet."
+        setError(
+          err instanceof Error ? err.message : "Failed to load saved analyses."
+        );
       })
       .finally(() => {
         if (!isMounted) return;
@@ -68,19 +80,33 @@ export default function SavedAnalysesPage(): JSX.Element {
   }, [isAuthenticated, isConfigured]);
 
   async function handleDelete(id: string): Promise<void> {
-    await brcAPIClient.deleteSavedAnalysis(id);
-    setSavedAnalyses((current) => current.filter((item) => item.id !== id));
+    setError(null);
+    try {
+      await brcAPIClient.deleteSavedAnalysis(id);
+      setSavedAnalyses((current) => current.filter((item) => item.id !== id));
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to delete saved analysis."
+      );
+    }
   }
 
   async function handleRestore(id: string): Promise<void> {
-    const restored = await brcAPIClient.restoreSavedAnalysis(id);
-    await router.push({
-      pathname: "/assistant",
-      query: {
-        savedAnalysisId: id,
-        sessionId: restored.session_id,
-      },
-    });
+    setError(null);
+    try {
+      const restored = await brcAPIClient.restoreSavedAnalysis(id);
+      await router.push({
+        pathname: "/assistant",
+        query: {
+          savedAnalysisId: id,
+          sessionId: restored.session_id,
+        },
+      });
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to restore saved analysis."
+      );
+    }
   }
 
   function renderContent(): JSX.Element {
@@ -108,6 +134,10 @@ export default function SavedAnalysesPage(): JSX.Element {
       );
     }
 
+    if (error && savedAnalyses.length === 0) {
+      return <Alert severity="error">{error}</Alert>;
+    }
+
     if (savedAnalyses.length === 0) {
       return (
         <Typography variant="body1">
@@ -118,6 +148,7 @@ export default function SavedAnalysesPage(): JSX.Element {
 
     return (
       <Stack spacing={2}>
+        {error && <Alert severity="error">{error}</Alert>}
         {savedAnalyses.map((savedAnalysis) => (
           <Box
             key={savedAnalysis.id}

--- a/pages/data/favorites.tsx
+++ b/pages/data/favorites.tsx
@@ -1,8 +1,19 @@
-import { Box, Button, Stack, Typography } from "@mui/material";
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Stack,
+  Typography,
+} from "@mui/material";
 import { Breadcrumb } from "@databiosphere/findable-ui/lib/components/common/Breadcrumbs/breadcrumbs";
+import Link from "next/link";
 import { JSX } from "react";
+import { sanitizeEntityId } from "../../app/apis/catalog/common/utils";
 import { SectionHero } from "../../app/components/Layout/components/AppLayout/components/Section/components/SectionHero/sectionHero";
+import { useAssemblyFavorites } from "../../app/hooks/useAssemblyFavorites";
 import { useAuth } from "../../app/providers/authentication";
+import { getEntity } from "../../app/services/workflows/query";
+import { Assembly } from "../../app/views/WorkflowInputsView/types";
 
 const BREADCRUMBS: Breadcrumb[] = [
   {
@@ -16,29 +27,96 @@ const BREADCRUMBS: Breadcrumb[] = [
 ];
 
 export default function FavoritesPage(): JSX.Element {
-  const { isAuthenticated, isConfigured, isLoading, login } = useAuth();
+  const {
+    isAuthenticated,
+    isConfigured,
+    isLoading: isAuthLoading,
+    login,
+  } = useAuth();
+  const { favorites, isLoading } = useAssemblyFavorites();
+
+  function getAssembly(accession: string): Assembly | null {
+    try {
+      return getEntity<Assembly>("assemblies", sanitizeEntityId(accession));
+    } catch {
+      return null;
+    }
+  }
+
+  function renderContent(): JSX.Element {
+    if (!isConfigured || isAuthLoading || isLoading) {
+      return (
+        <Stack alignItems="center" py={6}>
+          <CircularProgress />
+        </Stack>
+      );
+    }
+
+    if (!isAuthenticated) {
+      return (
+        <Stack spacing={2}>
+          <Typography variant="h5">Sign in required</Typography>
+          <Typography variant="body1">
+            Favorites are stored per account.
+          </Typography>
+          <Box>
+            <Button onClick={login} variant="contained">
+              Sign In
+            </Button>
+          </Box>
+        </Stack>
+      );
+    }
+
+    if (favorites.length === 0) {
+      return (
+        <Typography variant="body1">
+          You have not saved any assemblies yet.
+        </Typography>
+      );
+    }
+
+    return (
+      <Stack spacing={2}>
+        {favorites.map((favorite) => {
+          const assembly = getAssembly(favorite.entity_id);
+          const href = `/data/assemblies/${sanitizeEntityId(favorite.entity_id)}`;
+
+          return (
+            <Box
+              key={`${favorite.entity_type}:${favorite.entity_id}`}
+              sx={{
+                border: (theme) => `1px solid ${theme.palette.divider}`,
+                borderRadius: 2,
+                p: 3,
+              }}
+            >
+              <Stack spacing={1}>
+                <Typography component="h2" variant="h6">
+                  {assembly?.accession ?? favorite.entity_id}
+                </Typography>
+                <Box>
+                  <Button LinkComponent={Link} href={href} variant="outlined">
+                    Open Assembly
+                  </Button>
+                </Box>
+              </Stack>
+            </Box>
+          );
+        })}
+      </Stack>
+    );
+  }
 
   return (
     <>
       <SectionHero
         breadcrumbs={BREADCRUMBS}
         head="Favorites"
-        subHead="Saved assemblies will appear here once the favorites flow is wired in."
+        subHead="Saved assemblies follow your authenticated account and stay available across visits."
       />
       <Box sx={{ maxWidth: 960, mx: "auto", px: 3, py: 6, width: "100%" }}>
-        <Stack spacing={2}>
-          <Typography variant="body1">
-            This route is in place so account navigation is stable while the
-            favorites implementation lands in the next slice.
-          </Typography>
-          {isConfigured && !isLoading && !isAuthenticated && (
-            <Box>
-              <Button onClick={login} variant="contained">
-                Sign In
-              </Button>
-            </Box>
-          )}
-        </Stack>
+        {renderContent()}
       </Box>
     </>
   );

--- a/pages/data/favorites.tsx
+++ b/pages/data/favorites.tsx
@@ -1,5 +1,6 @@
 import { Breadcrumb } from "@databiosphere/findable-ui/lib/components/common/Breadcrumbs/breadcrumbs";
 import {
+  Alert,
   Box,
   Button,
   CircularProgress,
@@ -33,7 +34,7 @@ export default function FavoritesPage(): JSX.Element {
     isLoading: isAuthLoading,
     login,
   } = useAuth();
-  const { favorites, isLoading } = useAssemblyFavorites();
+  const { error, favorites, isLoading } = useAssemblyFavorites();
 
   function getAssembly(accession: string): Assembly | null {
     try {
@@ -65,6 +66,14 @@ export default function FavoritesPage(): JSX.Element {
             </Button>
           </Box>
         </Stack>
+      );
+    }
+
+    if (error) {
+      return (
+        <Alert severity="error">
+          Failed to load favorites: {error.message}
+        </Alert>
       );
     }
 

--- a/pages/data/favorites.tsx
+++ b/pages/data/favorites.tsx
@@ -1,3 +1,4 @@
+import { Breadcrumb } from "@databiosphere/findable-ui/lib/components/common/Breadcrumbs/breadcrumbs";
 import {
   Box,
   Button,
@@ -5,7 +6,6 @@ import {
   Stack,
   Typography,
 } from "@mui/material";
-import { Breadcrumb } from "@databiosphere/findable-ui/lib/components/common/Breadcrumbs/breadcrumbs";
 import Link from "next/link";
 import { JSX } from "react";
 import { sanitizeEntityId } from "../../app/apis/catalog/common/utils";

--- a/pages/data/favorites.tsx
+++ b/pages/data/favorites.tsx
@@ -1,0 +1,45 @@
+import { Box, Button, Stack, Typography } from "@mui/material";
+import { Breadcrumb } from "@databiosphere/findable-ui/lib/components/common/Breadcrumbs/breadcrumbs";
+import { JSX } from "react";
+import { SectionHero } from "../../app/components/Layout/components/AppLayout/components/Section/components/SectionHero/sectionHero";
+import { useAuth } from "../../app/providers/authentication";
+
+const BREADCRUMBS: Breadcrumb[] = [
+  {
+    path: "/",
+    text: "Home",
+  },
+  {
+    path: "/data/favorites",
+    text: "Favorites",
+  },
+];
+
+export default function FavoritesPage(): JSX.Element {
+  const { isAuthenticated, isConfigured, isLoading, login } = useAuth();
+
+  return (
+    <>
+      <SectionHero
+        breadcrumbs={BREADCRUMBS}
+        head="Favorites"
+        subHead="Saved assemblies will appear here once the favorites flow is wired in."
+      />
+      <Box sx={{ maxWidth: 960, mx: "auto", px: 3, py: 6, width: "100%" }}>
+        <Stack spacing={2}>
+          <Typography variant="body1">
+            This route is in place so account navigation is stable while the
+            favorites implementation lands in the next slice.
+          </Typography>
+          {isConfigured && !isLoading && !isAuthenticated && (
+            <Box>
+              <Button onClick={login} variant="contained">
+                Sign In
+              </Button>
+            </Box>
+          )}
+        </Stack>
+      </Box>
+    </>
+  );
+}

--- a/tests/hooks/useAssemblyFavorites.test.ts
+++ b/tests/hooks/useAssemblyFavorites.test.ts
@@ -1,0 +1,72 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useAssemblyFavorites } from "../../app/hooks/useAssemblyFavorites";
+import { useAuth } from "../../app/providers/authentication";
+import { brcAPIClient } from "../../app/services/brc-api-client";
+import { FavoriteResponse } from "../../app/types/api";
+
+jest.mock("../../app/providers/authentication", () => ({
+  useAuth: jest.fn(),
+}));
+jest.mock("../../app/services/brc-api-client", () => ({
+  brcAPIClient: {
+    createFavorite: jest.fn(),
+    deleteFavorite: jest.fn(),
+    getFavorites: jest.fn(),
+  },
+}));
+
+const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+const mockClient = brcAPIClient as jest.Mocked<typeof brcAPIClient>;
+
+const ACCESSION = "GCF_000001405.40";
+
+describe("useAssemblyFavorites", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      isConfigured: true,
+    } as unknown as ReturnType<typeof useAuth>);
+    mockClient.getFavorites.mockResolvedValue([]);
+  });
+
+  test("flags isToggling while a toggle request is in flight", async () => {
+    let resolveCreate: ((value: FavoriteResponse) => void) | undefined;
+    mockClient.createFavorite.mockReturnValue(
+      new Promise<FavoriteResponse>((resolve) => {
+        resolveCreate = resolve;
+      })
+    );
+
+    const { result } = renderHook(() => useAssemblyFavorites());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let togglePromise: Promise<void> | undefined;
+    act(() => {
+      togglePromise = result.current.toggleFavorite(ACCESSION);
+    });
+
+    expect(result.current.isToggling).toBe(true);
+
+    await act(async () => {
+      resolveCreate?.({ entity_id: ACCESSION } as FavoriteResponse);
+      await togglePromise;
+    });
+
+    expect(result.current.isToggling).toBe(false);
+  });
+
+  test("clears isToggling and records error when a toggle fails", async () => {
+    mockClient.createFavorite.mockRejectedValue(new Error("network down"));
+
+    const { result } = renderHook(() => useAssemblyFavorites());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.toggleFavorite(ACCESSION);
+    });
+
+    expect(result.current.isToggling).toBe(false);
+    expect(result.current.error).toBeInstanceOf(Error);
+  });
+});


### PR DESCRIPTION
## What this does

Adds a DB-backed user persistence layer on top of the already-merged Keycloak SSO foundation:

- **Favorites** -- users can save assembly entities; "Saved" state survives reload and is scoped per account.
- **Saved analyses** -- assistant chat sessions can be snapshotted, listed at `/assistant/saved`, and restored back into a fresh working session.
- **Workflow run tracking** -- every Galaxy handoff (from site browse or from the assistant) records a row in `workflow_runs`, so users see their launch history at `/account/workflow-runs` and the `launch_source="assistant"` analytics correlate back to the originating chat session.
- **Account menu + preferences page** -- a header dropdown gates the four new pages; the preferences page is a placeholder that persists a raw JSON object, confirming the account-settings path works end to end.

## Architecture

New Postgres tables under `backend/api/app/db/`: `users`, `favorites`, `saved_analyses`, `workflow_runs`. SQLAlchemy 2.x async + Alembic migrations. The Keycloak OIDC callback upserts the user row, with a guard against the concurrent-first-login race (two simultaneous first requests no longer collide on the insert -- the loser catches `IntegrityError`, rolls back, refetches, and updates).

New API endpoints under `/api/v1/`:
- `auth/me`, `user/me`, `user/preferences`
- `favorites` (GET/POST/DELETE)
- `saved_analyses` (GET/POST/DELETE/restore)
- `workflow_runs` (GET/POST)

Frontend: account menu component, four new pages (`/data/favorites`, `/assistant/saved`, `/account/workflow-runs`, `/account/preferences`), an `AssemblyFavoriteButton` (disabled while a toggle is in flight, so a fast double-click can't fire racing add/remove calls off a stale snapshot), a `useAssemblyFavorites` hook, and a `brc-api-client` service for talking to the new endpoints. `useAssistantChat` and `useLaunchGalaxy` are extended to thread saved-analysis IDs and workflow-run tracking through.

Server-side ownership is enforced from the auth session, never from request bodies. Tests cover cross-user isolation (`test_user_persistence_api.py`, `test_workflow_runs_api.py`) and the assistant-session ownership check on the workflow-runs POST.

Anonymous-to-authenticated handoff: a chat session started while logged out can be claimed by the user when they sign in. `SessionService.claim_session()` stamps the user's sub onto an anonymous session, gated on possession of the signed session cookie -- so in deployed environments (where `SESSION_COOKIE_SECRET` is set; the gate no-ops in local/dev when it's unset) knowing the session ID alone is not enough to claim it. Applied to `/assistant/chat` (continue) and `/saved_analyses` POST (save), and covered by a session-cookie-gate test on the save path (valid cookie -> 200, missing/wrong -> 403).

## Testing performed

- Full local gate is green on the current tip: Prettier, ESLint, `tsc --noEmit`, backend `uv run pytest` (220 passing; the 8 `test_links.py` smoke tests need a live Docker backend and are excluded), and the frontend Jest suite (555 passing). Branch is rebased onto current `main`.
- Drove the four flows end to end in a browser against the `docker-compose.auth.yml` stack (Keycloak + Postgres + Redis + Galaxy): SSO login + user upsert, favorites add/remove/persist, workflow-runs API + listing. The saved-analyses save path was exercised via API + DB (the assistant UI save flow needs an LLM key the test stack doesn't carry).
- Verified server-side ownership: POSTing `/favorites` with a fabricated `user_id` body field is ignored; the favorite lands on the authenticated user.
- Verified the workflow_runs ownership fix in the live stack: a bogus `assistant_session_id` is rejected with 404.

## Notes for reviewers

- DB migrations are off by default on startup. The `docker-compose.auth.yml` stack sets `RUN_MIGRATIONS_ON_STARTUP=true` for local/dev/CI; prod deploys keep explicit migration control via `alembic upgrade head` at deploy time.
- `workflow_runs.user_id` uses `ON DELETE SET NULL` on purpose -- the table mixes authenticated and anonymous tracking, so a deleted user's run gracefully becomes an anonymous record rather than being lost.
- `compute_handoff()` carries the assistant session ID into Galaxy handoff URLs as `?assistantSessionId=...`. That's what wires the `launch_source="assistant"` correlation together; the frontend `useLaunchGalaxy` reads it back when recording the run.
- This introduces an app database: `DATABASE_URL` is now required for the persistent-user features (`get_engine()` raises if it's unset), and `docker-compose.auth.yml` adds a `brc-app-db` Postgres service alongside the migration knob.
- The full husky gate (Prettier / ESLint / `tsc` + `ruff format`) now passes on the branch tip, which is rebased onto current `main` on top of the merged Keycloak auth.

## Out of scope for this PR

- `/account/preferences` is a self-acknowledged placeholder until product picks settings to wire up.
- The API `version` field still reports the Dockerfile default rather than `package.json` -- separate hygiene fix.
- Anonymous POSTs to `/workflow_runs` aren't rate-limited yet (audit flagged it; rate-limiting is its own change). The body-size cap added here handles the payload-abuse angle; request-frequency is separate.
- True pre-parse request-size protection (middleware / proxy limits). The Content-Length checks in `/user/preferences` and `/workflow_runs` are authoritative for storage size, but FastAPI has already parsed the body before they run -- deferred to an ingress-layer change.
- A handful of small audit nits (entity_type query validation, mid-word title truncation, saveAnalysis error-message granularity) deferred to keep this PR focused.

