### PR TITLE
feat: ground the assistant's suggestion chips in the catalog

### DIFF
--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -216,8 +216,9 @@ prefixed with "SUGGESTIONS:". Each item is either:
 
 Only tag a chip with an entity a tool actually returned -- never offer a \
 specific organism, assembly, or workflow you haven't verified. Tagged chips \
-that don't match the catalog are dropped before the user sees them, so an \
-invented entity simply won't appear. Generic action chips don't need a tag.
+whose entity isn't in the catalog are dropped before the user sees them, and \
+the label must name the same entity you tagged. Generic action chips don't \
+need a tag.
 
 Example:
 SUGGESTIONS: ["Tell me about variant calling", {"label": "Use the \
@@ -658,6 +659,8 @@ class AssistantAgent:
                 if not self._chip_entities_in_catalog(item):
                     logger.info("Dropping ungrounded suggestion chip: %s", label)
                     continue
+                # The tag is validated above; the label itself is free text the
+                # prompt is responsible for keeping consistent with the tag.
                 chips.append(SuggestionChip(label=label, message=label))
             # Anything else (numbers, nested lists) is ignored.
         return chips
@@ -666,23 +669,39 @@ class AssistantAgent:
         """Return True when every catalog entity a chip references actually exists.
 
         A chip may tag itself with an organism (scientific name), assembly
-        (accession), or workflow (IWC id). Untagged chips are trivially valid.
-        Any lookup error is treated as "not present" so we fail closed and
-        don't surface an unverified option.
+        (accession), or workflow (IWC id). Keys are matched case-insensitively
+        and empty/whitespace tags are treated as absent. Organisms are matched
+        EXACTLY (not via the fuzzy search_organisms), so a genus or partial name
+        can't sneak through; assemblies and workflows are looked up by their
+        canonical id (accession / IWC id) per the chip contract -- a chip that
+        tags a display name instead will be dropped.
+
+        This is defense-in-depth, not a hard guarantee: it validates the tag,
+        but the visible label is free text and only constrained by the prompt.
+        Any lookup error fails closed (drop the chip).
         """
+        # Normalize keys to lowercase and strip values so "Organism", padded
+        # whitespace, etc. don't bypass validation.
+        tags = {
+            k.lower(): v.strip()
+            for k, v in chip.items()
+            if isinstance(k, str) and isinstance(v, str)
+        }
         try:
-            organism = chip.get("organism")
-            if organism and not self.catalog.search_organisms(str(organism)):
+            organism = tags.get("organism")
+            if organism and self.catalog.find_organism_exact(organism) is None:
                 return False
-            assembly = chip.get("assembly")
-            if assembly and self.catalog.get_assembly_details(str(assembly)) is None:
+            assembly = tags.get("assembly")
+            if assembly and self.catalog.get_assembly_details(assembly) is None:
                 return False
-            workflow = chip.get("workflow")
-            if workflow and self.catalog.get_workflow_details(str(workflow)) is None:
+            workflow = tags.get("workflow")
+            if workflow and self.catalog.get_workflow_details(workflow) is None:
                 return False
             return True
         except Exception:
-            logger.warning("Catalog lookup failed validating a suggestion chip")
+            logger.warning(
+                "Catalog lookup failed validating a suggestion chip", exc_info=True
+            )
             return False
 
     def _apply_schema_updates(

--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -6,7 +6,7 @@ import json
 import logging
 import re
 import time
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic_ai import Agent, RunContext, Tool
 from pydantic_ai.messages import ModelMessage, ModelMessagesTypeAdapter
@@ -135,6 +135,15 @@ especially if it has a gene annotation (GTF) available.
 - When all required fields are filled, tell the user their configuration is \
   complete and they can continue to the workflow setup.
 - Don't hallucinate data — if a tool returns no results, say so.
+- **Only offer real catalog data.** Never present a specific organism, \
+  assembly, or workflow -- in your prose OR as a suggestion chip -- unless a \
+  tool call in this conversation actually returned it. To narrow things down \
+  (e.g. "which species?"), call the relevant tool (search_organisms, \
+  get_workflows_in_category, etc.) first and offer only what it returns, or \
+  ask an open question. Do NOT list example organisms, assemblies, or \
+  workflows from your own knowledge. For instance, if the user mentions \
+  Candida, do not rattle off "C. albicans, C. auris, C. glabrata" from \
+  memory -- search the catalog and offer only the species we actually have.
 - If the user asks about something outside bioinformatics/BRC Analytics, \
   politely redirect.
 - Each message includes the current analysis state in brackets. Use this to \
@@ -197,9 +206,22 @@ NOT emit it.
 
 After each response, suggest 2-4 short phrases the user might want to say next. \
 Format them as a JSON array at the very end of your response, on its own line, \
-prefixed with "SUGGESTIONS:". For example:
-SUGGESTIONS: ["Search ENA for public data", "Use the reference assembly", \
-"Tell me about variant calling"]
+prefixed with "SUGGESTIONS:". Each item is either:
+- a plain string for a generic action, e.g. "Tell me about variant calling"; or
+- an object that proposes a SPECIFIC catalog entity you have already confirmed \
+  via a tool this conversation, tagging it so it can be double-checked: \
+  {"label": "Use the P. falciparum reference", "assembly": "GCF_000002765.6"}. \
+  Valid entity keys: "organism" (scientific name), "assembly" (accession), \
+  "workflow" (IWC id).
+
+Only tag a chip with an entity a tool actually returned -- never offer a \
+specific organism, assembly, or workflow you haven't verified. Tagged chips \
+that don't match the catalog are dropped before the user sees them, so an \
+invented entity simply won't appear. Generic action chips don't need a tag.
+
+Example:
+SUGGESTIONS: ["Tell me about variant calling", {"label": "Use the \
+P. falciparum reference", "assembly": "GCF_000002765.6"}]
 
 If no suggestions are appropriate, omit the SUGGESTIONS line entirely.
 """
@@ -589,12 +611,8 @@ class AssistantAgent:
                 try:
                     json_str = line[s_match.end() :].strip()
                     items = json.loads(json_str)
-                    if isinstance(items, list) and all(
-                        isinstance(s, str) for s in items
-                    ):
-                        suggestions = [
-                            SuggestionChip(label=s, message=s) for s in items
-                        ]
+                    if isinstance(items, list):
+                        suggestions = self._build_suggestion_chips(items)
                     else:
                         reply_lines.append(line)
                 except (json.JSONDecodeError, TypeError):
@@ -616,6 +634,56 @@ class AssistantAgent:
                 reply_lines.append(line)
 
         return "\n".join(reply_lines).rstrip(), suggestions, schema_updates
+
+    def _build_suggestion_chips(self, items: List[Any]) -> List[SuggestionChip]:
+        """Build suggestion chips, dropping any that reference data we don't have.
+
+        Each item is either a plain string (a generic action chip) or an object
+        like {"label": ..., "organism"/"assembly"/"workflow": ...} that proposes
+        a specific catalog entity. Entity-tagged chips are validated against the
+        catalog and dropped when the referenced organism/assembly/workflow isn't
+        present, so the assistant never offers a selection we can't fulfill
+        (#1297). Plain action chips pass through untouched.
+        """
+        chips: List[SuggestionChip] = []
+        for item in items:
+            if isinstance(item, str):
+                label = item.strip()
+                if label:
+                    chips.append(SuggestionChip(label=label, message=label))
+            elif isinstance(item, dict):
+                label = str(item.get("label", "")).strip()
+                if not label:
+                    continue
+                if not self._chip_entities_in_catalog(item):
+                    logger.info("Dropping ungrounded suggestion chip: %s", label)
+                    continue
+                chips.append(SuggestionChip(label=label, message=label))
+            # Anything else (numbers, nested lists) is ignored.
+        return chips
+
+    def _chip_entities_in_catalog(self, chip: Dict[str, Any]) -> bool:
+        """Return True when every catalog entity a chip references actually exists.
+
+        A chip may tag itself with an organism (scientific name), assembly
+        (accession), or workflow (IWC id). Untagged chips are trivially valid.
+        Any lookup error is treated as "not present" so we fail closed and
+        don't surface an unverified option.
+        """
+        try:
+            organism = chip.get("organism")
+            if organism and not self.catalog.search_organisms(str(organism)):
+                return False
+            assembly = chip.get("assembly")
+            if assembly and self.catalog.get_assembly_details(str(assembly)) is None:
+                return False
+            workflow = chip.get("workflow")
+            if workflow and self.catalog.get_workflow_details(str(workflow)) is None:
+                return False
+            return True
+        except Exception:
+            logger.warning("Catalog lookup failed validating a suggestion chip")
+            return False
 
     def _apply_schema_updates(
         self,

--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -211,8 +211,10 @@ prefixed with "SUGGESTIONS:". Each item is either:
 - an object that proposes a SPECIFIC catalog entity you have already confirmed \
   via a tool this conversation, tagging it so it can be double-checked: \
   {"label": "Use the P. falciparum reference", "assembly": "GCF_000002765.6"}. \
-  Valid entity keys: "organism" (scientific name), "assembly" (accession), \
-  "workflow" (IWC id).
+  Valid entity keys: "organism" (NCBI taxonomy id), "assembly" (accession), \
+  "workflow" (IWC id). Tag organisms by the numeric taxonomy id a tool \
+  returned (the taxonomy_id field), not the species name -- it's the stable, \
+  unambiguous key.
 
 Only tag a chip with an entity a tool actually returned -- never offer a \
 specific organism, assembly, or workflow you haven't verified. Tagged chips \
@@ -221,7 +223,8 @@ the label must name the same entity you tagged. Generic action chips don't \
 need a tag.
 
 Example:
-SUGGESTIONS: ["Tell me about variant calling", {"label": "Use the \
+SUGGESTIONS: ["Tell me about variant calling", {"label": "Explore \
+Plasmodium falciparum", "organism": "5833"}, {"label": "Use the \
 P. falciparum reference", "assembly": "GCF_000002765.6"}]
 
 If no suggestions are appropriate, omit the SUGGESTIONS line entirely.
@@ -671,15 +674,17 @@ class AssistantAgent:
     def _chip_entities_in_catalog(self, chip: Dict[str, Any]) -> bool:
         """Return True when every catalog entity a chip references actually exists.
 
-        A chip may tag itself with an organism (scientific name or taxonomy id),
-        assembly (accession), or workflow (IWC id). Keys are matched
-        case-insensitively; a recognized entity value is coerced to a string and
-        looked up, so a non-string value (e.g. a numeric taxid) is still
-        validated rather than silently passed through. An empty/whitespace tag is
-        treated as absent. Organisms are matched EXACTLY (not via the fuzzy
-        search_organisms), so a genus or partial name can't sneak through;
-        assemblies and workflows are looked up by their canonical id per the chip
-        contract -- a chip that tags a display name instead will be dropped.
+        A chip may tag itself with an organism (NCBI taxonomy id), assembly
+        (accession), or workflow (IWC id) -- each entity's stable, canonical key.
+        Keys are matched case-insensitively; a recognized entity value is coerced
+        to a string and looked up, so a non-string value (e.g. a numeric taxid)
+        is still validated rather than silently passed through. An empty/
+        whitespace tag is treated as absent. Organisms resolve on the taxonomy id
+        (an exact species/common name is still accepted as a fail-soft fallback);
+        either way the match is EXACT -- not the fuzzy search_organisms -- so a
+        genus or partial name can't sneak through. Assemblies and workflows are
+        looked up by their canonical id per the chip contract -- a chip that tags
+        a display name instead will be dropped.
 
         This is defense-in-depth, not a hard guarantee: it validates the tag, but
         the visible label is free text and only constrained by the prompt. Any

--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -668,35 +668,38 @@ class AssistantAgent:
     def _chip_entities_in_catalog(self, chip: Dict[str, Any]) -> bool:
         """Return True when every catalog entity a chip references actually exists.
 
-        A chip may tag itself with an organism (scientific name), assembly
-        (accession), or workflow (IWC id). Keys are matched case-insensitively
-        and empty/whitespace tags are treated as absent. Organisms are matched
-        EXACTLY (not via the fuzzy search_organisms), so a genus or partial name
-        can't sneak through; assemblies and workflows are looked up by their
-        canonical id (accession / IWC id) per the chip contract -- a chip that
-        tags a display name instead will be dropped.
+        A chip may tag itself with an organism (scientific name or taxonomy id),
+        assembly (accession), or workflow (IWC id). Keys are matched
+        case-insensitively; a recognized entity value is coerced to a string and
+        looked up, so a non-string value (e.g. a numeric taxid) is still
+        validated rather than silently passed through. An empty/whitespace tag is
+        treated as absent. Organisms are matched EXACTLY (not via the fuzzy
+        search_organisms), so a genus or partial name can't sneak through;
+        assemblies and workflows are looked up by their canonical id per the chip
+        contract -- a chip that tags a display name instead will be dropped.
 
-        This is defense-in-depth, not a hard guarantee: it validates the tag,
-        but the visible label is free text and only constrained by the prompt.
-        Any lookup error fails closed (drop the chip).
+        This is defense-in-depth, not a hard guarantee: it validates the tag, but
+        the visible label is free text and only constrained by the prompt. Any
+        lookup error fails closed (drop the chip).
         """
-        # Normalize keys to lowercase and strip values so "Organism", padded
-        # whitespace, etc. don't bypass validation.
-        tags = {
-            k.lower(): v.strip()
-            for k, v in chip.items()
-            if isinstance(k, str) and isinstance(v, str)
-        }
+        # Lowercase keys so "Organism" etc. don't bypass validation.
+        tags = {k.lower(): v for k, v in chip.items() if isinstance(k, str)}
+        lookups = (
+            ("organism", self.catalog.find_organism_exact),
+            ("assembly", self.catalog.get_assembly_details),
+            ("workflow", self.catalog.get_workflow_details),
+        )
         try:
-            organism = tags.get("organism")
-            if organism and self.catalog.find_organism_exact(organism) is None:
-                return False
-            assembly = tags.get("assembly")
-            if assembly and self.catalog.get_assembly_details(assembly) is None:
-                return False
-            workflow = tags.get("workflow")
-            if workflow and self.catalog.get_workflow_details(workflow) is None:
-                return False
+            for key, lookup in lookups:
+                if key not in tags:
+                    continue
+                # Coerce to string so a numeric/None/list value is validated
+                # (and fails closed) rather than skipped.
+                value = str(tags[key]).strip()
+                if not value:
+                    continue  # empty/whitespace tag -> treat as untagged
+                if lookup(value) is None:
+                    return False
             return True
         except Exception:
             logger.warning(

--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -653,9 +653,12 @@ class AssistantAgent:
                 if label:
                     chips.append(SuggestionChip(label=label, message=label))
             elif isinstance(item, dict):
-                label = str(item.get("label", "")).strip()
-                if not label:
+                # Only accept a real string label -- a null/missing label must
+                # be dropped, not coerced into the literal "None".
+                label = item.get("label")
+                if not isinstance(label, str) or not label.strip():
                     continue
+                label = label.strip()
                 if not self._chip_entities_in_catalog(item):
                     logger.info("Dropping ungrounded suggestion chip: %s", label)
                     continue
@@ -682,8 +685,8 @@ class AssistantAgent:
         the visible label is free text and only constrained by the prompt. Any
         lookup error fails closed (drop the chip).
         """
-        # Lowercase keys so "Organism" etc. don't bypass validation.
-        tags = {k.lower(): v for k, v in chip.items() if isinstance(k, str)}
+        # Strip + lowercase keys so "Organism" or "organism " don't bypass.
+        tags = {k.strip().lower(): v for k, v in chip.items() if isinstance(k, str)}
         lookups = (
             ("organism", self.catalog.find_organism_exact),
             ("assembly", self.catalog.get_assembly_details),

--- a/backend/api/app/services/tools/catalog_data.py
+++ b/backend/api/app/services/tools/catalog_data.py
@@ -82,9 +82,12 @@ class CatalogData:
                 return self._summarize_organism(org)
         return None
 
-    def find_organism_exact(self, name: str) -> Optional[Dict[str, Any]]:
+    def find_organism_exact(self, name: Any) -> Optional[Dict[str, Any]]:
         """Find an organism by an exact (case-insensitive) species name, common
         name, or NCBI taxonomy id.
+
+        Accepts any input (e.g. a numeric taxid or None); the value is coerced
+        to a string before matching.
 
         Unlike search_organisms, this does NOT match on genus or substrings, so
         a genus ("Candida") or a partial string ("almonella") will not resolve.

--- a/backend/api/app/services/tools/catalog_data.py
+++ b/backend/api/app/services/tools/catalog_data.py
@@ -91,9 +91,11 @@ class CatalogData:
         Used to validate that a *specific* organism actually exists before the
         assistant offers it (#1297).
         """
-        if not name or not name.strip():
+        if name is None:
             return None
-        q = name.strip().lower()
+        q = str(name).strip().lower()
+        if not q:
+            return None
         for org in self.organisms:
             candidates = {
                 (org.get("taxonomicLevelSpecies") or "").lower(),

--- a/backend/api/app/services/tools/catalog_data.py
+++ b/backend/api/app/services/tools/catalog_data.py
@@ -82,6 +82,29 @@ class CatalogData:
                 return self._summarize_organism(org)
         return None
 
+    def find_organism_exact(self, name: str) -> Optional[Dict[str, Any]]:
+        """Find an organism by an exact (case-insensitive) species name, common
+        name, or NCBI taxonomy id.
+
+        Unlike search_organisms, this does NOT match on genus or substrings, so
+        a genus ("Candida") or a partial string ("almonella") will not resolve.
+        Used to validate that a *specific* organism actually exists before the
+        assistant offers it (#1297).
+        """
+        if not name or not name.strip():
+            return None
+        q = name.strip().lower()
+        for org in self.organisms:
+            candidates = {
+                (org.get("taxonomicLevelSpecies") or "").lower(),
+                (org.get("commonName") or "").lower(),
+                str(org.get("ncbiTaxonomyId") or "").lower(),
+            }
+            candidates.discard("")
+            if q in candidates:
+                return self._summarize_organism(org)
+        return None
+
     def _summarize_organism(self, org: Dict[str, Any]) -> Dict[str, Any]:
         """Return a compact summary suitable for LLM context."""
         genomes = org.get("genomes", [])

--- a/backend/api/app/services/tools/catalog_data.py
+++ b/backend/api/app/services/tools/catalog_data.py
@@ -83,16 +83,16 @@ class CatalogData:
         return None
 
     def find_organism_exact(self, name: Any) -> Optional[Dict[str, Any]]:
-        """Find an organism by an exact (case-insensitive) species name, common
-        name, or NCBI taxonomy id.
+        """Find an organism by its NCBI taxonomy id -- the stable, canonical key
+        suggestion chips tag organisms with (#1297). An exact (case-insensitive)
+        species or common name is also accepted as a fail-soft fallback so a chip
+        the model mis-tags by name isn't needlessly dropped.
 
         Accepts any input (e.g. a numeric taxid or None); the value is coerced
         to a string before matching.
 
         Unlike search_organisms, this does NOT match on genus or substrings, so
         a genus ("Candida") or a partial string ("almonella") will not resolve.
-        Used to validate that a *specific* organism actually exists before the
-        assistant offers it (#1297).
         """
         if name is None:
             return None

--- a/backend/api/tests/test_assistant_agent.py
+++ b/backend/api/tests/test_assistant_agent.py
@@ -212,6 +212,25 @@ class TestParseStructuredOutput:
         _, suggestions, _ = agent._parse_structured_output(raw)
         assert suggestions == []
 
+    def test_tagged_non_string_entity_is_validated_not_bypassed(self, agent):
+        # A non-string entity value (e.g. a numeric taxid) must still be
+        # validated, not silently passed through (codex re-review regression).
+        agent.catalog.find_organism_exact.return_value = None
+        raw = 'SUGGESTIONS: [{"label": "Use C. glabrata", "organism": 5476}]'
+        _, suggestions, _ = agent._parse_structured_output(raw)
+        assert suggestions == []
+        agent.catalog.find_organism_exact.assert_called_once_with("5476")
+
+    def test_tagged_numeric_taxid_validated_and_kept(self, agent):
+        # A valid numeric taxid is coerced to a string, validated, and kept.
+        agent.catalog.find_organism_exact.return_value = {
+            "species": "Plasmodium falciparum"
+        }
+        raw = 'SUGGESTIONS: [{"label": "Use P. falciparum", "organism": 5833}]'
+        _, suggestions, _ = agent._parse_structured_output(raw)
+        assert len(suggestions) == 1
+        assert suggestions[0].label == "Use P. falciparum"
+
 
 # ---------- _apply_schema_updates ----------
 

--- a/backend/api/tests/test_assistant_agent.py
+++ b/backend/api/tests/test_assistant_agent.py
@@ -231,6 +231,23 @@ class TestParseStructuredOutput:
         assert len(suggestions) == 1
         assert suggestions[0].label == "Use P. falciparum"
 
+    def test_tagged_chip_with_non_string_label_dropped(self, agent):
+        # A null label must be dropped, not coerced into the literal "None".
+        agent.catalog.find_organism_exact.return_value = {"species": "Yeast"}
+        raw = 'SUGGESTIONS: [{"label": null, "organism": "Saccharomyces cerevisiae"}]'
+        _, suggestions, _ = agent._parse_structured_output(raw)
+        assert suggestions == []
+
+    def test_tagged_entity_key_with_trailing_space_is_validated(self, agent):
+        # A key like "organism " (trailing space) must not bypass validation.
+        agent.catalog.find_organism_exact.return_value = None
+        raw = (
+            'SUGGESTIONS: [{"label": "Use C. glabrata", '
+            '"organism ": "Candida glabrata"}]'
+        )
+        _, suggestions, _ = agent._parse_structured_output(raw)
+        assert suggestions == []
+
 
 # ---------- _apply_schema_updates ----------
 

--- a/backend/api/tests/test_assistant_agent.py
+++ b/backend/api/tests/test_assistant_agent.py
@@ -127,7 +127,7 @@ class TestParseStructuredOutput:
     # ---- catalog-grounded suggestion chips (#1297) ----
 
     def test_tagged_chip_in_catalog_kept(self, agent):
-        agent.catalog.search_organisms.return_value = [{"taxonomyId": "5476"}]
+        agent.catalog.find_organism_exact.return_value = {"species": "Candida albicans"}
         raw = (
             'SUGGESTIONS: [{"label": "Use Candida albicans", '
             '"organism": "Candida albicans"}]'
@@ -138,7 +138,7 @@ class TestParseStructuredOutput:
         assert suggestions[0].message == "Use Candida albicans"
 
     def test_tagged_organism_not_in_catalog_dropped(self, agent):
-        agent.catalog.search_organisms.return_value = []
+        agent.catalog.find_organism_exact.return_value = None
         raw = (
             'SUGGESTIONS: [{"label": "Use C. glabrata", '
             '"organism": "Candida glabrata"}]'
@@ -149,7 +149,7 @@ class TestParseStructuredOutput:
         assert "glabrata" not in text
 
     def test_mixed_string_and_tagged_chips(self, agent):
-        agent.catalog.search_organisms.return_value = []
+        agent.catalog.find_organism_exact.return_value = None
         raw = (
             'SUGGESTIONS: ["Tell me about variant calling", '
             '{"label": "Use C. glabrata", "organism": "Candida glabrata"}]'
@@ -177,8 +177,38 @@ class TestParseStructuredOutput:
         assert suggestions == []
 
     def test_tagged_chip_without_label_dropped(self, agent):
-        agent.catalog.search_organisms.return_value = [{"taxonomyId": "5476"}]
+        agent.catalog.find_organism_exact.return_value = {"species": "Candida albicans"}
         raw = 'SUGGESTIONS: [{"organism": "Candida albicans"}]'
+        _, suggestions, _ = agent._parse_structured_output(raw)
+        assert suggestions == []
+
+    def test_tagged_organism_mixed_case_key_is_validated(self, agent):
+        # A capital "Organism" key must NOT bypass validation.
+        agent.catalog.find_organism_exact.return_value = None
+        raw = (
+            'SUGGESTIONS: [{"label": "Use C. glabrata", '
+            '"Organism": "Candida glabrata"}]'
+        )
+        _, suggestions, _ = agent._parse_structured_output(raw)
+        assert suggestions == []
+
+    def test_tagged_empty_entity_treated_as_untagged(self, agent):
+        # An empty/whitespace tag is treated as absent -- the chip passes as a
+        # generic action chip (the catalog is never consulted).
+        raw = 'SUGGESTIONS: [{"label": "Sounds good", "organism": "   "}]'
+        _, suggestions, _ = agent._parse_structured_output(raw)
+        assert len(suggestions) == 1
+        assert suggestions[0].label == "Sounds good"
+        agent.catalog.find_organism_exact.assert_not_called()
+
+    def test_tagged_chip_dropped_if_any_entity_invalid(self, agent):
+        # Organism resolves but the assembly doesn't -- the whole chip is dropped.
+        agent.catalog.find_organism_exact.return_value = {"species": "Yeast"}
+        agent.catalog.get_assembly_details.return_value = None
+        raw = (
+            'SUGGESTIONS: [{"label": "Use this combo", '
+            '"organism": "Saccharomyces cerevisiae", "assembly": "GCA_bogus.1"}]'
+        )
         _, suggestions, _ = agent._parse_structured_output(raw)
         assert suggestions == []
 

--- a/backend/api/tests/test_assistant_agent.py
+++ b/backend/api/tests/test_assistant_agent.py
@@ -124,6 +124,64 @@ class TestParseStructuredOutput:
         _, _, updates = agent._parse_structured_output(raw)
         assert updates == {"organism": "E. coli"}
 
+    # ---- catalog-grounded suggestion chips (#1297) ----
+
+    def test_tagged_chip_in_catalog_kept(self, agent):
+        agent.catalog.search_organisms.return_value = [{"taxonomyId": "5476"}]
+        raw = (
+            'SUGGESTIONS: [{"label": "Use Candida albicans", '
+            '"organism": "Candida albicans"}]'
+        )
+        _, suggestions, _ = agent._parse_structured_output(raw)
+        assert len(suggestions) == 1
+        assert suggestions[0].label == "Use Candida albicans"
+        assert suggestions[0].message == "Use Candida albicans"
+
+    def test_tagged_organism_not_in_catalog_dropped(self, agent):
+        agent.catalog.search_organisms.return_value = []
+        raw = (
+            'SUGGESTIONS: [{"label": "Use C. glabrata", '
+            '"organism": "Candida glabrata"}]'
+        )
+        text, suggestions, _ = agent._parse_structured_output(raw)
+        assert suggestions == []
+        # The dropped chip must not leak into the visible reply text.
+        assert "glabrata" not in text
+
+    def test_mixed_string_and_tagged_chips(self, agent):
+        agent.catalog.search_organisms.return_value = []
+        raw = (
+            'SUGGESTIONS: ["Tell me about variant calling", '
+            '{"label": "Use C. glabrata", "organism": "Candida glabrata"}]'
+        )
+        _, suggestions, _ = agent._parse_structured_output(raw)
+        assert len(suggestions) == 1
+        assert suggestions[0].label == "Tell me about variant calling"
+
+    def test_tagged_assembly_not_in_catalog_dropped(self, agent):
+        agent.catalog.get_assembly_details.return_value = None
+        raw = (
+            'SUGGESTIONS: [{"label": "Use GCF_999999999.9", '
+            '"assembly": "GCF_999999999.9"}]'
+        )
+        _, suggestions, _ = agent._parse_structured_output(raw)
+        assert suggestions == []
+
+    def test_tagged_workflow_not_in_catalog_dropped(self, agent):
+        agent.catalog.get_workflow_details.return_value = None
+        raw = (
+            'SUGGESTIONS: [{"label": "Run mystery workflow", '
+            '"workflow": "not-a-real-iwc-id"}]'
+        )
+        _, suggestions, _ = agent._parse_structured_output(raw)
+        assert suggestions == []
+
+    def test_tagged_chip_without_label_dropped(self, agent):
+        agent.catalog.search_organisms.return_value = [{"taxonomyId": "5476"}]
+        raw = 'SUGGESTIONS: [{"organism": "Candida albicans"}]'
+        _, suggestions, _ = agent._parse_structured_output(raw)
+        assert suggestions == []
+
 
 # ---------- _apply_schema_updates ----------
 

--- a/backend/api/tests/test_catalog_data.py
+++ b/backend/api/tests/test_catalog_data.py
@@ -173,6 +173,42 @@ class TestSearchOrganisms:
         assert "HAPLOID" in org["ploidies"]
 
 
+# ---------- find_organism_exact (catalog grounding, #1297) ----------
+
+
+class TestFindOrganismExact:
+    def test_exact_species_match(self, catalog):
+        org = catalog.find_organism_exact("Plasmodium falciparum")
+        assert org is not None
+        assert org["species"] == "Plasmodium falciparum"
+
+    def test_case_insensitive(self, catalog):
+        assert catalog.find_organism_exact("plasmodium falciparum") is not None
+
+    def test_common_name_match(self, catalog):
+        assert catalog.find_organism_exact("malaria parasite") is not None
+
+    def test_taxonomy_id_match(self, catalog):
+        assert catalog.find_organism_exact("5833") is not None
+
+    def test_genus_alone_does_not_match(self, catalog):
+        # search_organisms matches genus; find_organism_exact must NOT -- this is
+        # the false-positive that let ungrounded species through (#1297).
+        assert catalog.search_organisms("Plasmodium")  # fuzzy still matches
+        assert catalog.find_organism_exact("Plasmodium") is None
+
+    def test_partial_string_does_not_match(self, catalog):
+        assert catalog.find_organism_exact("Plasmod") is None
+        assert catalog.find_organism_exact("falciparum") is None
+
+    def test_absent_organism_returns_none(self, catalog):
+        assert catalog.find_organism_exact("Candida glabrata") is None
+
+    def test_blank_returns_none(self, catalog):
+        assert catalog.find_organism_exact("") is None
+        assert catalog.find_organism_exact("   ") is None
+
+
 # ---------- Assembly queries ----------
 
 

--- a/backend/api/tests/test_catalog_data.py
+++ b/backend/api/tests/test_catalog_data.py
@@ -191,6 +191,11 @@ class TestFindOrganismExact:
     def test_taxonomy_id_match(self, catalog):
         assert catalog.find_organism_exact("5833") is not None
 
+    def test_non_string_taxid_input(self, catalog):
+        # Robust to a non-string caller (e.g. a numeric taxid from a chip tag).
+        assert catalog.find_organism_exact(5833) is not None
+        assert catalog.find_organism_exact(None) is None
+
     def test_genus_alone_does_not_match(self, catalog):
         # search_organisms matches genus; find_organism_exact must NOT -- this is
         # the false-positive that let ungrounded species through (#1297).


### PR DESCRIPTION
Closes #1297.

The assistant was offering specific organisms it didn't have -- e.g. "which Candida species?" with a clickable C. glabrata chip that then turned out not to be in the catalog. Two layers:

**1. Prompt rule.** Forbids presenting a specific organism/assembly/workflow -- in prose or as a chip -- unless a tool returned it this conversation; tells the model to search first instead of listing examples from memory. The Candida case is called out explicitly.

**2. Server-side chip validation (defense-in-depth).** Suggestion chips can tag the entity they propose (`{"label": "...", "assembly": "GCF_000002765.6"}`); the parser validates tagged organism/assembly/workflow refs against the catalog and drops any that don't resolve. Organisms are matched *exactly* (not via the fuzzy search), keys are case-insensitive, entity values are coerced before lookup (so a numeric taxid is validated, not skipped), and empty tags are treated as untagged. Plain action chips pass through; the frontend still consumes label/message, so no frontend change.

This is defense-in-depth, not a hard guarantee: the tag is validated but the visible label is free text, so ungrounded mentions in prose or untagged chips stay prompt-controlled. That matches the issue's "offer selections" framing.

Reviewed adversarially by Codex over two rounds -- it caught fuzzy-match false positives, key-normalization bypasses, and a regression where non-string tags skipped validation; all tightened with matching test coverage. An eval for the prompt behavior is a follow-up: it needs the eval harness to expose per-turn suggestions plus an actual model run, which is gated on #1299's API budget.
