### PR TITLE
feat: mark the analysis assistant page as beta

### DIFF
--- a/app/views/AssistantView/assistantView.tsx
+++ b/app/views/AssistantView/assistantView.tsx
@@ -59,7 +59,7 @@ export const AssistantView = (): JSX.Element => {
     <Fragment>
       <SectionHero
         breadcrumbs={BREADCRUMBS}
-        head="Analysis Assistant"
+        head="Analysis Assistant (Beta)"
         subHead="Explore data and configure analyses with AI guidance"
       />
       <AssistantSection>


### PR DESCRIPTION
Adds a `(Beta)` marker to the assistant page title ("Analysis Assistant (Beta)") so users know it's a work in progress during the beta launch.

Closes #1291.

**Coordination:** touches the same title as #1289 (compact header). If #1289 lands first this is a trivial rebase -- the "(Beta)" just moves into the new compact header.
