### PR TITLE
chore: align the assistant page header with the organism list header (#1309)

### DIFF
--- a/app/views/AssistantView/assistantView.styles.ts
+++ b/app/views/AssistantView/assistantView.styles.ts
@@ -1,29 +1,25 @@
-import { GridPaperSection } from "@databiosphere/findable-ui/lib/components/common/Section/section.styles";
+import { Title } from "@databiosphere/findable-ui/lib/components/common/Title/title";
 import styled from "@emotion/styled";
-import { Box } from "@mui/material";
+import { Box, Stack } from "@mui/material";
 import { sectionLayout } from "../../components/Layout/components/AppLayout/components/Section/section.styles";
 
-export const AssistantSection = styled(GridPaperSection)`
-  padding: 24px 0;
+export const StyledSection = styled.section`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
   width: 100%;
 `;
 
-export const SectionContent = styled(Box)`
+export const StyledTitle = styled(Title)`
+  & {
+    line-height: 56px;
+  }
+`;
+
+export const SectionContent = styled(Stack)`
   ${sectionLayout};
   padding: 0 16px;
   width: calc(100% - 32px);
-`;
-
-export const CompactHeader = styled(Box)`
-  padding-bottom: 16px;
-`;
-
-export const CompactHead = styled.h1`
-  font-family: "Inter Tight", sans-serif;
-  font-size: 28px;
-  font-weight: 500;
-  line-height: 36px;
-  margin: 8px 0 0;
 `;
 
 export const TwoPanelLayout = styled(Box)({

--- a/app/views/AssistantView/assistantView.tsx
+++ b/app/views/AssistantView/assistantView.tsx
@@ -1,4 +1,3 @@
-import { Breadcrumbs } from "@databiosphere/findable-ui/lib/components/common/Breadcrumbs/breadcrumbs";
 import { useFeatureFlag } from "@databiosphere/findable-ui/lib/hooks/useFeatureFlag/useFeatureFlag";
 import RestartAltIcon from "@mui/icons-material/RestartAlt";
 import { Box, Button } from "@mui/material";
@@ -10,15 +9,13 @@ import { llmAPIClient } from "../../services/llm-api-client";
 import { AssistantInfoResponse } from "../../types/api";
 import {
   AssistantDisclaimer,
-  AssistantSection,
   ChatColumn,
-  CompactHead,
-  CompactHeader,
   SchemaColumn,
   SectionContent,
+  StyledSection,
+  StyledTitle,
   TwoPanelLayout,
 } from "./assistantView.styles";
-import { BREADCRUMBS } from "./common/constants";
 
 export const AssistantView = (): JSX.Element => {
   const isAssistantEnabled = useFeatureFlag("assistant");
@@ -58,13 +55,16 @@ export const AssistantView = (): JSX.Element => {
   const modelLabel = formatModelLabel(info);
 
   return (
-    <AssistantSection>
+    <StyledSection>
       <SectionContent>
-        <CompactHeader>
-          <Breadcrumbs breadcrumbs={BREADCRUMBS} />
-          <CompactHead>Analysis Assistant (Beta)</CompactHead>
-        </CompactHeader>
-        <Box sx={{ display: "flex", justifyContent: "flex-end", pb: 1 }}>
+        <StyledTitle>Analysis Assistant (Beta)</StyledTitle>
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "flex-end",
+            pb: 1,
+          }}
+        >
           <Button
             onClick={resetSession}
             size="small"
@@ -96,7 +96,7 @@ export const AssistantView = (): JSX.Element => {
           anything important before relying on it.
         </AssistantDisclaimer>
       </SectionContent>
-    </AssistantSection>
+    </StyledSection>
   );
 };
 

--- a/app/views/AssistantView/common/constants.ts
+++ b/app/views/AssistantView/common/constants.ts
@@ -1,6 +1,0 @@
-import { Breadcrumb } from "@databiosphere/findable-ui/lib/components/common/Breadcrumbs/breadcrumbs";
-
-export const BREADCRUMBS: Breadcrumb[] = [
-  { path: "/", text: "Home" },
-  { path: "", text: "Analysis Assistant" },
-];


### PR DESCRIPTION
## Summary
- Replace the assistant page's `CompactHeader` (custom h1 + breadcrumbs) with findable-ui's `<Title>` so the heading matches the organism / assembly list pages (Inter, 30/40 at sm-up, 24/32 below).
- Drop the breadcrumbs from the assistant page.
- Remove the now-unused `CompactHeader` / `CompactHead` styled components and the `BREADCRUMBS` constant file.

Closes #1309.

## Test plan
- [x] `npm run build:local` succeeds
- [x] Visit `/assistant?assistant=true` and confirm the heading visually matches the heading on `/data/organisms` and `/data/assemblies`
- [x] Heading renders as a single `<h1>` reading "Analysis Assistant (Beta)"
- [x] No breadcrumbs on the assistant page
- [x] Chat panel still fits the viewport (no regression from #1304)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2108" height="1312" alt="image" src="https://github.com/user-attachments/assets/68d6afad-8dbd-46a4-a7df-bb6125368943" />
