### PR TITLE
fix: use a compact header on the assistant page so the chat fits the viewport

### DIFF
--- a/app/views/AssistantView/assistantView.styles.ts
+++ b/app/views/AssistantView/assistantView.styles.ts
@@ -18,12 +18,12 @@ export const CompactHeader = styled(Box)`
   padding-bottom: 16px;
 `;
 
-export const CompactHead = styled(Box)`
-  font-family: "Inter", sans-serif;
+export const CompactHead = styled.h1`
+  font-family: "Inter Tight", sans-serif;
   font-size: 28px;
   font-weight: 500;
   line-height: 36px;
-  margin-top: 8px;
+  margin: 8px 0 0;
 `;
 
 export const TwoPanelLayout = styled(Box)({

--- a/app/views/AssistantView/assistantView.styles.ts
+++ b/app/views/AssistantView/assistantView.styles.ts
@@ -14,6 +14,18 @@ export const SectionContent = styled(Box)`
   width: calc(100% - 32px);
 `;
 
+export const CompactHeader = styled(Box)`
+  padding-bottom: 16px;
+`;
+
+export const CompactHead = styled(Box)`
+  font-family: "Inter", sans-serif;
+  font-size: 28px;
+  font-weight: 500;
+  line-height: 36px;
+  margin-top: 8px;
+`;
+
 export const TwoPanelLayout = styled(Box)({
   "@media (min-width: 960px)": {
     flexDirection: "row",

--- a/app/views/AssistantView/assistantView.tsx
+++ b/app/views/AssistantView/assistantView.tsx
@@ -1,10 +1,10 @@
+import { Breadcrumbs } from "@databiosphere/findable-ui/lib/components/common/Breadcrumbs/breadcrumbs";
 import { useFeatureFlag } from "@databiosphere/findable-ui/lib/hooks/useFeatureFlag/useFeatureFlag";
 import RestartAltIcon from "@mui/icons-material/RestartAlt";
 import { Box, Button } from "@mui/material";
 import Error from "next/error";
-import { Fragment, JSX, useEffect, useState } from "react";
+import { JSX, useEffect, useState } from "react";
 import { ChatPanel, SchemaPanel } from "../../components/Assistant";
-import { SectionHero } from "../../components/Layout/components/AppLayout/components/Section/components/SectionHero/sectionHero";
 import { useAssistantChat } from "../../hooks/useAssistantChat";
 import { llmAPIClient } from "../../services/llm-api-client";
 import { AssistantInfoResponse } from "../../types/api";
@@ -12,6 +12,8 @@ import {
   AssistantDisclaimer,
   AssistantSection,
   ChatColumn,
+  CompactHead,
+  CompactHeader,
   SchemaColumn,
   SectionContent,
   TwoPanelLayout,
@@ -56,48 +58,45 @@ export const AssistantView = (): JSX.Element => {
   const modelLabel = formatModelLabel(info);
 
   return (
-    <Fragment>
-      <SectionHero
-        breadcrumbs={BREADCRUMBS}
-        head="Analysis Assistant (Beta)"
-        subHead="Explore data and configure analyses with AI guidance"
-      />
-      <AssistantSection>
-        <SectionContent>
-          <Box sx={{ display: "flex", justifyContent: "flex-end", pb: 1 }}>
-            <Button
-              onClick={resetSession}
-              size="small"
-              startIcon={<RestartAltIcon />}
-              sx={{ visibility: showReset ? "visible" : "hidden" }}
-              variant="text"
-            >
-              New Conversation
-            </Button>
-          </Box>
-          <TwoPanelLayout>
-            <ChatColumn>
-              <ChatPanel
-                error={error}
-                isRestoring={isRestoring}
-                loading={loading}
-                messages={messages}
-                onRetry={onRetry}
-                onSend={sendMessage}
-                suggestions={suggestions}
-              />
-            </ChatColumn>
-            <SchemaColumn>
-              <SchemaPanel handoffUrl={handoffUrl} schema={schema} />
-            </SchemaColumn>
-          </TwoPanelLayout>
-          <AssistantDisclaimer>
-            AI assistant — {modelLabel}. Responses can be inaccurate; verify
-            anything important before relying on it.
-          </AssistantDisclaimer>
-        </SectionContent>
-      </AssistantSection>
-    </Fragment>
+    <AssistantSection>
+      <SectionContent>
+        <CompactHeader>
+          <Breadcrumbs breadcrumbs={BREADCRUMBS} />
+          <CompactHead>Analysis Assistant (Beta)</CompactHead>
+        </CompactHeader>
+        <Box sx={{ display: "flex", justifyContent: "flex-end", pb: 1 }}>
+          <Button
+            onClick={resetSession}
+            size="small"
+            startIcon={<RestartAltIcon />}
+            sx={{ visibility: showReset ? "visible" : "hidden" }}
+            variant="text"
+          >
+            New Conversation
+          </Button>
+        </Box>
+        <TwoPanelLayout>
+          <ChatColumn>
+            <ChatPanel
+              error={error}
+              isRestoring={isRestoring}
+              loading={loading}
+              messages={messages}
+              onRetry={onRetry}
+              onSend={sendMessage}
+              suggestions={suggestions}
+            />
+          </ChatColumn>
+          <SchemaColumn>
+            <SchemaPanel handoffUrl={handoffUrl} schema={schema} />
+          </SchemaColumn>
+        </TwoPanelLayout>
+        <AssistantDisclaimer>
+          AI assistant — {modelLabel}. Responses can be inaccurate; verify
+          anything important before relying on it.
+        </AssistantDisclaimer>
+      </SectionContent>
+    </AssistantSection>
   );
 };
 


### PR DESCRIPTION
The tall `SectionHero` hero ate enough vertical space that the chat panel -- and on shorter viewports the message input -- got pushed below the fold on load and refresh. This swaps it for a compact breadcrumb + title header so the header and the input are visible without scrolling.

It's a lightweight compact header (breadcrumbs + a smaller title), not the exact findable-ui list chrome -- that isn't reusable on a custom page. Happy to refine with the designer.

Closes #1289.

**Coordination:** this overlaps with #1291 (beta tag) and #1292 (About link), which both add to this title region. Recommend merging this one first; the others are trivial rebases on top.
