### PR TITLE
feat: add an About the Assistant learn page and links

### DIFF
--- a/app/docs/learn/assistant.mdx
+++ b/app/docs/learn/assistant.mdx
@@ -1,0 +1,26 @@
+---
+breadcrumbs:
+  - path: "/learn"
+    text: "Learn"
+  - path: ""
+    text: "About the Assistant"
+contentType: "ARTICLE"
+description: ""
+enableOutline: true
+title: "About the Assistant"
+---
+
+## What is the Analysis Assistant?
+
+The Analysis Assistant is a chat interface that helps you set up a genomic analysis on BRC Analytics without hunting through the catalog yourself. You describe what you want to do in plain language, and the assistant helps you pick an organism, a genome assembly, and a compatible workflow from the BRC catalog. Once your setup is complete, it hands off to the workflow stepper so you can review the configuration and launch the analysis in Galaxy.
+
+The assistant is in **beta**. Like any AI tool, it can make mistakes -- double-check anything important before relying on it, and use the feedback link on the assistant page to tell us what's working and what isn't.
+
+## How to use it
+
+1. **Ask in plain language.** Start by describing your analysis -- for example, _"I want to call variants for Plasmodium falciparum"_ -- or just say what organism you're working with.
+2. **Explore the catalog.** The assistant looks up real organisms, assemblies, and workflows from the BRC catalog. It will suggest options and ask follow-up questions to narrow things down.
+3. **Configure your analysis.** As you answer, the assistant fills in the pieces it needs: the reference assembly, the workflow, and details about your data.
+4. **Hand off to the workflow stepper.** When the setup is ready, the assistant hands you off to the workflow stepper with your selections pre-filled. From there you can review everything and launch in Galaxy.
+
+If the assistant doesn't have what you're looking for -- for example, an organism or assembly that isn't in the catalog -- it will say so. You can browse the [catalog](/data/organisms) directly, or [open an issue](https://github.com/galaxyproject/brc-analytics/issues) to request that we add it.

--- a/app/views/AssistantView/assistantView.tsx
+++ b/app/views/AssistantView/assistantView.tsx
@@ -1,7 +1,8 @@
 import { useFeatureFlag } from "@databiosphere/findable-ui/lib/hooks/useFeatureFlag/useFeatureFlag";
 import RestartAltIcon from "@mui/icons-material/RestartAlt";
-import { Box, Button } from "@mui/material";
+import { Box, Button, Link } from "@mui/material";
 import Error from "next/error";
+import NextLink from "next/link";
 import { JSX, useEffect, useState } from "react";
 import { ChatPanel, SchemaPanel } from "../../components/Assistant";
 import { useAssistantChat } from "../../hooks/useAssistantChat";
@@ -60,11 +61,15 @@ export const AssistantView = (): JSX.Element => {
         <StyledTitle>Analysis Assistant (Beta)</StyledTitle>
         <Box
           sx={{
+            alignItems: "center",
             display: "flex",
-            justifyContent: "flex-end",
+            justifyContent: "space-between",
             pb: 1,
           }}
         >
+          <Link component={NextLink} href="/learn/assistant" variant="body2">
+            About the Assistant →
+          </Link>
           <Button
             onClick={resetSession}
             size="small"

--- a/app/views/LearnView/constants.ts
+++ b/app/views/LearnView/constants.ts
@@ -17,6 +17,13 @@ export const CARDS: ComponentProps<typeof SectionContentCard>[] = [
     title: "Getting Started",
   },
   {
+    StartIcon: SmartToyIcon,
+    cardUrl: "/learn/assistant",
+    secondaryText:
+      "Set up an analysis by chatting in plain language, then hand off to Galaxy to run it.",
+    title: "About the Assistant",
+  },
+  {
     StartIcon: GalaxyIcon,
     cardUrl: "/learn/using-galaxy",
     secondaryText:


### PR DESCRIPTION
Addresses all three parts of #1292:

- New `/learn/assistant` MDX page ("About the Assistant") describing what the assistant is and how to use it (first-pass copy, refine during beta).
- A card for it on the Learn landing grid.
- An "About the Assistant →" link on the assistant page.

I put the link in the toolbar row (next to New Conversation) rather than literally adjacent to the title, since the title region is being reworked in #1289. Easy to move it into the compact header once that lands.

Closes #1292.
