### PR TITLE
feat: add assembly count min and max workflow annotations

### DIFF
--- a/app/apis/catalog/brc-analytics-catalog/common/entities.ts
+++ b/app/apis/catalog/brc-analytics-catalog/common/entities.ts
@@ -117,6 +117,8 @@ export interface WorkflowCategory {
 }
 
 export interface Workflow {
+  assemblyCountMax: number | null;
+  assemblyCountMin: number;
   iwcId: string;
   parameters: WorkflowParameter[];
   ploidy: WORKFLOW_PLOIDY;

--- a/app/apis/catalog/brc-analytics-catalog/common/workflowAssembly.ts
+++ b/app/apis/catalog/brc-analytics-catalog/common/workflowAssembly.ts
@@ -1,0 +1,15 @@
+/**
+ * Determines whether a workflow's minimum assembly requirement can be met
+ * given the number of compatible assemblies available.
+ * Used by both the QC report and the UI workflow-list filter as the
+ * single source of truth for this rule.
+ * @param assemblyCountMin - Minimum assemblies required (0 = none required).
+ * @param compatibleAssemblyCount - Number of compatible assemblies available.
+ * @returns True if the requirement is met (user can run the workflow).
+ */
+export function workflowMeetsAssemblyMinimum(
+  assemblyCountMin: number,
+  compatibleAssemblyCount: number
+): boolean {
+  return assemblyCountMin === 0 || compatibleAssemblyCount >= assemblyCountMin;
+}

--- a/app/views/AnalyzeWorkflowsView/custom/constants.ts
+++ b/app/views/AnalyzeWorkflowsView/custom/constants.ts
@@ -6,6 +6,8 @@ import {
 } from "../../../apis/catalog/brc-analytics-catalog/common/schema-entities";
 
 export const CUSTOM_WORKFLOW: Workflow = {
+  assemblyCountMax: 1,
+  assemblyCountMin: 1,
   iwcId: "",
   parameters: [
     {

--- a/app/views/AnalyzeWorkflowsView/differentialExpressionAnalysis/constants.ts
+++ b/app/views/AnalyzeWorkflowsView/differentialExpressionAnalysis/constants.ts
@@ -5,6 +5,8 @@ import {
 } from "../../../apis/catalog/brc-analytics-catalog/common/schema-entities";
 
 export const DIFFERENTIAL_EXPRESSION_ANALYSIS: Workflow = {
+  assemblyCountMax: 1,
+  assemblyCountMin: 1,
   iwcId: "",
   parameters: [],
   ploidy: WORKFLOW_PLOIDY.ANY,

--- a/app/views/AnalyzeWorkflowsView/lexicmap/constants.ts
+++ b/app/views/AnalyzeWorkflowsView/lexicmap/constants.ts
@@ -5,6 +5,8 @@ import {
 } from "../../../apis/catalog/brc-analytics-catalog/common/schema-entities";
 
 export const LEXICMAP: Workflow = {
+  assemblyCountMax: 0,
+  assemblyCountMin: 0,
   iwcId: "",
   parameters: [],
   ploidy: WORKFLOW_PLOIDY.ANY,

--- a/app/views/AnalyzeWorkflowsView/loganSearch/constants.ts
+++ b/app/views/AnalyzeWorkflowsView/loganSearch/constants.ts
@@ -5,6 +5,8 @@ import {
 } from "../../../apis/catalog/brc-analytics-catalog/common/schema-entities";
 
 export const LOGAN_SEARCH: Workflow = {
+  assemblyCountMax: 0,
+  assemblyCountMin: 0,
   iwcId: "",
   parameters: [],
   ploidy: WORKFLOW_PLOIDY.ANY,

--- a/app/views/WorkflowsView/utils.ts
+++ b/app/views/WorkflowsView/utils.ts
@@ -3,6 +3,7 @@ import type {
   WorkflowAssemblyMapping,
   WorkflowCategory,
 } from "../../apis/catalog/brc-analytics-catalog/common/entities";
+import { workflowMeetsAssemblyMinimum } from "../../apis/catalog/brc-analytics-catalog/common/workflowAssembly";
 import { DIFFERENTIAL_EXPRESSION_ANALYSIS } from "../AnalyzeWorkflowsView/differentialExpressionAnalysis/constants";
 import { LEXICMAP } from "../AnalyzeWorkflowsView/lexicmap/constants";
 import { LOGAN_SEARCH } from "../AnalyzeWorkflowsView/loganSearch/constants";
@@ -109,11 +110,9 @@ export function getWorkflows(
 
   const assemblyByTaxonomyId = indexAssemblyByTaxonomyId(organisms);
 
-  // Create a lookup set for workflows with compatible assemblies.
-  const workflowsWithAssemblies = new Set(
-    mappings
-      .filter((m) => m.compatibleAssemblyCount > 0)
-      .map((m) => m.workflowTrsId)
+  // Create a lookup map from TRS ID to compatible assembly count.
+  const compatibleCountByTrsId = new Map(
+    mappings.map((m) => [m.workflowTrsId, m.compatibleAssemblyCount])
   );
 
   for (const category of workflowCategories) {
@@ -129,8 +128,9 @@ export function getWorkflows(
         continue;
       }
 
-      // Skip workflows with no compatible assemblies.
-      if (!workflowsWithAssemblies.has(workflow.trsId)) {
+      // Skip workflows whose minimum assembly requirement cannot be met.
+      const count = compatibleCountByTrsId.get(workflow.trsId) ?? 0;
+      if (!workflowMeetsAssemblyMinimum(workflow.assemblyCountMin, count)) {
         continue;
       }
 

--- a/catalog/build/ts/build-workflow-mappings.ts
+++ b/catalog/build/ts/build-workflow-mappings.ts
@@ -173,7 +173,7 @@ export function generateWorkflowMappingsQC(
   lines.push("", "## Summary Statistics", "");
   lines.push(`- Total active workflows: ${workflows.length}`);
   lines.push(
-    `- Workflows with ≥1 compatible assembly: ${workflows.length - workflowsWithUnmetMinimum.length}`
+    `- Workflows that meet their minimum assembly requirement: ${workflows.length - workflowsWithUnmetMinimum.length}`
   );
   lines.push(
     `- Workflows that cannot meet minimum assembly requirement: ${workflowsWithUnmetMinimum.length}`

--- a/catalog/build/ts/build-workflow-mappings.ts
+++ b/catalog/build/ts/build-workflow-mappings.ts
@@ -7,6 +7,7 @@ import {
   WORKFLOW_PARAMETER_VARIABLE,
   WORKFLOW_PLOIDY,
 } from "../../../app/apis/catalog/brc-analytics-catalog/common/schema-entities";
+import { workflowMeetsAssemblyMinimum } from "../../../app/apis/catalog/brc-analytics-catalog/common/workflowAssembly";
 
 // Type constraint: both BRC and GA2 assemblies have these fields
 type AssemblyForCompatibility = {
@@ -127,25 +128,32 @@ export function generateWorkflowMappingsQC(
     mappings.map((m) => [m.workflowTrsId, m.compatibleAssemblyCount])
   );
 
-  const workflowsWithNoAssemblies = workflows.filter(
-    (wf) => (mappingsByTrsId.get(wf.trsId) ?? 0) === 0
+  const workflowsWithUnmetMinimum = workflows.filter(
+    (wf) =>
+      !workflowMeetsAssemblyMinimum(
+        wf.assemblyCountMin,
+        mappingsByTrsId.get(wf.trsId) ?? 0
+      )
   );
 
   const lines: string[] = [
     `# Workflow-Assembly Mappings QC Report (${siteName})`,
     "",
-    "## Workflows with no compatible assemblies",
+    "## Workflows that cannot meet their minimum assembly requirement",
     "",
   ];
 
-  if (workflowsWithNoAssemblies.length === 0) {
+  if (workflowsWithUnmetMinimum.length === 0) {
     lines.push("None", "");
   } else {
-    for (const wf of workflowsWithNoAssemblies) {
+    for (const wf of workflowsWithUnmetMinimum) {
+      const count = mappingsByTrsId.get(wf.trsId) ?? 0;
       const reason = wf.taxonomyId
         ? `taxonomy_id: ${wf.taxonomyId}`
         : `ploidy: ${wf.ploidy}`;
-      lines.push(`- ${wf.workflowName} (${wf.trsId}) — ${reason}`);
+      lines.push(
+        `- ${wf.workflowName} (${wf.trsId}) — needs >= ${wf.assemblyCountMin}, ${count} compatible (${reason})`
+      );
     }
     lines.push("");
   }
@@ -165,10 +173,10 @@ export function generateWorkflowMappingsQC(
   lines.push("", "## Summary Statistics", "");
   lines.push(`- Total active workflows: ${workflows.length}`);
   lines.push(
-    `- Workflows with ≥1 compatible assembly: ${workflows.length - workflowsWithNoAssemblies.length}`
+    `- Workflows with ≥1 compatible assembly: ${workflows.length - workflowsWithUnmetMinimum.length}`
   );
   lines.push(
-    `- Workflows with 0 compatible assemblies: ${workflowsWithNoAssemblies.length}`
+    `- Workflows that cannot meet minimum assembly requirement: ${workflowsWithUnmetMinimum.length}`
   );
   lines.push("");
 

--- a/catalog/build/ts/build-workflows.ts
+++ b/catalog/build/ts/build-workflows.ts
@@ -94,6 +94,8 @@ function buildWorkflow(
   sourceWorkflow: SourceWorkflow
 ): void {
   const {
+    assembly_count_max: assemblyCountMax,
+    assembly_count_min: assemblyCountMin,
     categories,
     iwc_id: iwcId,
     parameters: sourceParameters,
@@ -174,11 +176,33 @@ function buildWorkflow(
     // Add parameter if it has variable, url_spec, or collection_spec
     if (variable || url_spec || collection_spec) parameters.push(parameter);
   }
+  const resolvedScope = scope ?? WorkflowScope.ASSEMBLY;
+
+  // Resolve assembly count defaults based on scope.
+  // ASSEMBLY scope: default 1/1 (single assembly selection).
+  // ORGANISM and SEQUENCE: must be declared explicitly.
+  let resolvedMin: number;
+  let resolvedMax: number | null;
+  if (resolvedScope === WorkflowScope.ASSEMBLY) {
+    resolvedMin = assemblyCountMin ?? 1;
+    resolvedMax = assemblyCountMax ?? 1;
+  } else {
+    if (assemblyCountMin === null || assemblyCountMin === undefined) {
+      throw new Error(
+        `Workflow "${workflowName}" (scope: ${resolvedScope}): assembly_count_min is required for ORGANISM and SEQUENCE scope workflows`
+      );
+    }
+    resolvedMin = assemblyCountMin;
+    resolvedMax = assemblyCountMax ?? null;
+  }
+
   const workflow: Workflow = {
+    assemblyCountMax: resolvedMax,
+    assemblyCountMin: resolvedMin,
     iwcId,
     parameters,
     ploidy,
-    scope: scope ?? WorkflowScope.ASSEMBLY,
+    scope: resolvedScope,
     taxonomyId: typeof taxonomyId === "number" ? String(taxonomyId) : null,
     trsId,
     workflowDescription,

--- a/catalog/output/qc-report.workflow-mappings.md
+++ b/catalog/output/qc-report.workflow-mappings.md
@@ -1,6 +1,6 @@
 # Workflow-Assembly Mappings QC Report (BRC)
 
-## Workflows with no compatible assemblies
+## Workflows that cannot meet their minimum assembly requirement
 
 None
 
@@ -42,4 +42,4 @@ None
 
 - Total active workflows: 29
 - Workflows with ≥1 compatible assembly: 29
-- Workflows with 0 compatible assemblies: 0
+- Workflows that cannot meet minimum assembly requirement: 0

--- a/catalog/output/qc-report.workflow-mappings.md
+++ b/catalog/output/qc-report.workflow-mappings.md
@@ -41,5 +41,5 @@ None
 ## Summary Statistics
 
 - Total active workflows: 29
-- Workflows with ≥1 compatible assembly: 29
+- Workflows that meet their minimum assembly requirement: 29
 - Workflows that cannot meet minimum assembly requirement: 0

--- a/catalog/output/workflows.json
+++ b/catalog/output/workflows.json
@@ -6,6 +6,8 @@
     "showComingSoon": true,
     "workflows": [
       {
+        "assemblyCountMax": 1,
+        "assemblyCountMin": 1,
         "iwcId": "generic-non-segmented-viral-variant-calling-main",
         "parameters": [
           {
@@ -36,6 +38,8 @@
         "workflowName": "Variant calling and consensus construction from paired end short read data of non-segmented viral genomes"
       },
       {
+        "assemblyCountMax": 1,
+        "assemblyCountMin": 1,
         "iwcId": "haploid-variant-calling-wgs-pe-main",
         "parameters": [
           {
@@ -65,6 +69,8 @@
         "workflowName": "Paired end variant calling in haploid system"
       },
       {
+        "assemblyCountMax": 1,
+        "assemblyCountMin": 1,
         "iwcId": "ploidy-aware-genotype-calling-main",
         "parameters": [
           {
@@ -88,6 +94,8 @@
         "workflowName": "Paired end variant and ploidy-aware genotype calling"
       },
       {
+        "assemblyCountMax": 1,
+        "assemblyCountMin": 1,
         "iwcId": "sars-cov-2-pe-illumina-artic-variant-calling-covid-19-pe-artic-illumina",
         "parameters": [
           {
@@ -129,6 +137,8 @@
         "workflowName": "COVID-19: variation analysis on ARTIC PE data"
       },
       {
+        "assemblyCountMax": 1,
+        "assemblyCountMin": 1,
         "iwcId": "sars-cov-2-pe-illumina-wgs-variant-calling-covid-19-pe-wgs-illumina",
         "parameters": [
           {
@@ -154,6 +164,8 @@
         "workflowName": "COVID-19: variation analysis on WGS PE data"
       },
       {
+        "assemblyCountMax": 1,
+        "assemblyCountMin": 1,
         "iwcId": "sars-cov-2-se-illumina-wgs-variant-calling-covid-19-se-wgs-illumina",
         "parameters": [
           {
@@ -187,6 +199,8 @@
     "showComingSoon": true,
     "workflows": [
       {
+        "assemblyCountMax": 1,
+        "assemblyCountMin": 1,
         "iwcId": "fastq-to-matrix-10x-scrna-seq-fastq-to-matrix-10x-cellplex",
         "parameters": [
           {
@@ -216,6 +230,8 @@
         "workflowName": "Single-Cell RNA-seq Preprocessing: 10X Genomics CellPlex Multiplexed Samples"
       },
       {
+        "assemblyCountMax": 1,
+        "assemblyCountMin": 1,
         "iwcId": "fastq-to-matrix-10x-scrna-seq-fastq-to-matrix-10x-v3",
         "parameters": [
           {
@@ -245,6 +261,8 @@
         "workflowName": "Single-Cell RNA-seq Preprocessing: 10X Genomics v3 to Seurat and Scanpy Compatible Format"
       },
       {
+        "assemblyCountMax": 1,
+        "assemblyCountMin": 1,
         "iwcId": "rnaseq-pe-main",
         "parameters": [
           {
@@ -274,6 +292,8 @@
         "workflowName": "RNA-Seq Analysis: Paired-End Read Processing and Quantification"
       },
       {
+        "assemblyCountMax": 1,
+        "assemblyCountMin": 1,
         "iwcId": "rnaseq-sr-main",
         "parameters": [
           {
@@ -311,6 +331,8 @@
     "showComingSoon": true,
     "workflows": [
       {
+        "assemblyCountMax": 1,
+        "assemblyCountMin": 1,
         "iwcId": "atacseq-main",
         "parameters": [
           {
@@ -336,6 +358,8 @@
         "workflowName": "ATAC-seq Analysis: Chromatin Accessibility Profiling"
       },
       {
+        "assemblyCountMax": 1,
+        "assemblyCountMin": 1,
         "iwcId": "chipseq-pe-main",
         "parameters": [
           {
@@ -361,6 +385,8 @@
         "workflowName": "ChIP-seq Analysis: Paired-End Read Processing"
       },
       {
+        "assemblyCountMax": 1,
+        "assemblyCountMin": 1,
         "iwcId": "chipseq-sr-main",
         "parameters": [
           {
@@ -386,6 +412,8 @@
         "workflowName": "ChIP-seq Analysis: Single-End Read Processing"
       },
       {
+        "assemblyCountMax": 1,
+        "assemblyCountMin": 1,
         "iwcId": "consensus-peaks-consensus-peaks-atac-cutandrun",
         "parameters": [],
         "ploidy": "ANY",
@@ -396,6 +424,8 @@
         "workflowName": "Consensus Peak Calling for ATAC-seq and CUT and RUN Replicates"
       },
       {
+        "assemblyCountMax": 1,
+        "assemblyCountMin": 1,
         "iwcId": "cutandrun-main",
         "parameters": [
           {
@@ -422,6 +452,8 @@
         "workflowName": "CUT&amp;RUN/CUT&amp;TAG Analysis: Protein-DNA Interaction Mapping"
       },
       {
+        "assemblyCountMax": 1,
+        "assemblyCountMin": 1,
         "iwcId": "hic-hicup-cooler-chic-fastq-to-cool-hicup-cooler",
         "parameters": [
           {
@@ -447,6 +479,8 @@
         "workflowName": "Capture Hi-C Processing: FASTQ to Balanced Cool Files"
       },
       {
+        "assemblyCountMax": 1,
+        "assemblyCountMin": 1,
         "iwcId": "hic-hicup-cooler-hic-fastq-to-cool-hicup-cooler",
         "parameters": [
           {
@@ -472,6 +506,8 @@
         "workflowName": "Hi-C Processing: FASTQ to Balanced Cool Files"
       },
       {
+        "assemblyCountMax": 1,
+        "assemblyCountMin": 1,
         "iwcId": "hic-hicup-cooler-hic-fastq-to-pairs-hicup",
         "parameters": [
           {
@@ -505,6 +541,8 @@
     "showComingSoon": false,
     "workflows": [
       {
+        "assemblyCountMax": 1,
+        "assemblyCountMin": 1,
         "iwcId": "generic-non-segmented-viral-variant-calling-main",
         "parameters": [
           {
@@ -535,6 +573,8 @@
         "workflowName": "Variant calling and consensus construction from paired end short read data of non-segmented viral genomes"
       },
       {
+        "assemblyCountMax": 0,
+        "assemblyCountMin": 0,
         "iwcId": "influenza-isolates-consensus-and-subtyping-main",
         "parameters": [
           {
@@ -607,6 +647,8 @@
         "workflowName": "Influenza A isolate subtyping and consensus sequence generation"
       },
       {
+        "assemblyCountMax": 1,
+        "assemblyCountMin": 1,
         "iwcId": "pox-virus-amplicon-main",
         "parameters": [
           {
@@ -630,6 +672,8 @@
     "showComingSoon": true,
     "workflows": [
       {
+        "assemblyCountMax": 1,
+        "assemblyCountMin": 1,
         "iwcId": "amr_gene_detection-main",
         "parameters": [
           {
@@ -645,6 +689,8 @@
         "workflowName": "AMR Gene Detection"
       },
       {
+        "assemblyCountMax": 1,
+        "assemblyCountMin": 1,
         "iwcId": "annotation-braker3-main",
         "parameters": [
           {
@@ -660,6 +706,8 @@
         "workflowName": "Genome annotation with Braker3"
       },
       {
+        "assemblyCountMax": 1,
+        "assemblyCountMin": 1,
         "iwcId": "bacterial_genome_annotation-main",
         "parameters": [
           {
@@ -675,6 +723,8 @@
         "workflowName": "Bacterial Genome Annotation"
       },
       {
+        "assemblyCountMax": 1,
+        "assemblyCountMin": 1,
         "iwcId": "lncrnas-annotation-main",
         "parameters": [
           {
@@ -702,6 +752,8 @@
     "showComingSoon": false,
     "workflows": [
       {
+        "assemblyCountMax": 0,
+        "assemblyCountMin": 0,
         "iwcId": "assembly-with-flye-main",
         "parameters": [
           {
@@ -717,6 +769,8 @@
         "workflowName": "Genome assembly with Flye"
       },
       {
+        "assemblyCountMax": 0,
+        "assemblyCountMin": 0,
         "iwcId": "bacterial-genome-assembly-main",
         "parameters": [],
         "ploidy": "ANY",
@@ -727,6 +781,8 @@
         "workflowName": "Bacterial Genome Assembly using Shovill"
       },
       {
+        "assemblyCountMax": 1,
+        "assemblyCountMin": 1,
         "iwcId": "polish-with-long-reads-main",
         "parameters": [
           {
@@ -761,6 +817,8 @@
     "showComingSoon": false,
     "workflows": [
       {
+        "assemblyCountMax": null,
+        "assemblyCountMin": 2,
         "iwcId": "hyphy-capheine-core-and-compare",
         "parameters": [],
         "ploidy": "ANY",

--- a/catalog/py_package/catalog_build/generated_schema/schema.py
+++ b/catalog/py_package/catalog_build/generated_schema/schema.py
@@ -1,13 +1,32 @@
-from __future__ import annotations
+from __future__ import annotations 
 
 import re
 import sys
-from datetime import date, datetime, time
-from decimal import Decimal
-from enum import Enum
-from typing import Any, ClassVar, Dict, List, Literal, Optional, Union
+from datetime import (
+    date,
+    datetime,
+    time
+)
+from decimal import Decimal 
+from enum import Enum 
+from typing import (
+    Any,
+    ClassVar,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Union
+)
 
-from pydantic import BaseModel, ConfigDict, Field, RootModel, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    RootModel,
+    field_validator
+)
+
 
 metamodel_version = "None"
 version = "None"
@@ -15,62 +34,52 @@ version = "None"
 
 class ConfiguredBaseModel(BaseModel):
     model_config = ConfigDict(
-        validate_assignment=True,
-        validate_default=True,
-        extra="forbid",
-        arbitrary_types_allowed=True,
-        use_enum_values=True,
-        strict=False,
+        validate_assignment = True,
+        validate_default = True,
+        extra = "forbid",
+        arbitrary_types_allowed = True,
+        use_enum_values = True,
+        strict = False,
     )
     pass
+
+
 
 
 class LinkMLMeta(RootModel):
     root: Dict[str, Any] = {}
     model_config = ConfigDict(frozen=True)
 
-    def __getattr__(self, key: str):
+    def __getattr__(self, key:str):
         return getattr(self.root, key)
 
-    def __getitem__(self, key: str):
+    def __getitem__(self, key:str):
         return self.root[key]
 
-    def __setitem__(self, key: str, value):
+    def __setitem__(self, key:str, value):
         self.root[key] = value
 
-    def __contains__(self, key: str) -> bool:
+    def __contains__(self, key:str) -> bool:
         return key in self.root
 
 
-linkml_meta = LinkMLMeta(
-    {
-        "default_prefix": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/schema.yaml#",
-        "description": "Combined source data schemas.",
-        "id": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/schema.yaml#",
-        "imports": [
-            "./assemblies",
-            "./organisms",
-            "./outbreaks",
-            "./workflow_categories",
-            "./workflows",
-        ],
-        "name": "schema",
-        "prefixes": {
-            "linkml": {
-                "prefix_prefix": "linkml",
-                "prefix_reference": "https://w3id.org/linkml/",
-            }
-        },
-        "source_file": "/home/danielle/Documents/brc-analytics/brc-analytics/catalog/py_package/catalog_build/schema_utils/../schema/schema.yaml",
-    }
-)
-
+linkml_meta = LinkMLMeta({'default_prefix': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/schema.yaml#',
+     'description': 'Combined source data schemas.',
+     'id': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/schema.yaml#',
+     'imports': ['./assemblies',
+                 './organisms',
+                 './outbreaks',
+                 './workflow_categories',
+                 './workflows'],
+     'name': 'schema',
+     'prefixes': {'linkml': {'prefix_prefix': 'linkml',
+                             'prefix_reference': 'https://w3id.org/linkml/'}},
+     'source_file': '/home/danielle/Documents/brc-analytics/brc-analytics/catalog/py_package/catalog_build/schema_utils/../schema/schema.yaml'} )
 
 class OrganismPloidy(str, Enum):
     """
     Possible ploidies of an organism.
     """
-
     DIPLOID = "DIPLOID"
     HAPLOID = "HAPLOID"
     POLYPLOID = "POLYPLOID"
@@ -80,7 +89,6 @@ class OutbreakPriority(str, Enum):
     """
     Possible priorities of an outbreak.
     """
-
     HIGHEST = "HIGHEST"
     CRITICAL = "CRITICAL"
     HIGH = "HIGH"
@@ -92,7 +100,6 @@ class OutbreakResourceType(str, Enum):
     """
     Possible types of an outbreak resource.
     """
-
     PUBLICATION = "PUBLICATION"
     REFERENCE = "REFERENCE"
     NEWS = "NEWS"
@@ -106,7 +113,6 @@ class WorkflowCategoryId(str, Enum):
     """
     Set of IDs of workflow categories.
     """
-
     VARIANT_CALLING = "VARIANT_CALLING"
     TRANSCRIPTOMICS = "TRANSCRIPTOMICS"
     REGULATION = "REGULATION"
@@ -121,10 +127,9 @@ class WorkflowCategoryId(str, Enum):
 
 class CollectionType(str, Enum):
     """
-        Galaxy collection types supported for collection_spec in workflow parameters.
-    Currently only 'list' collections are supported, which represent a simple ordered list of datasets.
+    Galaxy collection types supported for collection_spec in workflow parameters.
+Currently only 'list' collections are supported, which represent a simple ordered list of datasets.
     """
-
     # A simple ordered list of datasets. Each element in the collection is a separate dataset.
     list = "list"
 
@@ -133,7 +138,6 @@ class WorkflowParameterVariable(str, Enum):
     """
     Possible variables that can be inserted into workflow parameters.
     """
-
     ASSEMBLY_ID = "ASSEMBLY_ID"
     ASSEMBLY_FASTA_URL = "ASSEMBLY_FASTA_URL"
     FASTA_COLLECTION = "FASTA_COLLECTION"
@@ -146,7 +150,6 @@ class WorkflowPloidy(str, Enum):
     """
     Possible ploidies supported by workflows.
     """
-
     ANY = "ANY"
     DIPLOID = "DIPLOID"
     HAPLOID = "HAPLOID"
@@ -157,7 +160,6 @@ class WorkflowScope(str, Enum):
     """
     The scope level at which a workflow operates, determining its display context and required inputs.
     """
-
     # Workflow operates on a specific genome assembly and requires assembly selection as the first step.
     ASSEMBLY = "ASSEMBLY"
     # Workflow operates at the organism level, either requiring no specific assembly or working across multiple assemblies.
@@ -170,7 +172,6 @@ class LibraryLayout(str, Enum):
     """
     Enumeration of possible library layouts for sequencing data.
     """
-
     # Paired-end sequencing reads
     PAIRED = "PAIRED"
     # Single-end sequencing reads
@@ -181,7 +182,6 @@ class LibrarySource(str, Enum):
     """
     Enumeration of possible library sources for sequencing data.
     """
-
     # Genomic DNA (includes PCR products from genomic DNA)
     GENOMIC = "GENOMIC"
     # Genomic DNA from a single cell
@@ -206,7 +206,6 @@ class LibraryStrategy(str, Enum):
     """
     Enumeration of possible library strategies for sequencing data.
     """
-
     # Whole genome sequencing
     WGS = "WGS"
     # Whole genome amplification
@@ -291,261 +290,100 @@ class LibraryStrategy(str, Enum):
     OTHER = "OTHER"
 
 
+
 class Assemblies(ConfiguredBaseModel):
     """
     Root object containing a collection of genomic assembly definitions for the BRC Analytics platform.
     """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/assemblies.yaml#',
+         'tree_root': True})
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/assemblies.yaml#",
-            "tree_root": True,
-        }
-    )
-
-    assemblies: List[Assembly] = Field(
-        default=...,
-        description="""Collection of genomic assembly entries that will be available for analysis in the BRC Analytics platform.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "assemblies", "domain_of": ["Assemblies"]}
-        },
-    )
+    assemblies: List[Assembly] = Field(default=..., description="""Collection of genomic assembly entries that will be available for analysis in the BRC Analytics platform.""", json_schema_extra = { "linkml_meta": {'alias': 'assemblies', 'domain_of': ['Assemblies']} })
 
 
 class Assembly(ConfiguredBaseModel):
     """
     Definition of a genomic assembly with its unique identifier.
     """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/assemblies.yaml#'})
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/assemblies.yaml#"
-        }
-    )
-
-    accession: str = Field(
-        default=...,
-        description="""The unique accession identifier for the assembly (e.g., GCA_000001405.28 for GRCh38), used to retrieve the assembly data from public repositories.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "accession", "domain_of": ["Assembly"]}
-        },
-    )
+    accession: str = Field(default=..., description="""The unique accession identifier for the assembly (e.g., GCA_000001405.28 for GRCh38), used to retrieve the assembly data from public repositories.""", json_schema_extra = { "linkml_meta": {'alias': 'accession', 'domain_of': ['Assembly']} })
 
 
 class Organisms(ConfiguredBaseModel):
     """
     Root object containing a collection of organism definitions for the BRC Analytics platform.
     """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/organisms.yaml#',
+         'tree_root': True})
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/organisms.yaml#",
-            "tree_root": True,
-        }
-    )
-
-    organisms: List[Organism] = Field(
-        default=...,
-        description="""Collection of organism entries that will be available in the BRC Analytics platform.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "organisms", "domain_of": ["Organisms"]}
-        },
-    )
+    organisms: List[Organism] = Field(default=..., description="""Collection of organism entries that will be available in the BRC Analytics platform.""", json_schema_extra = { "linkml_meta": {'alias': 'organisms', 'domain_of': ['Organisms']} })
 
 
 class Organism(ConfiguredBaseModel):
     """
     Definition of an organism with its taxonomic and genetic characteristics.
     """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/organisms.yaml#'})
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/organisms.yaml#"
-        }
-    )
-
-    taxonomy_id: int = Field(
-        default=...,
-        description="""An NCBI Taxonomy ID at rank 'species'.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "taxonomy_id",
-                "domain_of": ["Organism", "Outbreak", "Workflow"],
-            }
-        },
-    )
-    ploidy: List[OrganismPloidy] = Field(
-        default=...,
-        description="""The possible ploidy states (number of chromosome sets) that the organism may have, which determines compatible workflows.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "ploidy", "domain_of": ["Organism", "Workflow"]}
-        },
-    )
+    taxonomy_id: int = Field(default=..., description="""An NCBI Taxonomy ID at rank 'species'.""", json_schema_extra = { "linkml_meta": {'alias': 'taxonomy_id', 'domain_of': ['Organism', 'Outbreak', 'Workflow']} })
+    ploidy: List[OrganismPloidy] = Field(default=..., description="""The possible ploidy states (number of chromosome sets) that the organism may have, which determines compatible workflows.""", json_schema_extra = { "linkml_meta": {'alias': 'ploidy', 'domain_of': ['Organism', 'Workflow']} })
 
 
 class Outbreaks(ConfiguredBaseModel):
     """
     Root object containing a collection of pathogen definitions for the BRC Analytics platform to highlight as outbreaks/priority pathogens.
     """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/outbreaks.yaml#',
+         'tree_root': True})
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/outbreaks.yaml#",
-            "tree_root": True,
-        }
-    )
-
-    outbreaks: List[Outbreak] = Field(
-        default=...,
-        description="""Collection of pathogen entries that will be displayed in the BRC Analytics platform as outbreaks/priority pathogens.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "outbreaks", "domain_of": ["Outbreaks"]}
-        },
-    )
+    outbreaks: List[Outbreak] = Field(default=..., description="""Collection of pathogen entries that will be displayed in the BRC Analytics platform as outbreaks/priority pathogens.""", json_schema_extra = { "linkml_meta": {'alias': 'outbreaks', 'domain_of': ['Outbreaks']} })
 
 
 class Outbreak(ConfiguredBaseModel):
     """
     Definition of a priority pathogen with its taxonomic classification, priority level, and associated resources.
     """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/outbreaks.yaml#'})
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/outbreaks.yaml#"
-        }
-    )
-
-    name: str = Field(
-        default=...,
-        description="""The display name of the pathogen as it will appear in the BRC Analytics interface.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "name",
-                "domain_of": ["Outbreak", "WorkflowCategory", "WorkflowCollectionSpec"],
-            }
-        },
-    )
-    taxonomy_id: int = Field(
-        default=...,
-        description="""The NCBI Taxonomy ID for the pathogen. Used to link to relevant genomic data and workflows.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "taxonomy_id",
-                "domain_of": ["Organism", "Outbreak", "Workflow"],
-            }
-        },
-    )
-    priority: OutbreakPriority = Field(
-        default=...,
-        description="""The priority level of the pathogen, which determines its visibility and prominence in the BRC Analytics interface.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "priority", "domain_of": ["Outbreak"]}
-        },
-    )
-    resources: List[OutbreakResource] = Field(
-        default=...,
-        description="""Collection of external resources (references, tools, databases) related to the pathogen.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "resources", "domain_of": ["Outbreak"]}
-        },
-    )
-    description: MarkdownFileReference = Field(
-        default=...,
-        description="""Reference to a markdown file containing detailed information about the pathogen.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "description",
-                "domain_of": [
-                    "Outbreak",
-                    "WorkflowCategory",
-                    "WorkflowDataRequirements",
-                ],
-            }
-        },
-    )
-    active: bool = Field(
-        default=...,
-        description="""Boolean flag that determines if the pathogen should be included in the BRC Analytics interface. Used to manage visibility as pathogen relevance changes over time.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "active", "domain_of": ["Outbreak", "Workflow"]}
-        },
-    )
-    highlight_descendant_taxonomy_ids: Optional[List[int]] = Field(
-        default=None,
-        description="""List of NCBI Taxonomy IDs for descendant taxa (e.g., specific strains or serotypes) that should be highlighted within the outbreak category.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "highlight_descendant_taxonomy_ids",
-                "domain_of": ["Outbreak"],
-            }
-        },
-    )
+    name: str = Field(default=..., description="""The display name of the pathogen as it will appear in the BRC Analytics interface.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
+         'domain_of': ['Outbreak', 'WorkflowCategory', 'WorkflowCollectionSpec']} })
+    taxonomy_id: int = Field(default=..., description="""The NCBI Taxonomy ID for the pathogen. Used to link to relevant genomic data and workflows.""", json_schema_extra = { "linkml_meta": {'alias': 'taxonomy_id', 'domain_of': ['Organism', 'Outbreak', 'Workflow']} })
+    priority: OutbreakPriority = Field(default=..., description="""The priority level of the pathogen, which determines its visibility and prominence in the BRC Analytics interface.""", json_schema_extra = { "linkml_meta": {'alias': 'priority', 'domain_of': ['Outbreak']} })
+    resources: List[OutbreakResource] = Field(default=..., description="""Collection of external resources (references, tools, databases) related to the pathogen.""", json_schema_extra = { "linkml_meta": {'alias': 'resources', 'domain_of': ['Outbreak']} })
+    description: MarkdownFileReference = Field(default=..., description="""Reference to a markdown file containing detailed information about the pathogen.""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+         'domain_of': ['Outbreak', 'WorkflowCategory', 'WorkflowDataRequirements']} })
+    active: bool = Field(default=..., description="""Boolean flag that determines if the pathogen should be included in the BRC Analytics interface. Used to manage visibility as pathogen relevance changes over time.""", json_schema_extra = { "linkml_meta": {'alias': 'active', 'domain_of': ['Outbreak', 'Workflow']} })
+    highlight_descendant_taxonomy_ids: Optional[List[int]] = Field(default=None, description="""List of NCBI Taxonomy IDs for descendant taxa (e.g., specific strains or serotypes) that should be highlighted within the outbreak category.""", json_schema_extra = { "linkml_meta": {'alias': 'highlight_descendant_taxonomy_ids', 'domain_of': ['Outbreak']} })
 
 
 class OutbreakResource(ConfiguredBaseModel):
     """
     Definition of an external resource (reference, tool, database) associated with a priority pathogen.
     """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/outbreaks.yaml#'})
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/outbreaks.yaml#"
-        }
-    )
-
-    url: str = Field(
-        default=...,
-        description="""The complete URL (including http/https protocol) to the external resource.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "url",
-                "domain_of": ["OutbreakResource", "WorkflowUrlSpec"],
-            }
-        },
-    )
-    title: str = Field(
-        default=...,
-        description="""The display title for the resource link as it will appear in the BRC Analytics interface.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "title", "domain_of": ["OutbreakResource"]}
-        },
-    )
-    type: OutbreakResourceType = Field(
-        default=...,
-        description="""The category or type of the resource (e.g., REFERENCE, TOOL, DATABASE), which determines how it is displayed and organized.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "type", "domain_of": ["OutbreakResource"]}
-        },
-    )
+    url: str = Field(default=..., description="""The complete URL (including http/https protocol) to the external resource.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['OutbreakResource', 'WorkflowUrlSpec']} })
+    title: str = Field(default=..., description="""The display title for the resource link as it will appear in the BRC Analytics interface.""", json_schema_extra = { "linkml_meta": {'alias': 'title', 'domain_of': ['OutbreakResource']} })
+    type: OutbreakResourceType = Field(default=..., description="""The category or type of the resource (e.g., REFERENCE, TOOL, DATABASE), which determines how it is displayed and organized.""", json_schema_extra = { "linkml_meta": {'alias': 'type', 'domain_of': ['OutbreakResource']} })
 
 
 class MarkdownFileReference(ConfiguredBaseModel):
     """
     A reference to a markdown file containing detailed content about a priority pathogen.
     """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/outbreaks.yaml#'})
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/outbreaks.yaml#"
-        }
-    )
+    path: str = Field(default=..., description="""Relative path to the markdown file from the project root. Must end with .md extension.""", json_schema_extra = { "linkml_meta": {'alias': 'path', 'domain_of': ['MarkdownFileReference']} })
 
-    path: str = Field(
-        default=...,
-        description="""Relative path to the markdown file from the project root. Must end with .md extension.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "path", "domain_of": ["MarkdownFileReference"]}
-        },
-    )
-
-    @field_validator("path")
+    @field_validator('path')
     def pattern_path(cls, v):
-        pattern = re.compile(r".*\.md$")
-        if isinstance(v, list):
+        pattern=re.compile(r".*\.md$")
+        if isinstance(v,list):
             for element in v:
                 if isinstance(v, str) and not pattern.match(element):
                     raise ValueError(f"Invalid path format: {element}")
-        elif isinstance(v, str):
+        elif isinstance(v,str):
             if not pattern.match(v):
                 raise ValueError(f"Invalid path format: {v}")
         return v
@@ -555,242 +393,67 @@ class WorkflowCategories(ConfiguredBaseModel):
     """
     Root object containing a collection of workflow category definitions used to organize workflows in the BRC Analytics platform.
     """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflow_categories.yaml#',
+         'tree_root': True})
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflow_categories.yaml#",
-            "tree_root": True,
-        }
-    )
-
-    workflow_categories: List[WorkflowCategory] = Field(
-        default=...,
-        description="""Collection of workflow category entries that will be used to group and organize workflows in the BRC Analytics interface.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "workflow_categories",
-                "domain_of": ["WorkflowCategories"],
-            }
-        },
-    )
+    workflow_categories: List[WorkflowCategory] = Field(default=..., description="""Collection of workflow category entries that will be used to group and organize workflows in the BRC Analytics interface.""", json_schema_extra = { "linkml_meta": {'alias': 'workflow_categories', 'domain_of': ['WorkflowCategories']} })
 
 
 class WorkflowCategory(ConfiguredBaseModel):
     """
     Definition of a workflow category used to group related workflows for organization and display purposes.
     """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflow_categories.yaml#'})
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflow_categories.yaml#"
-        }
-    )
-
-    category: WorkflowCategoryId = Field(
-        default=...,
-        description="""The unique identifier for the workflow category, used to link workflows to their respective categories.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "category", "domain_of": ["WorkflowCategory"]}
-        },
-    )
-    name: str = Field(
-        default=...,
-        description="""The human-readable display name of the workflow category as it will appear in the BRC Analytics interface.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "name",
-                "domain_of": ["Outbreak", "WorkflowCategory", "WorkflowCollectionSpec"],
-            }
-        },
-    )
-    description: str = Field(
-        default=...,
-        description="""A detailed description of the workflow category explaining its purpose and the types of workflows it contains.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "description",
-                "domain_of": [
-                    "Outbreak",
-                    "WorkflowCategory",
-                    "WorkflowDataRequirements",
-                ],
-            }
-        },
-    )
-    show_coming_soon: bool = Field(
-        default=...,
-        description="""Boolean flag that determines whether to display a 'Coming Soon' indicator for this category in the BRC Analytics interface when workflows in this category are not yet available.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "show_coming_soon",
-                "domain_of": ["WorkflowCategory"],
-            }
-        },
-    )
+    category: WorkflowCategoryId = Field(default=..., description="""The unique identifier for the workflow category, used to link workflows to their respective categories.""", json_schema_extra = { "linkml_meta": {'alias': 'category', 'domain_of': ['WorkflowCategory']} })
+    name: str = Field(default=..., description="""The human-readable display name of the workflow category as it will appear in the BRC Analytics interface.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
+         'domain_of': ['Outbreak', 'WorkflowCategory', 'WorkflowCollectionSpec']} })
+    description: str = Field(default=..., description="""A detailed description of the workflow category explaining its purpose and the types of workflows it contains.""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+         'domain_of': ['Outbreak', 'WorkflowCategory', 'WorkflowDataRequirements']} })
+    show_coming_soon: bool = Field(default=..., description="""Boolean flag that determines whether to display a 'Coming Soon' indicator for this category in the BRC Analytics interface when workflows in this category are not yet available.""", json_schema_extra = { "linkml_meta": {'alias': 'show_coming_soon', 'domain_of': ['WorkflowCategory']} })
 
 
 class Workflows(ConfiguredBaseModel):
     """
     Root object containing a collection of Galaxy workflow definitions for the BRC Analytics platform.
     """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#',
+         'tree_root': True})
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#",
-            "tree_root": True,
-        }
-    )
-
-    workflows: List[Workflow] = Field(
-        default=...,
-        description="""Collection of workflow entries that will be available to users in the BRC Analytics platform.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "workflows", "domain_of": ["Workflows"]}
-        },
-    )
+    workflows: List[Workflow] = Field(default=..., description="""Collection of workflow entries that will be available to users in the BRC Analytics platform.""", json_schema_extra = { "linkml_meta": {'alias': 'workflows', 'domain_of': ['Workflows']} })
 
 
 class Workflow(ConfiguredBaseModel):
     """
     Definition of a Galaxy workflow with its metadata, parameters, and organism compatibility information.
     """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#'})
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#"
-        }
-    )
-
-    trs_id: str = Field(
-        default=...,
-        description="""The Tool Repository Service (TRS) identifier for the workflow, used to locate and retrieve the workflow from a Galaxy server.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "trs_id", "domain_of": ["Workflow"]}
-        },
-    )
-    categories: List[WorkflowCategoryId] = Field(
-        default=...,
-        description="""List of category identifiers that this workflow belongs to, determining how it is organized and displayed in the BRC Analytics interface.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "categories", "domain_of": ["Workflow"]}
-        },
-    )
-    workflow_name: str = Field(
-        default=...,
-        description="""The human-readable display name of the workflow as it will appear in the BRC Analytics interface.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "workflow_name", "domain_of": ["Workflow"]}
-        },
-    )
-    workflow_description: str = Field(
-        default=...,
-        description="""A detailed description of the workflow's purpose, functionality, and expected outputs for users.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "workflow_description", "domain_of": ["Workflow"]}
-        },
-    )
-    ploidy: WorkflowPloidy = Field(
-        default=...,
-        description="""The ploidy state (number of chromosome sets) that this workflow is designed to work with, ensuring compatibility with organism data.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "ploidy", "domain_of": ["Organism", "Workflow"]}
-        },
-    )
-    scope: Optional[WorkflowScope] = Field(
-        default=None,
-        description="""The scope level at which this workflow operates, determining where it is displayed in the UI and what the first configuration step should be. Defaults to ASSEMBLY for backward compatibility.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "scope", "domain_of": ["Workflow"]}
-        },
-    )
-    taxonomy_id: Optional[int] = Field(
-        default=None,
-        description="""The NCBI Taxonomy ID of the organism this workflow is designed for. If specified, the workflow will be available for all assemblies with this ID in their taxonomic lineage.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "taxonomy_id",
-                "domain_of": ["Organism", "Outbreak", "Workflow"],
-            }
-        },
-    )
-    parameters: List[WorkflowParameter] = Field(
-        default=...,
-        description="""Collection of input parameters that will be passed to the workflow when it is executed, including data sources and configuration options.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "parameters", "domain_of": ["Workflow"]}
-        },
-    )
-    active: bool = Field(
-        default=...,
-        description="""Boolean flag that determines if the workflow should be included in the BRC Analytics interface. Used to manage visibility of workflows that may be under development or deprecated.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "active", "domain_of": ["Outbreak", "Workflow"]}
-        },
-    )
-    iwc_id: str = Field(
-        default=...,
-        description="""The Intergalactic Workflow Commission (IWC) identifier for the workflow, used to link to the workflow's page on the IWC website.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "iwc_id", "domain_of": ["Workflow"]}
-        },
-    )
+    trs_id: str = Field(default=..., description="""The Tool Repository Service (TRS) identifier for the workflow, used to locate and retrieve the workflow from a Galaxy server.""", json_schema_extra = { "linkml_meta": {'alias': 'trs_id', 'domain_of': ['Workflow']} })
+    categories: List[WorkflowCategoryId] = Field(default=..., description="""List of category identifiers that this workflow belongs to, determining how it is organized and displayed in the BRC Analytics interface.""", json_schema_extra = { "linkml_meta": {'alias': 'categories', 'domain_of': ['Workflow']} })
+    workflow_name: str = Field(default=..., description="""The human-readable display name of the workflow as it will appear in the BRC Analytics interface.""", json_schema_extra = { "linkml_meta": {'alias': 'workflow_name', 'domain_of': ['Workflow']} })
+    workflow_description: str = Field(default=..., description="""A detailed description of the workflow's purpose, functionality, and expected outputs for users.""", json_schema_extra = { "linkml_meta": {'alias': 'workflow_description', 'domain_of': ['Workflow']} })
+    ploidy: WorkflowPloidy = Field(default=..., description="""The ploidy state (number of chromosome sets) that this workflow is designed to work with, ensuring compatibility with organism data.""", json_schema_extra = { "linkml_meta": {'alias': 'ploidy', 'domain_of': ['Organism', 'Workflow']} })
+    scope: Optional[WorkflowScope] = Field(default=None, description="""The scope level at which this workflow operates, determining where it is displayed in the UI and what the first configuration step should be. Defaults to ASSEMBLY for backward compatibility.""", json_schema_extra = { "linkml_meta": {'alias': 'scope', 'domain_of': ['Workflow']} })
+    assembly_count_min: Optional[int] = Field(default=None, description="""The minimum number of genome assemblies a user must select for this workflow. Defaults to 1 for ASSEMBLY-scope workflows; must be set explicitly for ORGANISM and SEQUENCE scope. Use 0 for workflows that take no user-selected assemblies (e.g. assembly-building or curated-FASTA workflows).""", json_schema_extra = { "linkml_meta": {'alias': 'assembly_count_min', 'domain_of': ['Workflow']} })
+    assembly_count_max: Optional[int] = Field(default=None, description="""The maximum number of genome assemblies a user may select for this workflow. Null/absent means no upper limit. Defaults to 1 for ASSEMBLY-scope workflows; must be set explicitly for ORGANISM and SEQUENCE scope.""", json_schema_extra = { "linkml_meta": {'alias': 'assembly_count_max', 'domain_of': ['Workflow']} })
+    taxonomy_id: Optional[int] = Field(default=None, description="""The NCBI Taxonomy ID of the organism this workflow is designed for. If specified, the workflow will be available for all assemblies with this ID in their taxonomic lineage.""", json_schema_extra = { "linkml_meta": {'alias': 'taxonomy_id', 'domain_of': ['Organism', 'Outbreak', 'Workflow']} })
+    parameters: List[WorkflowParameter] = Field(default=..., description="""Collection of input parameters that will be passed to the workflow when it is executed, including data sources and configuration options.""", json_schema_extra = { "linkml_meta": {'alias': 'parameters', 'domain_of': ['Workflow']} })
+    active: bool = Field(default=..., description="""Boolean flag that determines if the workflow should be included in the BRC Analytics interface. Used to manage visibility of workflows that may be under development or deprecated.""", json_schema_extra = { "linkml_meta": {'alias': 'active', 'domain_of': ['Outbreak', 'Workflow']} })
+    iwc_id: str = Field(default=..., description="""The Intergalactic Workflow Commission (IWC) identifier for the workflow, used to link to the workflow's page on the IWC website.""", json_schema_extra = { "linkml_meta": {'alias': 'iwc_id', 'domain_of': ['Workflow']} })
 
 
 class WorkflowDataRequirements(ConfiguredBaseModel):
     """
     Specification of data requirements for a workflow parameter, such as library strategy and layout.
     """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#'})
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#"
-        }
-    )
-
-    library_strategy: Optional[List[LibraryStrategy]] = Field(
-        default=None,
-        description="""The library strategy values that are acceptable for this parameter (e.g., 'WGS', 'RNA-Seq').""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "library_strategy",
-                "domain_of": ["WorkflowDataRequirements"],
-            }
-        },
-    )
-    library_layout: Optional[LibraryLayout] = Field(
-        default=None,
-        description="""The library layout that is required for this parameter (e.g., 'PAIRED', 'SINGLE').""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "library_layout",
-                "domain_of": ["WorkflowDataRequirements"],
-            }
-        },
-    )
-    library_source: Optional[List[LibrarySource]] = Field(
-        default=None,
-        description="""The library source values that are acceptable for this parameter (e.g., 'GENOMIC', 'TRANSCRIPTOMIC SINGLE CELL').""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "library_source",
-                "domain_of": ["WorkflowDataRequirements"],
-            }
-        },
-    )
-    description: Optional[str] = Field(
-        default=None,
-        description="""A descriptive text to provide additional context about the data requirements, useful for non-standard library strategies like 'OTHER'.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "description",
-                "domain_of": [
-                    "Outbreak",
-                    "WorkflowCategory",
-                    "WorkflowDataRequirements",
-                ],
-            }
-        },
-    )
+    library_strategy: Optional[List[LibraryStrategy]] = Field(default=None, description="""The library strategy values that are acceptable for this parameter (e.g., 'WGS', 'RNA-Seq').""", json_schema_extra = { "linkml_meta": {'alias': 'library_strategy', 'domain_of': ['WorkflowDataRequirements']} })
+    library_layout: Optional[LibraryLayout] = Field(default=None, description="""The library layout that is required for this parameter (e.g., 'PAIRED', 'SINGLE').""", json_schema_extra = { "linkml_meta": {'alias': 'library_layout', 'domain_of': ['WorkflowDataRequirements']} })
+    library_source: Optional[List[LibrarySource]] = Field(default=None, description="""The library source values that are acceptable for this parameter (e.g., 'GENOMIC', 'TRANSCRIPTOMIC SINGLE CELL').""", json_schema_extra = { "linkml_meta": {'alias': 'library_source', 'domain_of': ['WorkflowDataRequirements']} })
+    description: Optional[str] = Field(default=None, description="""A descriptive text to provide additional context about the data requirements, useful for non-standard library strategies like 'OTHER'.""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+         'domain_of': ['Outbreak', 'WorkflowCategory', 'WorkflowDataRequirements']} })
 
 
 class WorkflowCollectionSpec(ConfiguredBaseModel):
@@ -813,156 +476,39 @@ class WorkflowCollectionSpec(ConfiguredBaseModel):
           md5: def456...
     ```
     """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#'})
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#"
-        }
-    )
-
-    collection_type: CollectionType = Field(
-        default=...,
-        description="""The type of Galaxy collection to create. Currently only 'list' is supported. Determines the structure of the collection.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "collection_type",
-                "domain_of": ["WorkflowCollectionSpec"],
-            }
-        },
-    )
-    elements: List[WorkflowUrlSpec] = Field(
-        default=...,
-        description="""Array of URL specifications that will become elements in the collection. Each element represents a file to include in the collection. Must contain at least one element.""",
-        min_length=1,
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "elements",
-                "domain_of": ["WorkflowCollectionSpec"],
-            }
-        },
-    )
-    name: Optional[str] = Field(
-        default=None,
-        description="""Optional identifier for the collection, used as the collection name in Galaxy. If not provided, defaults to 'Collection'.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "name",
-                "domain_of": ["Outbreak", "WorkflowCategory", "WorkflowCollectionSpec"],
-            }
-        },
-    )
+    collection_type: CollectionType = Field(default=..., description="""The type of Galaxy collection to create. Currently only 'list' is supported. Determines the structure of the collection.""", json_schema_extra = { "linkml_meta": {'alias': 'collection_type', 'domain_of': ['WorkflowCollectionSpec']} })
+    elements: List[WorkflowUrlSpec] = Field(default=..., description="""Array of URL specifications that will become elements in the collection. Each element represents a file to include in the collection. Must contain at least one element.""", min_length=1, json_schema_extra = { "linkml_meta": {'alias': 'elements', 'domain_of': ['WorkflowCollectionSpec']} })
+    name: Optional[str] = Field(default=None, description="""Optional identifier for the collection, used as the collection name in Galaxy. If not provided, defaults to 'Collection'.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
+         'domain_of': ['Outbreak', 'WorkflowCategory', 'WorkflowCollectionSpec']} })
 
 
 class WorkflowParameter(ConfiguredBaseModel):
     """
     Definition of an input parameter for a Galaxy workflow, specifying how the parameter value should be determined when the workflow is executed.
     """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#'})
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#"
-        }
-    )
-
-    key: str = Field(
-        default=...,
-        description="""The identifier for the parameter as expected by the Galaxy workflow, used to map the parameter value to the correct input.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "key", "domain_of": ["WorkflowParameter"]}
-        },
-    )
-    variable: Optional[WorkflowParameterVariable] = Field(
-        default=None,
-        description="""A predefined variable that will be substituted as the value of the parameter at runtime, such as assembly information.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "variable", "domain_of": ["WorkflowParameter"]}
-        },
-    )
-    collection_spec: Optional[WorkflowCollectionSpec] = Field(
-        default=None,
-        description="""A collection specification for the parameter, allowing multiple files from external sources to be provided as a Galaxy collection.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "collection_spec",
-                "domain_of": ["WorkflowParameter"],
-            }
-        },
-    )
-    url_spec: Optional[WorkflowUrlSpec] = Field(
-        default=None,
-        description="""A direct URL specification for the parameter, allowing for external data sources to be provided to the workflow.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "url_spec", "domain_of": ["WorkflowParameter"]}
-        },
-    )
-    data_requirements: Optional[WorkflowDataRequirements] = Field(
-        default=None,
-        description="""Specifications for the data requirements of this parameter, such as library strategy and layout.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "data_requirements",
-                "domain_of": ["WorkflowParameter"],
-            }
-        },
-    )
-    type_guide: Optional[Any] = Field(
-        default=None,
-        description="""Arbitrary data describing the expected type and format of the parameter, intended as a reference for catalog maintainers and not used in workflow execution.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "type_guide", "domain_of": ["WorkflowParameter"]}
-        },
-    )
+    key: str = Field(default=..., description="""The identifier for the parameter as expected by the Galaxy workflow, used to map the parameter value to the correct input.""", json_schema_extra = { "linkml_meta": {'alias': 'key', 'domain_of': ['WorkflowParameter']} })
+    variable: Optional[WorkflowParameterVariable] = Field(default=None, description="""A predefined variable that will be substituted as the value of the parameter at runtime, such as assembly information.""", json_schema_extra = { "linkml_meta": {'alias': 'variable', 'domain_of': ['WorkflowParameter']} })
+    collection_spec: Optional[WorkflowCollectionSpec] = Field(default=None, description="""A collection specification for the parameter, allowing multiple files from external sources to be provided as a Galaxy collection.""", json_schema_extra = { "linkml_meta": {'alias': 'collection_spec', 'domain_of': ['WorkflowParameter']} })
+    url_spec: Optional[WorkflowUrlSpec] = Field(default=None, description="""A direct URL specification for the parameter, allowing for external data sources to be provided to the workflow.""", json_schema_extra = { "linkml_meta": {'alias': 'url_spec', 'domain_of': ['WorkflowParameter']} })
+    data_requirements: Optional[WorkflowDataRequirements] = Field(default=None, description="""Specifications for the data requirements of this parameter, such as library strategy and layout.""", json_schema_extra = { "linkml_meta": {'alias': 'data_requirements', 'domain_of': ['WorkflowParameter']} })
+    type_guide: Optional[Any] = Field(default=None, description="""Arbitrary data describing the expected type and format of the parameter, intended as a reference for catalog maintainers and not used in workflow execution.""", json_schema_extra = { "linkml_meta": {'alias': 'type_guide', 'domain_of': ['WorkflowParameter']} })
 
 
 class WorkflowUrlSpec(ConfiguredBaseModel):
     """
     Definition of a URL-based data source for a workflow parameter, typically used for reference data or external resources.
     """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#'})
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#"
-        }
-    )
-
-    ext: str = Field(
-        default=...,
-        description="""The file extension of the resource at the URL, which determines how Galaxy will interpret the data (e.g., 'fasta', 'gff', 'tabular').""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "ext", "domain_of": ["WorkflowUrlSpec"]}
-        },
-    )
-    src: str = Field(
-        default=...,
-        description="""The source type for the parameter, typically 'url' to indicate an external URL source rather than a Galaxy dataset or other source type.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "src", "domain_of": ["WorkflowUrlSpec"]}
-        },
-    )
-    url: str = Field(
-        default=...,
-        description="""The complete URL (including http/https protocol) to the external resource that will be used as input to the workflow.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "url",
-                "domain_of": ["OutbreakResource", "WorkflowUrlSpec"],
-            }
-        },
-    )
-    db_key: Optional[str] = Field(
-        default=None,
-        description="""Optional database key (genome build) to associate with this file, used by Galaxy to link the file to a specific reference genome.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "db_key", "domain_of": ["WorkflowUrlSpec"]}
-        },
-    )
-    md5: Optional[str] = Field(
-        default=None,
-        description="""Optional MD5 checksum hash for file integrity verification.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "md5", "domain_of": ["WorkflowUrlSpec"]}
-        },
-    )
+    ext: str = Field(default=..., description="""The file extension of the resource at the URL, which determines how Galaxy will interpret the data (e.g., 'fasta', 'gff', 'tabular').""", json_schema_extra = { "linkml_meta": {'alias': 'ext', 'domain_of': ['WorkflowUrlSpec']} })
+    src: str = Field(default=..., description="""The source type for the parameter, typically 'url' to indicate an external URL source rather than a Galaxy dataset or other source type.""", json_schema_extra = { "linkml_meta": {'alias': 'src', 'domain_of': ['WorkflowUrlSpec']} })
+    url: str = Field(default=..., description="""The complete URL (including http/https protocol) to the external resource that will be used as input to the workflow.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['OutbreakResource', 'WorkflowUrlSpec']} })
+    db_key: Optional[str] = Field(default=None, description="""Optional database key (genome build) to associate with this file, used by Galaxy to link the file to a specific reference genome.""", json_schema_extra = { "linkml_meta": {'alias': 'db_key', 'domain_of': ['WorkflowUrlSpec']} })
+    md5: Optional[str] = Field(default=None, description="""Optional MD5 checksum hash for file integrity verification.""", json_schema_extra = { "linkml_meta": {'alias': 'md5', 'domain_of': ['WorkflowUrlSpec']} })
 
 
 # Model rebuild
@@ -983,3 +529,4 @@ WorkflowDataRequirements.model_rebuild()
 WorkflowCollectionSpec.model_rebuild()
 WorkflowParameter.model_rebuild()
 WorkflowUrlSpec.model_rebuild()
+

--- a/catalog/py_package/catalog_build/generated_schema/schema.py
+++ b/catalog/py_package/catalog_build/generated_schema/schema.py
@@ -1,32 +1,13 @@
-from __future__ import annotations 
+from __future__ import annotations
 
 import re
 import sys
-from datetime import (
-    date,
-    datetime,
-    time
-)
-from decimal import Decimal 
-from enum import Enum 
-from typing import (
-    Any,
-    ClassVar,
-    Dict,
-    List,
-    Literal,
-    Optional,
-    Union
-)
+from datetime import date, datetime, time
+from decimal import Decimal
+from enum import Enum
+from typing import Any, ClassVar, Dict, List, Literal, Optional, Union
 
-from pydantic import (
-    BaseModel,
-    ConfigDict,
-    Field,
-    RootModel,
-    field_validator
-)
-
+from pydantic import BaseModel, ConfigDict, Field, RootModel, field_validator
 
 metamodel_version = "None"
 version = "None"
@@ -34,52 +15,62 @@ version = "None"
 
 class ConfiguredBaseModel(BaseModel):
     model_config = ConfigDict(
-        validate_assignment = True,
-        validate_default = True,
-        extra = "forbid",
-        arbitrary_types_allowed = True,
-        use_enum_values = True,
-        strict = False,
+        validate_assignment=True,
+        validate_default=True,
+        extra="forbid",
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        strict=False,
     )
     pass
-
-
 
 
 class LinkMLMeta(RootModel):
     root: Dict[str, Any] = {}
     model_config = ConfigDict(frozen=True)
 
-    def __getattr__(self, key:str):
+    def __getattr__(self, key: str):
         return getattr(self.root, key)
 
-    def __getitem__(self, key:str):
+    def __getitem__(self, key: str):
         return self.root[key]
 
-    def __setitem__(self, key:str, value):
+    def __setitem__(self, key: str, value):
         self.root[key] = value
 
-    def __contains__(self, key:str) -> bool:
+    def __contains__(self, key: str) -> bool:
         return key in self.root
 
 
-linkml_meta = LinkMLMeta({'default_prefix': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/schema.yaml#',
-     'description': 'Combined source data schemas.',
-     'id': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/schema.yaml#',
-     'imports': ['./assemblies',
-                 './organisms',
-                 './outbreaks',
-                 './workflow_categories',
-                 './workflows'],
-     'name': 'schema',
-     'prefixes': {'linkml': {'prefix_prefix': 'linkml',
-                             'prefix_reference': 'https://w3id.org/linkml/'}},
-     'source_file': '/home/danielle/Documents/brc-analytics/brc-analytics/catalog/py_package/catalog_build/schema_utils/../schema/schema.yaml'} )
+linkml_meta = LinkMLMeta(
+    {
+        "default_prefix": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/schema.yaml#",
+        "description": "Combined source data schemas.",
+        "id": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/schema.yaml#",
+        "imports": [
+            "./assemblies",
+            "./organisms",
+            "./outbreaks",
+            "./workflow_categories",
+            "./workflows",
+        ],
+        "name": "schema",
+        "prefixes": {
+            "linkml": {
+                "prefix_prefix": "linkml",
+                "prefix_reference": "https://w3id.org/linkml/",
+            }
+        },
+        "source_file": "/home/danielle/Documents/brc-analytics/brc-analytics/catalog/py_package/catalog_build/schema_utils/../schema/schema.yaml",
+    }
+)
+
 
 class OrganismPloidy(str, Enum):
     """
     Possible ploidies of an organism.
     """
+
     DIPLOID = "DIPLOID"
     HAPLOID = "HAPLOID"
     POLYPLOID = "POLYPLOID"
@@ -89,6 +80,7 @@ class OutbreakPriority(str, Enum):
     """
     Possible priorities of an outbreak.
     """
+
     HIGHEST = "HIGHEST"
     CRITICAL = "CRITICAL"
     HIGH = "HIGH"
@@ -100,6 +92,7 @@ class OutbreakResourceType(str, Enum):
     """
     Possible types of an outbreak resource.
     """
+
     PUBLICATION = "PUBLICATION"
     REFERENCE = "REFERENCE"
     NEWS = "NEWS"
@@ -113,6 +106,7 @@ class WorkflowCategoryId(str, Enum):
     """
     Set of IDs of workflow categories.
     """
+
     VARIANT_CALLING = "VARIANT_CALLING"
     TRANSCRIPTOMICS = "TRANSCRIPTOMICS"
     REGULATION = "REGULATION"
@@ -127,9 +121,10 @@ class WorkflowCategoryId(str, Enum):
 
 class CollectionType(str, Enum):
     """
-    Galaxy collection types supported for collection_spec in workflow parameters.
-Currently only 'list' collections are supported, which represent a simple ordered list of datasets.
+        Galaxy collection types supported for collection_spec in workflow parameters.
+    Currently only 'list' collections are supported, which represent a simple ordered list of datasets.
     """
+
     # A simple ordered list of datasets. Each element in the collection is a separate dataset.
     list = "list"
 
@@ -138,6 +133,7 @@ class WorkflowParameterVariable(str, Enum):
     """
     Possible variables that can be inserted into workflow parameters.
     """
+
     ASSEMBLY_ID = "ASSEMBLY_ID"
     ASSEMBLY_FASTA_URL = "ASSEMBLY_FASTA_URL"
     FASTA_COLLECTION = "FASTA_COLLECTION"
@@ -150,6 +146,7 @@ class WorkflowPloidy(str, Enum):
     """
     Possible ploidies supported by workflows.
     """
+
     ANY = "ANY"
     DIPLOID = "DIPLOID"
     HAPLOID = "HAPLOID"
@@ -160,6 +157,7 @@ class WorkflowScope(str, Enum):
     """
     The scope level at which a workflow operates, determining its display context and required inputs.
     """
+
     # Workflow operates on a specific genome assembly and requires assembly selection as the first step.
     ASSEMBLY = "ASSEMBLY"
     # Workflow operates at the organism level, either requiring no specific assembly or working across multiple assemblies.
@@ -172,6 +170,7 @@ class LibraryLayout(str, Enum):
     """
     Enumeration of possible library layouts for sequencing data.
     """
+
     # Paired-end sequencing reads
     PAIRED = "PAIRED"
     # Single-end sequencing reads
@@ -182,6 +181,7 @@ class LibrarySource(str, Enum):
     """
     Enumeration of possible library sources for sequencing data.
     """
+
     # Genomic DNA (includes PCR products from genomic DNA)
     GENOMIC = "GENOMIC"
     # Genomic DNA from a single cell
@@ -206,6 +206,7 @@ class LibraryStrategy(str, Enum):
     """
     Enumeration of possible library strategies for sequencing data.
     """
+
     # Whole genome sequencing
     WGS = "WGS"
     # Whole genome amplification
@@ -290,100 +291,261 @@ class LibraryStrategy(str, Enum):
     OTHER = "OTHER"
 
 
-
 class Assemblies(ConfiguredBaseModel):
     """
     Root object containing a collection of genomic assembly definitions for the BRC Analytics platform.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/assemblies.yaml#',
-         'tree_root': True})
 
-    assemblies: List[Assembly] = Field(default=..., description="""Collection of genomic assembly entries that will be available for analysis in the BRC Analytics platform.""", json_schema_extra = { "linkml_meta": {'alias': 'assemblies', 'domain_of': ['Assemblies']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/assemblies.yaml#",
+            "tree_root": True,
+        }
+    )
+
+    assemblies: List[Assembly] = Field(
+        default=...,
+        description="""Collection of genomic assembly entries that will be available for analysis in the BRC Analytics platform.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "assemblies", "domain_of": ["Assemblies"]}
+        },
+    )
 
 
 class Assembly(ConfiguredBaseModel):
     """
     Definition of a genomic assembly with its unique identifier.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/assemblies.yaml#'})
 
-    accession: str = Field(default=..., description="""The unique accession identifier for the assembly (e.g., GCA_000001405.28 for GRCh38), used to retrieve the assembly data from public repositories.""", json_schema_extra = { "linkml_meta": {'alias': 'accession', 'domain_of': ['Assembly']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/assemblies.yaml#"
+        }
+    )
+
+    accession: str = Field(
+        default=...,
+        description="""The unique accession identifier for the assembly (e.g., GCA_000001405.28 for GRCh38), used to retrieve the assembly data from public repositories.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "accession", "domain_of": ["Assembly"]}
+        },
+    )
 
 
 class Organisms(ConfiguredBaseModel):
     """
     Root object containing a collection of organism definitions for the BRC Analytics platform.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/organisms.yaml#',
-         'tree_root': True})
 
-    organisms: List[Organism] = Field(default=..., description="""Collection of organism entries that will be available in the BRC Analytics platform.""", json_schema_extra = { "linkml_meta": {'alias': 'organisms', 'domain_of': ['Organisms']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/organisms.yaml#",
+            "tree_root": True,
+        }
+    )
+
+    organisms: List[Organism] = Field(
+        default=...,
+        description="""Collection of organism entries that will be available in the BRC Analytics platform.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "organisms", "domain_of": ["Organisms"]}
+        },
+    )
 
 
 class Organism(ConfiguredBaseModel):
     """
     Definition of an organism with its taxonomic and genetic characteristics.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/organisms.yaml#'})
 
-    taxonomy_id: int = Field(default=..., description="""An NCBI Taxonomy ID at rank 'species'.""", json_schema_extra = { "linkml_meta": {'alias': 'taxonomy_id', 'domain_of': ['Organism', 'Outbreak', 'Workflow']} })
-    ploidy: List[OrganismPloidy] = Field(default=..., description="""The possible ploidy states (number of chromosome sets) that the organism may have, which determines compatible workflows.""", json_schema_extra = { "linkml_meta": {'alias': 'ploidy', 'domain_of': ['Organism', 'Workflow']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/organisms.yaml#"
+        }
+    )
+
+    taxonomy_id: int = Field(
+        default=...,
+        description="""An NCBI Taxonomy ID at rank 'species'.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "taxonomy_id",
+                "domain_of": ["Organism", "Outbreak", "Workflow"],
+            }
+        },
+    )
+    ploidy: List[OrganismPloidy] = Field(
+        default=...,
+        description="""The possible ploidy states (number of chromosome sets) that the organism may have, which determines compatible workflows.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "ploidy", "domain_of": ["Organism", "Workflow"]}
+        },
+    )
 
 
 class Outbreaks(ConfiguredBaseModel):
     """
     Root object containing a collection of pathogen definitions for the BRC Analytics platform to highlight as outbreaks/priority pathogens.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/outbreaks.yaml#',
-         'tree_root': True})
 
-    outbreaks: List[Outbreak] = Field(default=..., description="""Collection of pathogen entries that will be displayed in the BRC Analytics platform as outbreaks/priority pathogens.""", json_schema_extra = { "linkml_meta": {'alias': 'outbreaks', 'domain_of': ['Outbreaks']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/outbreaks.yaml#",
+            "tree_root": True,
+        }
+    )
+
+    outbreaks: List[Outbreak] = Field(
+        default=...,
+        description="""Collection of pathogen entries that will be displayed in the BRC Analytics platform as outbreaks/priority pathogens.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "outbreaks", "domain_of": ["Outbreaks"]}
+        },
+    )
 
 
 class Outbreak(ConfiguredBaseModel):
     """
     Definition of a priority pathogen with its taxonomic classification, priority level, and associated resources.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/outbreaks.yaml#'})
 
-    name: str = Field(default=..., description="""The display name of the pathogen as it will appear in the BRC Analytics interface.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
-         'domain_of': ['Outbreak', 'WorkflowCategory', 'WorkflowCollectionSpec']} })
-    taxonomy_id: int = Field(default=..., description="""The NCBI Taxonomy ID for the pathogen. Used to link to relevant genomic data and workflows.""", json_schema_extra = { "linkml_meta": {'alias': 'taxonomy_id', 'domain_of': ['Organism', 'Outbreak', 'Workflow']} })
-    priority: OutbreakPriority = Field(default=..., description="""The priority level of the pathogen, which determines its visibility and prominence in the BRC Analytics interface.""", json_schema_extra = { "linkml_meta": {'alias': 'priority', 'domain_of': ['Outbreak']} })
-    resources: List[OutbreakResource] = Field(default=..., description="""Collection of external resources (references, tools, databases) related to the pathogen.""", json_schema_extra = { "linkml_meta": {'alias': 'resources', 'domain_of': ['Outbreak']} })
-    description: MarkdownFileReference = Field(default=..., description="""Reference to a markdown file containing detailed information about the pathogen.""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Outbreak', 'WorkflowCategory', 'WorkflowDataRequirements']} })
-    active: bool = Field(default=..., description="""Boolean flag that determines if the pathogen should be included in the BRC Analytics interface. Used to manage visibility as pathogen relevance changes over time.""", json_schema_extra = { "linkml_meta": {'alias': 'active', 'domain_of': ['Outbreak', 'Workflow']} })
-    highlight_descendant_taxonomy_ids: Optional[List[int]] = Field(default=None, description="""List of NCBI Taxonomy IDs for descendant taxa (e.g., specific strains or serotypes) that should be highlighted within the outbreak category.""", json_schema_extra = { "linkml_meta": {'alias': 'highlight_descendant_taxonomy_ids', 'domain_of': ['Outbreak']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/outbreaks.yaml#"
+        }
+    )
+
+    name: str = Field(
+        default=...,
+        description="""The display name of the pathogen as it will appear in the BRC Analytics interface.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Outbreak", "WorkflowCategory", "WorkflowCollectionSpec"],
+            }
+        },
+    )
+    taxonomy_id: int = Field(
+        default=...,
+        description="""The NCBI Taxonomy ID for the pathogen. Used to link to relevant genomic data and workflows.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "taxonomy_id",
+                "domain_of": ["Organism", "Outbreak", "Workflow"],
+            }
+        },
+    )
+    priority: OutbreakPriority = Field(
+        default=...,
+        description="""The priority level of the pathogen, which determines its visibility and prominence in the BRC Analytics interface.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "priority", "domain_of": ["Outbreak"]}
+        },
+    )
+    resources: List[OutbreakResource] = Field(
+        default=...,
+        description="""Collection of external resources (references, tools, databases) related to the pathogen.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "resources", "domain_of": ["Outbreak"]}
+        },
+    )
+    description: MarkdownFileReference = Field(
+        default=...,
+        description="""Reference to a markdown file containing detailed information about the pathogen.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": [
+                    "Outbreak",
+                    "WorkflowCategory",
+                    "WorkflowDataRequirements",
+                ],
+            }
+        },
+    )
+    active: bool = Field(
+        default=...,
+        description="""Boolean flag that determines if the pathogen should be included in the BRC Analytics interface. Used to manage visibility as pathogen relevance changes over time.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "active", "domain_of": ["Outbreak", "Workflow"]}
+        },
+    )
+    highlight_descendant_taxonomy_ids: Optional[List[int]] = Field(
+        default=None,
+        description="""List of NCBI Taxonomy IDs for descendant taxa (e.g., specific strains or serotypes) that should be highlighted within the outbreak category.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "highlight_descendant_taxonomy_ids",
+                "domain_of": ["Outbreak"],
+            }
+        },
+    )
 
 
 class OutbreakResource(ConfiguredBaseModel):
     """
     Definition of an external resource (reference, tool, database) associated with a priority pathogen.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/outbreaks.yaml#'})
 
-    url: str = Field(default=..., description="""The complete URL (including http/https protocol) to the external resource.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['OutbreakResource', 'WorkflowUrlSpec']} })
-    title: str = Field(default=..., description="""The display title for the resource link as it will appear in the BRC Analytics interface.""", json_schema_extra = { "linkml_meta": {'alias': 'title', 'domain_of': ['OutbreakResource']} })
-    type: OutbreakResourceType = Field(default=..., description="""The category or type of the resource (e.g., REFERENCE, TOOL, DATABASE), which determines how it is displayed and organized.""", json_schema_extra = { "linkml_meta": {'alias': 'type', 'domain_of': ['OutbreakResource']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/outbreaks.yaml#"
+        }
+    )
+
+    url: str = Field(
+        default=...,
+        description="""The complete URL (including http/https protocol) to the external resource.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["OutbreakResource", "WorkflowUrlSpec"],
+            }
+        },
+    )
+    title: str = Field(
+        default=...,
+        description="""The display title for the resource link as it will appear in the BRC Analytics interface.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "title", "domain_of": ["OutbreakResource"]}
+        },
+    )
+    type: OutbreakResourceType = Field(
+        default=...,
+        description="""The category or type of the resource (e.g., REFERENCE, TOOL, DATABASE), which determines how it is displayed and organized.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "type", "domain_of": ["OutbreakResource"]}
+        },
+    )
 
 
 class MarkdownFileReference(ConfiguredBaseModel):
     """
     A reference to a markdown file containing detailed content about a priority pathogen.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/outbreaks.yaml#'})
 
-    path: str = Field(default=..., description="""Relative path to the markdown file from the project root. Must end with .md extension.""", json_schema_extra = { "linkml_meta": {'alias': 'path', 'domain_of': ['MarkdownFileReference']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/outbreaks.yaml#"
+        }
+    )
 
-    @field_validator('path')
+    path: str = Field(
+        default=...,
+        description="""Relative path to the markdown file from the project root. Must end with .md extension.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "path", "domain_of": ["MarkdownFileReference"]}
+        },
+    )
+
+    @field_validator("path")
     def pattern_path(cls, v):
-        pattern=re.compile(r".*\.md$")
-        if isinstance(v,list):
+        pattern = re.compile(r".*\.md$")
+        if isinstance(v, list):
             for element in v:
                 if isinstance(v, str) and not pattern.match(element):
                     raise ValueError(f"Invalid path format: {element}")
-        elif isinstance(v,str):
+        elif isinstance(v, str):
             if not pattern.match(v):
                 raise ValueError(f"Invalid path format: {v}")
         return v
@@ -393,67 +555,256 @@ class WorkflowCategories(ConfiguredBaseModel):
     """
     Root object containing a collection of workflow category definitions used to organize workflows in the BRC Analytics platform.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflow_categories.yaml#',
-         'tree_root': True})
 
-    workflow_categories: List[WorkflowCategory] = Field(default=..., description="""Collection of workflow category entries that will be used to group and organize workflows in the BRC Analytics interface.""", json_schema_extra = { "linkml_meta": {'alias': 'workflow_categories', 'domain_of': ['WorkflowCategories']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflow_categories.yaml#",
+            "tree_root": True,
+        }
+    )
+
+    workflow_categories: List[WorkflowCategory] = Field(
+        default=...,
+        description="""Collection of workflow category entries that will be used to group and organize workflows in the BRC Analytics interface.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "workflow_categories",
+                "domain_of": ["WorkflowCategories"],
+            }
+        },
+    )
 
 
 class WorkflowCategory(ConfiguredBaseModel):
     """
     Definition of a workflow category used to group related workflows for organization and display purposes.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflow_categories.yaml#'})
 
-    category: WorkflowCategoryId = Field(default=..., description="""The unique identifier for the workflow category, used to link workflows to their respective categories.""", json_schema_extra = { "linkml_meta": {'alias': 'category', 'domain_of': ['WorkflowCategory']} })
-    name: str = Field(default=..., description="""The human-readable display name of the workflow category as it will appear in the BRC Analytics interface.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
-         'domain_of': ['Outbreak', 'WorkflowCategory', 'WorkflowCollectionSpec']} })
-    description: str = Field(default=..., description="""A detailed description of the workflow category explaining its purpose and the types of workflows it contains.""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Outbreak', 'WorkflowCategory', 'WorkflowDataRequirements']} })
-    show_coming_soon: bool = Field(default=..., description="""Boolean flag that determines whether to display a 'Coming Soon' indicator for this category in the BRC Analytics interface when workflows in this category are not yet available.""", json_schema_extra = { "linkml_meta": {'alias': 'show_coming_soon', 'domain_of': ['WorkflowCategory']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflow_categories.yaml#"
+        }
+    )
+
+    category: WorkflowCategoryId = Field(
+        default=...,
+        description="""The unique identifier for the workflow category, used to link workflows to their respective categories.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "category", "domain_of": ["WorkflowCategory"]}
+        },
+    )
+    name: str = Field(
+        default=...,
+        description="""The human-readable display name of the workflow category as it will appear in the BRC Analytics interface.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Outbreak", "WorkflowCategory", "WorkflowCollectionSpec"],
+            }
+        },
+    )
+    description: str = Field(
+        default=...,
+        description="""A detailed description of the workflow category explaining its purpose and the types of workflows it contains.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": [
+                    "Outbreak",
+                    "WorkflowCategory",
+                    "WorkflowDataRequirements",
+                ],
+            }
+        },
+    )
+    show_coming_soon: bool = Field(
+        default=...,
+        description="""Boolean flag that determines whether to display a 'Coming Soon' indicator for this category in the BRC Analytics interface when workflows in this category are not yet available.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "show_coming_soon",
+                "domain_of": ["WorkflowCategory"],
+            }
+        },
+    )
 
 
 class Workflows(ConfiguredBaseModel):
     """
     Root object containing a collection of Galaxy workflow definitions for the BRC Analytics platform.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#',
-         'tree_root': True})
 
-    workflows: List[Workflow] = Field(default=..., description="""Collection of workflow entries that will be available to users in the BRC Analytics platform.""", json_schema_extra = { "linkml_meta": {'alias': 'workflows', 'domain_of': ['Workflows']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#",
+            "tree_root": True,
+        }
+    )
+
+    workflows: List[Workflow] = Field(
+        default=...,
+        description="""Collection of workflow entries that will be available to users in the BRC Analytics platform.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "workflows", "domain_of": ["Workflows"]}
+        },
+    )
 
 
 class Workflow(ConfiguredBaseModel):
     """
     Definition of a Galaxy workflow with its metadata, parameters, and organism compatibility information.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#'})
 
-    trs_id: str = Field(default=..., description="""The Tool Repository Service (TRS) identifier for the workflow, used to locate and retrieve the workflow from a Galaxy server.""", json_schema_extra = { "linkml_meta": {'alias': 'trs_id', 'domain_of': ['Workflow']} })
-    categories: List[WorkflowCategoryId] = Field(default=..., description="""List of category identifiers that this workflow belongs to, determining how it is organized and displayed in the BRC Analytics interface.""", json_schema_extra = { "linkml_meta": {'alias': 'categories', 'domain_of': ['Workflow']} })
-    workflow_name: str = Field(default=..., description="""The human-readable display name of the workflow as it will appear in the BRC Analytics interface.""", json_schema_extra = { "linkml_meta": {'alias': 'workflow_name', 'domain_of': ['Workflow']} })
-    workflow_description: str = Field(default=..., description="""A detailed description of the workflow's purpose, functionality, and expected outputs for users.""", json_schema_extra = { "linkml_meta": {'alias': 'workflow_description', 'domain_of': ['Workflow']} })
-    ploidy: WorkflowPloidy = Field(default=..., description="""The ploidy state (number of chromosome sets) that this workflow is designed to work with, ensuring compatibility with organism data.""", json_schema_extra = { "linkml_meta": {'alias': 'ploidy', 'domain_of': ['Organism', 'Workflow']} })
-    scope: Optional[WorkflowScope] = Field(default=None, description="""The scope level at which this workflow operates, determining where it is displayed in the UI and what the first configuration step should be. Defaults to ASSEMBLY for backward compatibility.""", json_schema_extra = { "linkml_meta": {'alias': 'scope', 'domain_of': ['Workflow']} })
-    assembly_count_min: Optional[int] = Field(default=None, description="""The minimum number of genome assemblies a user must select for this workflow. Defaults to 1 for ASSEMBLY-scope workflows; must be set explicitly for ORGANISM and SEQUENCE scope. Use 0 for workflows that take no user-selected assemblies (e.g. assembly-building or curated-FASTA workflows).""", json_schema_extra = { "linkml_meta": {'alias': 'assembly_count_min', 'domain_of': ['Workflow']} })
-    assembly_count_max: Optional[int] = Field(default=None, description="""The maximum number of genome assemblies a user may select for this workflow. Null/absent means no upper limit. Defaults to 1 for ASSEMBLY-scope workflows; must be set explicitly for ORGANISM and SEQUENCE scope.""", json_schema_extra = { "linkml_meta": {'alias': 'assembly_count_max', 'domain_of': ['Workflow']} })
-    taxonomy_id: Optional[int] = Field(default=None, description="""The NCBI Taxonomy ID of the organism this workflow is designed for. If specified, the workflow will be available for all assemblies with this ID in their taxonomic lineage.""", json_schema_extra = { "linkml_meta": {'alias': 'taxonomy_id', 'domain_of': ['Organism', 'Outbreak', 'Workflow']} })
-    parameters: List[WorkflowParameter] = Field(default=..., description="""Collection of input parameters that will be passed to the workflow when it is executed, including data sources and configuration options.""", json_schema_extra = { "linkml_meta": {'alias': 'parameters', 'domain_of': ['Workflow']} })
-    active: bool = Field(default=..., description="""Boolean flag that determines if the workflow should be included in the BRC Analytics interface. Used to manage visibility of workflows that may be under development or deprecated.""", json_schema_extra = { "linkml_meta": {'alias': 'active', 'domain_of': ['Outbreak', 'Workflow']} })
-    iwc_id: str = Field(default=..., description="""The Intergalactic Workflow Commission (IWC) identifier for the workflow, used to link to the workflow's page on the IWC website.""", json_schema_extra = { "linkml_meta": {'alias': 'iwc_id', 'domain_of': ['Workflow']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#"
+        }
+    )
+
+    trs_id: str = Field(
+        default=...,
+        description="""The Tool Repository Service (TRS) identifier for the workflow, used to locate and retrieve the workflow from a Galaxy server.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "trs_id", "domain_of": ["Workflow"]}
+        },
+    )
+    categories: List[WorkflowCategoryId] = Field(
+        default=...,
+        description="""List of category identifiers that this workflow belongs to, determining how it is organized and displayed in the BRC Analytics interface.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "categories", "domain_of": ["Workflow"]}
+        },
+    )
+    workflow_name: str = Field(
+        default=...,
+        description="""The human-readable display name of the workflow as it will appear in the BRC Analytics interface.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "workflow_name", "domain_of": ["Workflow"]}
+        },
+    )
+    workflow_description: str = Field(
+        default=...,
+        description="""A detailed description of the workflow's purpose, functionality, and expected outputs for users.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "workflow_description", "domain_of": ["Workflow"]}
+        },
+    )
+    ploidy: WorkflowPloidy = Field(
+        default=...,
+        description="""The ploidy state (number of chromosome sets) that this workflow is designed to work with, ensuring compatibility with organism data.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "ploidy", "domain_of": ["Organism", "Workflow"]}
+        },
+    )
+    scope: Optional[WorkflowScope] = Field(
+        default=None,
+        description="""The scope level at which this workflow operates, determining where it is displayed in the UI and what the first configuration step should be. Defaults to ASSEMBLY for backward compatibility.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "scope", "domain_of": ["Workflow"]}
+        },
+    )
+    assembly_count_min: Optional[int] = Field(
+        default=None,
+        description="""The minimum number of genome assemblies a user must select for this workflow. Defaults to 1 for ASSEMBLY-scope workflows; must be set explicitly for ORGANISM and SEQUENCE scope. Use 0 for workflows that take no user-selected assemblies (e.g. assembly-building or curated-FASTA workflows).""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "assembly_count_min", "domain_of": ["Workflow"]}
+        },
+    )
+    assembly_count_max: Optional[int] = Field(
+        default=None,
+        description="""The maximum number of genome assemblies a user may select for this workflow. Null/absent means no upper limit. Defaults to 1 for ASSEMBLY-scope workflows; must be set explicitly for ORGANISM and SEQUENCE scope.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "assembly_count_max", "domain_of": ["Workflow"]}
+        },
+    )
+    taxonomy_id: Optional[int] = Field(
+        default=None,
+        description="""The NCBI Taxonomy ID of the organism this workflow is designed for. If specified, the workflow will be available for all assemblies with this ID in their taxonomic lineage.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "taxonomy_id",
+                "domain_of": ["Organism", "Outbreak", "Workflow"],
+            }
+        },
+    )
+    parameters: List[WorkflowParameter] = Field(
+        default=...,
+        description="""Collection of input parameters that will be passed to the workflow when it is executed, including data sources and configuration options.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "parameters", "domain_of": ["Workflow"]}
+        },
+    )
+    active: bool = Field(
+        default=...,
+        description="""Boolean flag that determines if the workflow should be included in the BRC Analytics interface. Used to manage visibility of workflows that may be under development or deprecated.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "active", "domain_of": ["Outbreak", "Workflow"]}
+        },
+    )
+    iwc_id: str = Field(
+        default=...,
+        description="""The Intergalactic Workflow Commission (IWC) identifier for the workflow, used to link to the workflow's page on the IWC website.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "iwc_id", "domain_of": ["Workflow"]}
+        },
+    )
 
 
 class WorkflowDataRequirements(ConfiguredBaseModel):
     """
     Specification of data requirements for a workflow parameter, such as library strategy and layout.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#'})
 
-    library_strategy: Optional[List[LibraryStrategy]] = Field(default=None, description="""The library strategy values that are acceptable for this parameter (e.g., 'WGS', 'RNA-Seq').""", json_schema_extra = { "linkml_meta": {'alias': 'library_strategy', 'domain_of': ['WorkflowDataRequirements']} })
-    library_layout: Optional[LibraryLayout] = Field(default=None, description="""The library layout that is required for this parameter (e.g., 'PAIRED', 'SINGLE').""", json_schema_extra = { "linkml_meta": {'alias': 'library_layout', 'domain_of': ['WorkflowDataRequirements']} })
-    library_source: Optional[List[LibrarySource]] = Field(default=None, description="""The library source values that are acceptable for this parameter (e.g., 'GENOMIC', 'TRANSCRIPTOMIC SINGLE CELL').""", json_schema_extra = { "linkml_meta": {'alias': 'library_source', 'domain_of': ['WorkflowDataRequirements']} })
-    description: Optional[str] = Field(default=None, description="""A descriptive text to provide additional context about the data requirements, useful for non-standard library strategies like 'OTHER'.""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'domain_of': ['Outbreak', 'WorkflowCategory', 'WorkflowDataRequirements']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#"
+        }
+    )
+
+    library_strategy: Optional[List[LibraryStrategy]] = Field(
+        default=None,
+        description="""The library strategy values that are acceptable for this parameter (e.g., 'WGS', 'RNA-Seq').""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "library_strategy",
+                "domain_of": ["WorkflowDataRequirements"],
+            }
+        },
+    )
+    library_layout: Optional[LibraryLayout] = Field(
+        default=None,
+        description="""The library layout that is required for this parameter (e.g., 'PAIRED', 'SINGLE').""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "library_layout",
+                "domain_of": ["WorkflowDataRequirements"],
+            }
+        },
+    )
+    library_source: Optional[List[LibrarySource]] = Field(
+        default=None,
+        description="""The library source values that are acceptable for this parameter (e.g., 'GENOMIC', 'TRANSCRIPTOMIC SINGLE CELL').""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "library_source",
+                "domain_of": ["WorkflowDataRequirements"],
+            }
+        },
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="""A descriptive text to provide additional context about the data requirements, useful for non-standard library strategies like 'OTHER'.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": [
+                    "Outbreak",
+                    "WorkflowCategory",
+                    "WorkflowDataRequirements",
+                ],
+            }
+        },
+    )
 
 
 class WorkflowCollectionSpec(ConfiguredBaseModel):
