### PR TITLE
feat: gate login UI on NEXT_PUBLIC_LOGIN_ENABLED env var

### DIFF
--- a/app/providers/authentication.tsx
+++ b/app/providers/authentication.tsx
@@ -8,6 +8,10 @@ import {
   useState,
 } from "react";
 
+// Optional base URL for the BFF auth endpoints. Empty = same-origin (the
+// deployed case, where nginx routes /api/v1/* to the backend). Set it only for
+// cross-origin local dev (frontend :3000 -> backend :8000). It is NOT a gate --
+// loginEnabled alone controls whether the login UI shows.
 const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || "";
 
 interface BrcUser {
@@ -53,7 +57,7 @@ export function BrcAuthProvider({
   const [user, setUser] = useState<BrcUser | null>(null);
 
   useEffect(() => {
-    if (!loginEnabled || !BACKEND_URL) {
+    if (!loginEnabled) {
       setIsLoading(false);
       return;
     }
@@ -93,7 +97,7 @@ export function BrcAuthProvider({
     <AuthContext.Provider
       value={{
         isAuthenticated: !!user,
-        isConfigured: loginEnabled && !!BACKEND_URL,
+        isConfigured: loginEnabled,
         isLoading,
         login,
         logout,

--- a/site-config/brc-analytics/local/config.ts
+++ b/site-config/brc-analytics/local/config.ts
@@ -27,6 +27,10 @@ const APP_TITLE = "BRC Analytics";
 const BROWSER_URL = LOCALHOST;
 const GIT_HUB_REPO_URL = "https://github.com/galaxyproject/brc-analytics";
 
+// Login UI is gated by a build-time env var so deployments (the playbook) flip
+// it per environment without an app-code change. Defaults off when unset.
+const LOGIN_ENABLED = process.env.NEXT_PUBLIC_LOGIN_ENABLED === "true";
+
 /**
  * Make site config object.
  * @param browserUrl - Browser URL.
@@ -48,7 +52,7 @@ export function makeConfig(
   browserUrl: string,
   gitHubUrl = GIT_HUB_REPO_URL,
   taxTreeData = data as TaxonomyNode,
-  loginEnabled = false
+  loginEnabled = LOGIN_ENABLED
 ): AppSiteConfig {
   return {
     appKey: APP_KEYS.BRC_ANALYTICS,


### PR DESCRIPTION
## What

Make the Galaxy SSO login UI toggleable **per deployment** via a build-time env var, so the playbook (which already owns per-environment Keycloak config) is the single gate -- no app-code edit to turn an environment on or off.

## Why

The login UI previously had two in-code gates: a hardcoded `loginEnabled` flag baked into each site-config file, and a non-empty `NEXT_PUBLIC_BACKEND_URL` (`isConfigured = loginEnabled && !!BACKEND_URL`). Toggling login meant editing app code, and the `BACKEND_URL` check hid the button on same-origin deploys (where it's empty).

## Change

- `site-config/brc-analytics/local/config.ts`: `makeConfig` defaults `loginEnabled` to `process.env.NEXT_PUBLIC_LOGIN_ENABLED === "true"`. Next inlines this at build time, and process-env values win over `.env` files, so a deploy can set it without touching committed config.
- `app/providers/authentication.tsx`: `loginEnabled` is the only in-code gate; `BACKEND_URL` is now an optional same-origin-default base URL (documented inline), needed only for cross-origin local dev.

Nothing is hardcoded per environment here -- the **playbook** sets `NEXT_PUBLIC_LOGIN_ENABLED` per env (companion change in brc-analytics-playbook). Default is off everywhere when the var is unset.

## Validation

`npx tsc --noEmit`, eslint, and prettier pass on the changed files. (Local husky's repo-wide `prettier --check .` trips on unrelated generated files under `.worktrees/`; CI checks a clean tree and is unaffected.)