@@ -476,39 +827,156 @@ class WorkflowCollectionSpec(ConfiguredBaseModel):
           md5: def456...
     ```
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#'})
 
-    collection_type: CollectionType = Field(default=..., description="""The type of Galaxy collection to create. Currently only 'list' is supported. Determines the structure of the collection.""", json_schema_extra = { "linkml_meta": {'alias': 'collection_type', 'domain_of': ['WorkflowCollectionSpec']} })
-    elements: List[WorkflowUrlSpec] = Field(default=..., description="""Array of URL specifications that will become elements in the collection. Each element represents a file to include in the collection. Must contain at least one element.""", min_length=1, json_schema_extra = { "linkml_meta": {'alias': 'elements', 'domain_of': ['WorkflowCollectionSpec']} })
-    name: Optional[str] = Field(default=None, description="""Optional identifier for the collection, used as the collection name in Galaxy. If not provided, defaults to 'Collection'.""", json_schema_extra = { "linkml_meta": {'alias': 'name',
-         'domain_of': ['Outbreak', 'WorkflowCategory', 'WorkflowCollectionSpec']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#"
+        }
+    )
+
+    collection_type: CollectionType = Field(
+        default=...,
+        description="""The type of Galaxy collection to create. Currently only 'list' is supported. Determines the structure of the collection.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "collection_type",
+                "domain_of": ["WorkflowCollectionSpec"],
+            }
+        },
+    )
+    elements: List[WorkflowUrlSpec] = Field(
+        default=...,
+        description="""Array of URL specifications that will become elements in the collection. Each element represents a file to include in the collection. Must contain at least one element.""",
+        min_length=1,
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "elements",
+                "domain_of": ["WorkflowCollectionSpec"],
+            }
+        },
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="""Optional identifier for the collection, used as the collection name in Galaxy. If not provided, defaults to 'Collection'.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Outbreak", "WorkflowCategory", "WorkflowCollectionSpec"],
+            }
+        },
+    )
 
 
 class WorkflowParameter(ConfiguredBaseModel):
     """
     Definition of an input parameter for a Galaxy workflow, specifying how the parameter value should be determined when the workflow is executed.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#'})
 
-    key: str = Field(default=..., description="""The identifier for the parameter as expected by the Galaxy workflow, used to map the parameter value to the correct input.""", json_schema_extra = { "linkml_meta": {'alias': 'key', 'domain_of': ['WorkflowParameter']} })
-    variable: Optional[WorkflowParameterVariable] = Field(default=None, description="""A predefined variable that will be substituted as the value of the parameter at runtime, such as assembly information.""", json_schema_extra = { "linkml_meta": {'alias': 'variable', 'domain_of': ['WorkflowParameter']} })
-    collection_spec: Optional[WorkflowCollectionSpec] = Field(default=None, description="""A collection specification for the parameter, allowing multiple files from external sources to be provided as a Galaxy collection.""", json_schema_extra = { "linkml_meta": {'alias': 'collection_spec', 'domain_of': ['WorkflowParameter']} })
-    url_spec: Optional[WorkflowUrlSpec] = Field(default=None, description="""A direct URL specification for the parameter, allowing for external data sources to be provided to the workflow.""", json_schema_extra = { "linkml_meta": {'alias': 'url_spec', 'domain_of': ['WorkflowParameter']} })
-    data_requirements: Optional[WorkflowDataRequirements] = Field(default=None, description="""Specifications for the data requirements of this parameter, such as library strategy and layout.""", json_schema_extra = { "linkml_meta": {'alias': 'data_requirements', 'domain_of': ['WorkflowParameter']} })
-    type_guide: Optional[Any] = Field(default=None, description="""Arbitrary data describing the expected type and format of the parameter, intended as a reference for catalog maintainers and not used in workflow execution.""", json_schema_extra = { "linkml_meta": {'alias': 'type_guide', 'domain_of': ['WorkflowParameter']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#"
+        }
+    )
+
+    key: str = Field(
+        default=...,
+        description="""The identifier for the parameter as expected by the Galaxy workflow, used to map the parameter value to the correct input.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "key", "domain_of": ["WorkflowParameter"]}
+        },
+    )
+    variable: Optional[WorkflowParameterVariable] = Field(
+        default=None,
+        description="""A predefined variable that will be substituted as the value of the parameter at runtime, such as assembly information.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "variable", "domain_of": ["WorkflowParameter"]}
+        },
+    )
+    collection_spec: Optional[WorkflowCollectionSpec] = Field(
+        default=None,
+        description="""A collection specification for the parameter, allowing multiple files from external sources to be provided as a Galaxy collection.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "collection_spec",
+                "domain_of": ["WorkflowParameter"],
+            }
+        },
+    )
+    url_spec: Optional[WorkflowUrlSpec] = Field(
+        default=None,
+        description="""A direct URL specification for the parameter, allowing for external data sources to be provided to the workflow.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "url_spec", "domain_of": ["WorkflowParameter"]}
+        },
+    )
+    data_requirements: Optional[WorkflowDataRequirements] = Field(
+        default=None,
+        description="""Specifications for the data requirements of this parameter, such as library strategy and layout.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "data_requirements",
+                "domain_of": ["WorkflowParameter"],
+            }
+        },
+    )
+    type_guide: Optional[Any] = Field(
+        default=None,
+        description="""Arbitrary data describing the expected type and format of the parameter, intended as a reference for catalog maintainers and not used in workflow execution.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "type_guide", "domain_of": ["WorkflowParameter"]}
+        },
+    )
 
 
 class WorkflowUrlSpec(ConfiguredBaseModel):
     """
     Definition of a URL-based data source for a workflow parameter, typically used for reference data or external resources.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#'})
 
-    ext: str = Field(default=..., description="""The file extension of the resource at the URL, which determines how Galaxy will interpret the data (e.g., 'fasta', 'gff', 'tabular').""", json_schema_extra = { "linkml_meta": {'alias': 'ext', 'domain_of': ['WorkflowUrlSpec']} })
-    src: str = Field(default=..., description="""The source type for the parameter, typically 'url' to indicate an external URL source rather than a Galaxy dataset or other source type.""", json_schema_extra = { "linkml_meta": {'alias': 'src', 'domain_of': ['WorkflowUrlSpec']} })
-    url: str = Field(default=..., description="""The complete URL (including http/https protocol) to the external resource that will be used as input to the workflow.""", json_schema_extra = { "linkml_meta": {'alias': 'url', 'domain_of': ['OutbreakResource', 'WorkflowUrlSpec']} })
-    db_key: Optional[str] = Field(default=None, description="""Optional database key (genome build) to associate with this file, used by Galaxy to link the file to a specific reference genome.""", json_schema_extra = { "linkml_meta": {'alias': 'db_key', 'domain_of': ['WorkflowUrlSpec']} })
-    md5: Optional[str] = Field(default=None, description="""Optional MD5 checksum hash for file integrity verification.""", json_schema_extra = { "linkml_meta": {'alias': 'md5', 'domain_of': ['WorkflowUrlSpec']} })
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#"
+        }
+    )
+
+    ext: str = Field(
+        default=...,
+        description="""The file extension of the resource at the URL, which determines how Galaxy will interpret the data (e.g., 'fasta', 'gff', 'tabular').""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "ext", "domain_of": ["WorkflowUrlSpec"]}
+        },
+    )
+    src: str = Field(
+        default=...,
+        description="""The source type for the parameter, typically 'url' to indicate an external URL source rather than a Galaxy dataset or other source type.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "src", "domain_of": ["WorkflowUrlSpec"]}
+        },
+    )
+    url: str = Field(
+        default=...,
+        description="""The complete URL (including http/https protocol) to the external resource that will be used as input to the workflow.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["OutbreakResource", "WorkflowUrlSpec"],
+            }
+        },
+    )
+    db_key: Optional[str] = Field(
+        default=None,
+        description="""Optional database key (genome build) to associate with this file, used by Galaxy to link the file to a specific reference genome.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "db_key", "domain_of": ["WorkflowUrlSpec"]}
+        },
+    )
+    md5: Optional[str] = Field(
+        default=None,
+        description="""Optional MD5 checksum hash for file integrity verification.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "md5", "domain_of": ["WorkflowUrlSpec"]}
+        },
+    )
 
 
 # Model rebuild
@@ -529,4 +997,3 @@ WorkflowDataRequirements.model_rebuild()
 WorkflowCollectionSpec.model_rebuild()
 WorkflowParameter.model_rebuild()
 WorkflowUrlSpec.model_rebuild()
-

--- a/catalog/py_package/catalog_build/schema/workflows.yaml
+++ b/catalog/py_package/catalog_build/schema/workflows.yaml
@@ -59,6 +59,14 @@ classes:
         description: The scope level at which this workflow operates, determining where it is displayed in the UI and what the first configuration step should be. Defaults to ASSEMBLY for backward compatibility.
         required: false
         range: WorkflowScope
+      assembly_count_min:
+        description: The minimum number of genome assemblies a user must select for this workflow. Defaults to 1 for ASSEMBLY-scope workflows; must be set explicitly for ORGANISM and SEQUENCE scope. Use 0 for workflows that take no user-selected assemblies (e.g. assembly-building or curated-FASTA workflows).
+        required: false
+        range: integer
+      assembly_count_max:
+        description: The maximum number of genome assemblies a user may select for this workflow. Null/absent means no upper limit. Defaults to 1 for ASSEMBLY-scope workflows; must be set explicitly for ORGANISM and SEQUENCE scope.
+        required: false
+        range: integer
       taxonomy_id:
         description: The NCBI Taxonomy ID of the organism this workflow is designed for. If specified, the workflow will be available for all assemblies with this ID in their taxonomic lineage.
         required: false

--- a/catalog/schema/generated/schema.ts
+++ b/catalog/schema/generated/schema.ts
@@ -360,6 +360,10 @@ export interface Workflow {
     ploidy: WorkflowPloidy,
     /** The scope level at which this workflow operates, determining where it is displayed in the UI and what the first configuration step should be. Defaults to ASSEMBLY for backward compatibility. */
     scope?: WorkflowScope | null,
+    /** The minimum number of genome assemblies a user must select for this workflow. Defaults to 1 for ASSEMBLY-scope workflows; must be set explicitly for ORGANISM and SEQUENCE scope. Use 0 for workflows that take no user-selected assemblies (e.g. assembly-building or curated-FASTA workflows). */
+    assembly_count_min?: number | null,
+    /** The maximum number of genome assemblies a user may select for this workflow. Null/absent means no upper limit. Defaults to 1 for ASSEMBLY-scope workflows; must be set explicitly for ORGANISM and SEQUENCE scope. */
+    assembly_count_max?: number | null,
     /** The NCBI Taxonomy ID of the organism this workflow is designed for. If specified, the workflow will be available for all assemblies with this ID in their taxonomic lineage. */
     taxonomy_id?: number | null,
     /** Collection of input parameters that will be passed to the workflow when it is executed, including data sources and configuration options. */

--- a/catalog/schema/generated/workflows.json
+++ b/catalog/schema/generated/workflows.json
@@ -101,6 +101,20 @@
                     "description": "Boolean flag that determines if the workflow should be included in the BRC Analytics interface. Used to manage visibility of workflows that may be under development or deprecated.",
                     "type": "boolean"
                 },
+                "assembly_count_max": {
+                    "description": "The maximum number of genome assemblies a user may select for this workflow. Null/absent means no upper limit. Defaults to 1 for ASSEMBLY-scope workflows; must be set explicitly for ORGANISM and SEQUENCE scope.",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "assembly_count_min": {
+                    "description": "The minimum number of genome assemblies a user must select for this workflow. Defaults to 1 for ASSEMBLY-scope workflows; must be set explicitly for ORGANISM and SEQUENCE scope. Use 0 for workflows that take no user-selected assemblies (e.g. assembly-building or curated-FASTA workflows).",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
                 "categories": {
                     "description": "List of category identifiers that this workflow belongs to, determining how it is organized and displayed in the BRC Analytics interface.",
                     "items": {

--- a/catalog/source/workflows.yml
+++ b/catalog/source/workflows.yml
@@ -104,6 +104,8 @@ workflows:
       and assembly graph
     ploidy: ANY
     scope: ORGANISM
+    assembly_count_min: 0
+    assembly_count_max: 0
     parameters:
       - key: Input sequence reads
         variable: SANGER_READ_RUN_SINGLE
@@ -175,6 +177,8 @@ workflows:
     workflow_description: Assembly of bacterial paired-end short read data
     ploidy: ANY
     scope: ORGANISM
+    assembly_count_min: 0
+    assembly_count_max: 0
     taxonomy_id: 2
     parameters:
       - key: Input adapter trimmed sequence reads (forward)
@@ -896,6 +900,7 @@ workflows:
       branch labeling for branch comparisons.
     ploidy: ANY
     scope: ORGANISM
+    assembly_count_min: 2
     taxonomy_id: 10239
     parameters:
       - key: reference cds
@@ -997,6 +1002,8 @@ workflows:
       for batches of Illumina PE sequenced Influenza A isolates.
     ploidy: ANY
     scope: ORGANISM
+    assembly_count_min: 0
+    assembly_count_max: 0
     taxonomy_id: 11320
     parameters:
       - key: References per segment collection

--- a/pages/data/[entityListType]/[entityId]/analyze/workflows/[trsId]/index.tsx
+++ b/pages/data/[entityListType]/[entityId]/analyze/workflows/[trsId]/index.tsx
@@ -173,7 +173,11 @@ function processOrganismPaths(
 
     if (!entityId) continue;
 
-    const compatibleCategories = buildOrganismWorkflows(entity, workflows);
+    const compatibleCategories = buildOrganismWorkflows(
+      entity,
+      workflows,
+      true
+    );
     const compatibleWorkflows = compatibleCategories.flatMap(
       (category) => category.workflows
     );

--- a/tests/analysisMethodCatalogs.utils.test.ts
+++ b/tests/analysisMethodCatalogs.utils.test.ts
@@ -20,6 +20,8 @@ describe("buildAssemblyWorkflows", () => {
       showComingSoon: false,
       workflows: [
         {
+          assemblyCountMax: 1,
+          assemblyCountMin: 1,
           iwcId: "iwc-any",
           parameters: [],
           ploidy: WORKFLOW_PLOIDY.ANY,
@@ -30,6 +32,8 @@ describe("buildAssemblyWorkflows", () => {
           workflowName: "ANY Workflow",
         },
         {
+          assemblyCountMax: 1,
+          assemblyCountMin: 1,
           iwcId: "iwc-haploid-999",
           parameters: [],
           ploidy: WORKFLOW_PLOIDY.HAPLOID,
@@ -48,6 +52,8 @@ describe("buildAssemblyWorkflows", () => {
       showComingSoon: true,
       workflows: [
         {
+          assemblyCountMax: 1,
+          assemblyCountMin: 1,
           iwcId: "iwc-diploid-not-lineage",
           parameters: [],
           ploidy: WORKFLOW_PLOIDY.DIPLOID,
@@ -66,6 +72,8 @@ describe("buildAssemblyWorkflows", () => {
       showComingSoon: false,
       workflows: [
         {
+          assemblyCountMax: 1,
+          assemblyCountMin: 1,
           iwcId: "iwc-haploid-other",
           parameters: [],
           ploidy: WORKFLOW_PLOIDY.HAPLOID,
@@ -84,6 +92,8 @@ describe("buildAssemblyWorkflows", () => {
       showComingSoon: false,
       workflows: [
         {
+          assemblyCountMax: 1,
+          assemblyCountMin: 1,
           iwcId: "iwc-transcriptomics-any",
           parameters: [],
           ploidy: WORKFLOW_PLOIDY.ANY,

--- a/tests/apis/catalog/brc-analytics-catalog/common/workflowAssembly.test.ts
+++ b/tests/apis/catalog/brc-analytics-catalog/common/workflowAssembly.test.ts
@@ -1,0 +1,21 @@
+import { workflowMeetsAssemblyMinimum } from "../../../../../app/apis/catalog/brc-analytics-catalog/common/workflowAssembly";
+
+describe("workflowMeetsAssemblyMinimum", () => {
+  test("returns true when assemblyCountMin is 0 (no assembly requirement)", () => {
+    expect(workflowMeetsAssemblyMinimum(0, 0)).toBe(true);
+    expect(workflowMeetsAssemblyMinimum(0, 5)).toBe(true);
+  });
+
+  test("returns true when compatible count meets or exceeds minimum", () => {
+    expect(workflowMeetsAssemblyMinimum(1, 1)).toBe(true);
+    expect(workflowMeetsAssemblyMinimum(1, 5)).toBe(true);
+    expect(workflowMeetsAssemblyMinimum(2, 2)).toBe(true);
+    expect(workflowMeetsAssemblyMinimum(2, 5)).toBe(true);
+  });
+
+  test("returns false when compatible count is below minimum", () => {
+    expect(workflowMeetsAssemblyMinimum(1, 0)).toBe(false);
+    expect(workflowMeetsAssemblyMinimum(2, 1)).toBe(false);
+    expect(workflowMeetsAssemblyMinimum(2, 0)).toBe(false);
+  });
+});

--- a/tests/catalog/build/ts/build-workflow-mappings.qc.test.ts
+++ b/tests/catalog/build/ts/build-workflow-mappings.qc.test.ts
@@ -1,0 +1,102 @@
+import {
+  Workflow,
+  WorkflowCategory,
+} from "../../../../app/apis/catalog/brc-analytics-catalog/common/entities";
+import {
+  WORKFLOW_PLOIDY,
+  WORKFLOW_SCOPE,
+} from "../../../../app/apis/catalog/brc-analytics-catalog/common/schema-entities";
+import { generateWorkflowMappingsQC } from "../../../../catalog/build/ts/build-workflow-mappings";
+
+describe("generateWorkflowMappingsQC - assembly count aware", () => {
+  const makeWorkflow = (
+    name: string,
+    trsId: string,
+    scope: WORKFLOW_SCOPE,
+    assemblyCountMin: number
+  ): Workflow => ({
+    assemblyCountMax: scope === WORKFLOW_SCOPE.ASSEMBLY ? 1 : 0,
+    assemblyCountMin,
+    iwcId: "",
+    parameters: [],
+    ploidy: WORKFLOW_PLOIDY.ANY,
+    scope,
+    taxonomyId: null,
+    trsId,
+    workflowDescription: "desc",
+    workflowName: name,
+  });
+
+  const categories: WorkflowCategory[] = [
+    {
+      category: "Test",
+      description: "d",
+      name: "test",
+      showComingSoon: false,
+      workflows: [
+        makeWorkflow(
+          "Assembly Wf",
+          "#trs-assembly",
+          WORKFLOW_SCOPE.ASSEMBLY,
+          1
+        ),
+        makeWorkflow(
+          "Organism Wf",
+          "#trs-organism",
+          WORKFLOW_SCOPE.ORGANISM,
+          0
+        ),
+        makeWorkflow("Hyphy Wf", "#trs-hyphy", WORKFLOW_SCOPE.ORGANISM, 2),
+      ],
+    },
+  ];
+
+  test("does not flag assembly-independent workflows (min 0)", () => {
+    const mappings = [
+      { compatibleAssemblyCount: 0, workflowTrsId: "#trs-organism" },
+    ];
+    const report = generateWorkflowMappingsQC(mappings, categories, "Test");
+    expect(report).toContain(
+      "Workflows that cannot meet their minimum assembly requirement"
+    );
+    expect(report).not.toContain("Organism Wf");
+  });
+
+  test("flags ASSEMBLY workflow with 0 compatible assemblies", () => {
+    const mappings = [
+      { compatibleAssemblyCount: 0, workflowTrsId: "#trs-assembly" },
+      { compatibleAssemblyCount: 0, workflowTrsId: "#trs-organism" },
+      { compatibleAssemblyCount: 5, workflowTrsId: "#trs-hyphy" },
+    ];
+    const report = generateWorkflowMappingsQC(mappings, categories, "Test");
+    expect(report).toContain("Assembly Wf");
+    expect(report).not.toContain("Organism Wf");
+    expect(report).not.toContain("Hyphy Wf");
+  });
+
+  test("flags workflow with insufficient assemblies (0 < count < min)", () => {
+    const mappings = [
+      { compatibleAssemblyCount: 5, workflowTrsId: "#trs-assembly" },
+      { compatibleAssemblyCount: 0, workflowTrsId: "#trs-organism" },
+      { compatibleAssemblyCount: 1, workflowTrsId: "#trs-hyphy" },
+    ];
+    const report = generateWorkflowMappingsQC(mappings, categories, "Test");
+    expect(report).toContain("Hyphy Wf");
+    expect(report).toContain("needs >= 2, 1 compatible");
+    expect(report).not.toContain("Assembly Wf");
+    expect(report).not.toContain("Organism Wf");
+  });
+
+  test("does not flag workflows that meet their minimum", () => {
+    const mappings = [
+      { compatibleAssemblyCount: 5, workflowTrsId: "#trs-assembly" },
+      { compatibleAssemblyCount: 0, workflowTrsId: "#trs-organism" },
+      { compatibleAssemblyCount: 5, workflowTrsId: "#trs-hyphy" },
+    ];
+    const report = generateWorkflowMappingsQC(mappings, categories, "Test");
+    expect(report).toContain("None");
+    expect(report).not.toContain("Assembly Wf");
+    expect(report).not.toContain("Organism Wf");
+    expect(report).not.toContain("Hyphy Wf");
+  });
+});

--- a/tests/catalog/build/ts/build-workflows.assemblyCount.test.ts
+++ b/tests/catalog/build/ts/build-workflows.assemblyCount.test.ts
@@ -1,0 +1,213 @@
+import { WORKFLOW_SCOPE } from "../../../../app/apis/catalog/brc-analytics-catalog/common/schema-entities";
+import { buildWorkflows } from "../../../../catalog/build/ts/build-workflows";
+
+// Mock YAML file reading so we can inject source workflows.
+jest.mock("../../../../catalog/build/ts/utils", () => ({
+  readYamlFile: jest.fn(),
+  saveJson: jest.fn(),
+}));
+
+import { readYamlFile } from "../../../../catalog/build/ts/utils";
+
+const mockReadYamlFile = readYamlFile as jest.MockedFunction<
+  typeof readYamlFile
+>;
+
+const BASE_SOURCE_WORKFLOW = {
+  active: true,
+  categories: ["ASSEMBLY"],
+  iwc_id: "test-iwc",
+  parameters: [],
+  ploidy: "ANY",
+  trs_id: "#test/trs",
+  workflow_description: "test workflow",
+  workflow_name: "Test Workflow",
+};
+
+describe("buildWorkflows - assembly count resolution", () => {
+  beforeEach(() => {
+    mockReadYamlFile.mockReset();
+  });
+
+  test("ASSEMBLY scope defaults to min 1 / max 1", async () => {
+    mockReadYamlFile.mockImplementation(async (path: string) => {
+      if (path.includes("workflow_categories")) {
+        return {
+          workflow_categories: [
+            {
+              category: "ASSEMBLY",
+              description: "d",
+              name: "n",
+              show_coming_soon: false,
+            },
+          ],
+        };
+      }
+      return {
+        workflows: [
+          {
+            ...BASE_SOURCE_WORKFLOW,
+            scope: "ASSEMBLY",
+          },
+        ],
+      };
+    });
+
+    const result = await buildWorkflows();
+    const wf = result[0].workflows[0];
+    expect(wf.assemblyCountMin).toBe(1);
+    expect(wf.assemblyCountMax).toBe(1);
+    expect(wf.scope).toBe(WORKFLOW_SCOPE.ASSEMBLY);
+  });
+
+  test("ASSEMBLY scope with explicit values uses them", async () => {
+    mockReadYamlFile.mockImplementation(async (path: string) => {
+      if (path.includes("workflow_categories")) {
+        return {
+          workflow_categories: [
+            {
+              category: "ASSEMBLY",
+              description: "d",
+              name: "n",
+              show_coming_soon: false,
+            },
+          ],
+        };
+      }
+      return {
+        workflows: [
+          {
+            ...BASE_SOURCE_WORKFLOW,
+            assembly_count_max: 10,
+            assembly_count_min: 3,
+            scope: "ASSEMBLY",
+          },
+        ],
+      };
+    });
+
+    const result = await buildWorkflows();
+    const wf = result[0].workflows[0];
+    expect(wf.assemblyCountMin).toBe(3);
+    expect(wf.assemblyCountMax).toBe(10);
+  });
+
+  test("ORGANISM scope passes through explicit min/max", async () => {
+    mockReadYamlFile.mockImplementation(async (path: string) => {
+      if (path.includes("workflow_categories")) {
+        return {
+          workflow_categories: [
+            {
+              category: "ASSEMBLY",
+              description: "d",
+              name: "n",
+              show_coming_soon: false,
+            },
+          ],
+        };
+      }
+      return {
+        workflows: [
+          {
+            ...BASE_SOURCE_WORKFLOW,
+            assembly_count_max: 0,
+            assembly_count_min: 0,
+            scope: "ORGANISM",
+          },
+        ],
+      };
+    });
+
+    const result = await buildWorkflows();
+    const wf = result[0].workflows[0];
+    expect(wf.assemblyCountMin).toBe(0);
+    expect(wf.assemblyCountMax).toBe(0);
+    expect(wf.scope).toBe(WORKFLOW_SCOPE.ORGANISM);
+  });
+
+  test("ORGANISM scope with no max defaults to null (unbounded)", async () => {
+    mockReadYamlFile.mockImplementation(async (path: string) => {
+      if (path.includes("workflow_categories")) {
+        return {
+          workflow_categories: [
+            {
+              category: "ASSEMBLY",
+              description: "d",
+              name: "n",
+              show_coming_soon: false,
+            },
+          ],
+        };
+      }
+      return {
+        workflows: [
+          {
+            ...BASE_SOURCE_WORKFLOW,
+            assembly_count_min: 2,
+            scope: "ORGANISM",
+          },
+        ],
+      };
+    });
+
+    const result = await buildWorkflows();
+    const wf = result[0].workflows[0];
+    expect(wf.assemblyCountMin).toBe(2);
+    expect(wf.assemblyCountMax).toBeNull();
+  });
+
+  test("ORGANISM scope missing assembly_count_min throws", async () => {
+    mockReadYamlFile.mockImplementation(async (path: string) => {
+      if (path.includes("workflow_categories")) {
+        return {
+          workflow_categories: [
+            {
+              category: "ASSEMBLY",
+              description: "d",
+              name: "n",
+              show_coming_soon: false,
+            },
+          ],
+        };
+      }
+      return {
+        workflows: [
+          {
+            ...BASE_SOURCE_WORKFLOW,
+            scope: "ORGANISM",
+          },
+        ],
+      };
+    });
+
+    await expect(buildWorkflows()).rejects.toThrow(
+      /assembly_count_min is required/
+    );
+  });
+
+  test("no scope defaults to ASSEMBLY with 1/1", async () => {
+    mockReadYamlFile.mockImplementation(async (path: string) => {
+      if (path.includes("workflow_categories")) {
+        return {
+          workflow_categories: [
+            {
+              category: "ASSEMBLY",
+              description: "d",
+              name: "n",
+              show_coming_soon: false,
+            },
+          ],
+        };
+      }
+      return {
+        workflows: [BASE_SOURCE_WORKFLOW],
+      };
+    });
+
+    const result = await buildWorkflows();
+    const wf = result[0].workflows[0];
+    expect(wf.assemblyCountMin).toBe(1);
+    expect(wf.assemblyCountMax).toBe(1);
+    expect(wf.scope).toBe(WORKFLOW_SCOPE.ASSEMBLY);
+  });
+});

--- a/tests/components/configureWorkflowInputs/buildSteps.scope.test.ts
+++ b/tests/components/configureWorkflowInputs/buildSteps.scope.test.ts
@@ -23,6 +23,8 @@ import { buildSteps } from "../../../app/components/Entity/components/ConfigureW
 
 describe("buildSteps - scope handling", () => {
   const BASE_WORKFLOW: Workflow = {
+    assemblyCountMax: 1,
+    assemblyCountMin: 1,
     iwcId: "iwc-test",
     parameters: [
       {

--- a/tests/components/configureWorkflowInputs/getConfiguredValues.scope.test.ts
+++ b/tests/components/configureWorkflowInputs/getConfiguredValues.scope.test.ts
@@ -34,6 +34,8 @@ jest.mock("../../../app/views/AnalyzeWorkflowsView/lexicmap/constants", () => ({
 
 describe("getConfiguredValues - scope-based logic", () => {
   const BASE_WORKFLOW: Workflow = {
+    assemblyCountMax: 1,
+    assemblyCountMin: 1,
     iwcId: "iwc-test",
     parameters: [],
     ploidy: WORKFLOW_PLOIDY.ANY,

--- a/tests/views/analyzeWorkflowsView/buildAssemblyWorkflows.scope.test.ts
+++ b/tests/views/analyzeWorkflowsView/buildAssemblyWorkflows.scope.test.ts
@@ -60,6 +60,8 @@ describe("buildAssemblyWorkflows - scope filtering", () => {
         showComingSoon: false,
         workflows: [
           {
+            assemblyCountMax: 1,
+            assemblyCountMin: 1,
             iwcId: "iwc-assembly",
             parameters: [],
             ploidy: WORKFLOW_PLOIDY.ANY,
@@ -89,6 +91,8 @@ describe("buildAssemblyWorkflows - scope filtering", () => {
         showComingSoon: false,
         workflows: [
           {
+            assemblyCountMax: 1,
+            assemblyCountMin: 1,
             iwcId: "iwc-no-scope",
             parameters: [],
             ploidy: WORKFLOW_PLOIDY.ANY,
@@ -118,6 +122,8 @@ describe("buildAssemblyWorkflows - scope filtering", () => {
         showComingSoon: false,
         workflows: [
           {
+            assemblyCountMax: 0,
+            assemblyCountMin: 0,
             iwcId: "iwc-organism",
             parameters: [],
             ploidy: WORKFLOW_PLOIDY.ANY,
@@ -146,6 +152,8 @@ describe("buildAssemblyWorkflows - scope filtering", () => {
         showComingSoon: false,
         workflows: [
           {
+            assemblyCountMax: 0,
+            assemblyCountMin: 0,
             iwcId: "iwc-sequence",
             parameters: [],
             ploidy: WORKFLOW_PLOIDY.ANY,
@@ -174,6 +182,8 @@ describe("buildAssemblyWorkflows - scope filtering", () => {
         showComingSoon: false,
         workflows: [
           {
+            assemblyCountMax: 1,
+            assemblyCountMin: 1,
             iwcId: "iwc-assembly",
             parameters: [],
             ploidy: WORKFLOW_PLOIDY.ANY,
@@ -184,6 +194,8 @@ describe("buildAssemblyWorkflows - scope filtering", () => {
             workflowName: "Assembly Workflow",
           },
           {
+            assemblyCountMax: 0,
+            assemblyCountMin: 0,
             iwcId: "iwc-organism",
             parameters: [],
             ploidy: WORKFLOW_PLOIDY.ANY,
@@ -194,6 +206,8 @@ describe("buildAssemblyWorkflows - scope filtering", () => {
             workflowName: "Organism Workflow",
           },
           {
+            assemblyCountMax: 0,
+            assemblyCountMin: 0,
             iwcId: "iwc-sequence",
             parameters: [],
             ploidy: WORKFLOW_PLOIDY.ANY,
@@ -230,6 +244,8 @@ describe("buildAssemblyWorkflows - scope filtering", () => {
         showComingSoon: false,
         workflows: [
           {
+            assemblyCountMax: 1,
+            assemblyCountMin: 1,
             iwcId: "iwc-rna-seq",
             parameters: [],
             ploidy: WORKFLOW_PLOIDY.ANY,
@@ -266,6 +282,8 @@ describe("buildAssemblyWorkflows - scope filtering", () => {
         showComingSoon: true,
         workflows: [
           {
+            assemblyCountMax: 0,
+            assemblyCountMin: 0,
             iwcId: "iwc-organism",
             parameters: [],
             ploidy: WORKFLOW_PLOIDY.ANY,

--- a/tests/views/organismView/buildOrganismWorkflows.test.ts
+++ b/tests/views/organismView/buildOrganismWorkflows.test.ts
@@ -26,6 +26,8 @@ describe("buildOrganismWorkflows", () => {
         showComingSoon: false,
         workflows: [
           {
+            assemblyCountMax: 0,
+            assemblyCountMin: 0,
             iwcId: "iwc-organism",
             parameters: [],
             ploidy: WORKFLOW_PLOIDY.ANY,
@@ -55,6 +57,8 @@ describe("buildOrganismWorkflows", () => {
         showComingSoon: false,
         workflows: [
           {
+            assemblyCountMax: 0,
+            assemblyCountMin: 0,
             iwcId: "iwc-universal",
             parameters: [],
             ploidy: WORKFLOW_PLOIDY.ANY,
@@ -83,6 +87,8 @@ describe("buildOrganismWorkflows", () => {
         showComingSoon: false,
         workflows: [
           {
+            assemblyCountMax: 1,
+            assemblyCountMin: 1,
             iwcId: "iwc-assembly",
             parameters: [],
             ploidy: WORKFLOW_PLOIDY.ANY,
@@ -110,6 +116,8 @@ describe("buildOrganismWorkflows", () => {
         showComingSoon: false,
         workflows: [
           {
+            assemblyCountMax: 0,
+            assemblyCountMin: 0,
             iwcId: "iwc-sequence",
             parameters: [],
             ploidy: WORKFLOW_PLOIDY.ANY,
@@ -137,6 +145,8 @@ describe("buildOrganismWorkflows", () => {
         showComingSoon: false,
         workflows: [
           {
+            assemblyCountMax: 0,
+            assemblyCountMin: 0,
             iwcId: "iwc-other",
             parameters: [],
             ploidy: WORKFLOW_PLOIDY.ANY,
@@ -164,6 +174,8 @@ describe("buildOrganismWorkflows", () => {
         showComingSoon: false,
         workflows: [
           {
+            assemblyCountMax: 0,
+            assemblyCountMin: 0,
             iwcId: "iwc-leaf",
             parameters: [],
             ploidy: WORKFLOW_PLOIDY.ANY,
@@ -192,6 +204,8 @@ describe("buildOrganismWorkflows", () => {
         showComingSoon: false,
         workflows: [
           {
+            assemblyCountMax: 0,
+            assemblyCountMin: 0,
             iwcId: "iwc-organism",
             parameters: [],
             ploidy: WORKFLOW_PLOIDY.ANY,
@@ -202,6 +216,8 @@ describe("buildOrganismWorkflows", () => {
             workflowName: "Organism Workflow",
           },
           {
+            assemblyCountMax: 1,
+            assemblyCountMin: 1,
             iwcId: "iwc-assembly",
             parameters: [],
             ploidy: WORKFLOW_PLOIDY.ANY,
@@ -238,6 +254,8 @@ describe("buildOrganismWorkflows", () => {
         showComingSoon: false,
         workflows: [
           {
+            assemblyCountMax: 0,
+            assemblyCountMin: 0,
             iwcId: "iwc-organism",
             parameters: [],
             ploidy: WORKFLOW_PLOIDY.ANY,

--- a/tests/views/workflowsView/getWorkflows.scope.test.ts
+++ b/tests/views/workflowsView/getWorkflows.scope.test.ts
@@ -13,6 +13,8 @@ jest.mock(
   "../../../app/views/AnalyzeWorkflowsView/differentialExpressionAnalysis/constants",
   () => ({
     DIFFERENTIAL_EXPRESSION_ANALYSIS: {
+      assemblyCountMax: 1,
+      assemblyCountMin: 1,
       iwcId: "iwc-deseq2",
       parameters: [],
       ploidy: "ANY",
@@ -55,6 +57,8 @@ describe("getWorkflows - scope handling", () => {
         showComingSoon: false,
         workflows: [
           {
+            assemblyCountMax: 1,
+            assemblyCountMin: 1,
             iwcId: "iwc-assembly",
             parameters: [],
             ploidy: WORKFLOW_PLOIDY.ANY,
@@ -84,6 +88,8 @@ describe("getWorkflows - scope handling", () => {
         showComingSoon: false,
         workflows: [
           {
+            assemblyCountMax: 1,
+            assemblyCountMin: 1,
             iwcId: "iwc-assembly",
             parameters: [],
             ploidy: WORKFLOW_PLOIDY.ANY,
@@ -112,6 +118,8 @@ describe("getWorkflows - scope handling", () => {
         showComingSoon: false,
         workflows: [
           {
+            assemblyCountMax: 0,
+            assemblyCountMin: 0,
             iwcId: "iwc-organism",
             parameters: [],
             ploidy: WORKFLOW_PLOIDY.ANY,
@@ -139,6 +147,8 @@ describe("getWorkflows - scope handling", () => {
         showComingSoon: false,
         workflows: [
           {
+            assemblyCountMax: 0,
+            assemblyCountMin: 0,
             iwcId: "iwc-sequence",
             parameters: [],
             ploidy: WORKFLOW_PLOIDY.ANY,
@@ -166,6 +176,8 @@ describe("getWorkflows - scope handling", () => {
         showComingSoon: false,
         workflows: [
           {
+            assemblyCountMax: 1,
+            assemblyCountMin: 1,
             iwcId: "iwc-no-scope",
             parameters: [],
             ploidy: WORKFLOW_PLOIDY.ANY,
@@ -193,6 +205,8 @@ describe("getWorkflows - scope handling", () => {
         showComingSoon: false,
         workflows: [
           {
+            assemblyCountMax: 1,
+            assemblyCountMin: 1,
             iwcId: "iwc-assembly",
             parameters: [],
             ploidy: WORKFLOW_PLOIDY.ANY,
@@ -203,6 +217,8 @@ describe("getWorkflows - scope handling", () => {
             workflowName: "Assembly Workflow",
           },
           {
+            assemblyCountMax: 0,
+            assemblyCountMin: 0,
             iwcId: "iwc-organism",
             parameters: [],
             ploidy: WORKFLOW_PLOIDY.ANY,
@@ -213,6 +229,8 @@ describe("getWorkflows - scope handling", () => {
             workflowName: "Organism Workflow",
           },
           {
+            assemblyCountMax: 0,
+            assemblyCountMin: 0,
             iwcId: "iwc-sequence",
             parameters: [],
             ploidy: WORKFLOW_PLOIDY.ANY,
@@ -255,6 +273,8 @@ describe("getWorkflows - scope handling", () => {
         showComingSoon: false,
         workflows: [
           {
+            assemblyCountMax: 1,
+            assemblyCountMin: 1,
             iwcId: "iwc-no-assemblies",
             parameters: [],
             ploidy: WORKFLOW_PLOIDY.ANY,
@@ -292,7 +312,7 @@ describe("getWorkflows - scope handling", () => {
   test("includes LMLS workflows when feature flag is enabled", () => {
     const categories: WorkflowCategory[] = [];
 
-    const result = getWorkflows(categories, MAPPINGS, ORGANISMS, true);
+    const result = getWorkflows(categories, MAPPINGS, ORGANISMS, false, true);
 
     // Should include DEA + Logan Search + Lexicmap
     expect(result).toHaveLength(3);
@@ -306,7 +326,7 @@ describe("getWorkflows - scope handling", () => {
   test("LMLS workflows have SEQUENCE scope when feature flag is enabled", () => {
     const categories: WorkflowCategory[] = [];
 
-    const result = getWorkflows(categories, MAPPINGS, ORGANISMS, true);
+    const result = getWorkflows(categories, MAPPINGS, ORGANISMS, false, true);
 
     const loganSearch = result.find((w) => w.trsId === "logan-search");
     const lexicmap = result.find((w) => w.trsId === "lexicmap");
@@ -318,7 +338,7 @@ describe("getWorkflows - scope handling", () => {
   test("LMLS workflows have correct category when feature flag is enabled", () => {
     const categories: WorkflowCategory[] = [];
 
-    const result = getWorkflows(categories, MAPPINGS, ORGANISMS, true);
+    const result = getWorkflows(categories, MAPPINGS, ORGANISMS, false, true);
 
     const loganSearch = result.find((w) => w.trsId === "logan-search");
     const lexicmap = result.find((w) => w.trsId === "lexicmap");


### PR DESCRIPTION
## Description

Adds `assembly_count_min` and `assembly_count_max` constraints to the workflow model and uses them to filter organism-scoped workflows by available assembly count.

## Related Issue
 
closes https://github.com/galaxyproject/brc-analytics/issues/1306
