### PR TITLE
feat: style the "about the assistant" link to match the design (#1316)

### DIFF
--- a/app/views/AssistantView/assistantView.styles.ts
+++ b/app/views/AssistantView/assistantView.styles.ts
@@ -1,4 +1,3 @@
-import { Title } from "@databiosphere/findable-ui/lib/components/common/Title/title";
 import styled from "@emotion/styled";
 import { Box, Stack } from "@mui/material";
 import { sectionLayout } from "../../components/Layout/components/AppLayout/components/Section/section.styles";
@@ -8,12 +7,6 @@ export const StyledSection = styled.section`
   flex-direction: column;
   flex: 1;
   width: 100%;
-`;
-
-export const StyledTitle = styled(Title)`
-  & {
-    line-height: 56px;
-  }
 `;
 
 export const SectionContent = styled(Stack)`

--- a/app/views/AssistantView/assistantView.tsx
+++ b/app/views/AssistantView/assistantView.tsx
@@ -1,8 +1,7 @@
 import { useFeatureFlag } from "@databiosphere/findable-ui/lib/hooks/useFeatureFlag/useFeatureFlag";
 import RestartAltIcon from "@mui/icons-material/RestartAlt";
-import { Box, Button, Link } from "@mui/material";
+import { Button } from "@mui/material";
 import Error from "next/error";
-import NextLink from "next/link";
 import { JSX, useEffect, useState } from "react";
 import { ChatPanel, SchemaPanel } from "../../components/Assistant";
 import { useAssistantChat } from "../../hooks/useAssistantChat";
@@ -14,9 +13,9 @@ import {
   SchemaColumn,
   SectionContent,
   StyledSection,
-  StyledTitle,
   TwoPanelLayout,
 } from "./assistantView.styles";
+import { Headline } from "./components/Headline/headline";
 
 export const AssistantView = (): JSX.Element => {
   const isAssistantEnabled = useFeatureFlag("assistant");
@@ -58,28 +57,16 @@ export const AssistantView = (): JSX.Element => {
   return (
     <StyledSection>
       <SectionContent>
-        <StyledTitle>Analysis Assistant (Beta)</StyledTitle>
-        <Box
-          sx={{
-            alignItems: "center",
-            display: "flex",
-            justifyContent: "space-between",
-            pb: 1,
-          }}
+        <Headline />
+        <Button
+          onClick={resetSession}
+          size="small"
+          startIcon={<RestartAltIcon />}
+          sx={{ visibility: showReset ? "visible" : "hidden" }}
+          variant="text"
         >
-          <Link component={NextLink} href="/learn/assistant" variant="body2">
-            About the Assistant →
-          </Link>
-          <Button
-            onClick={resetSession}
-            size="small"
-            startIcon={<RestartAltIcon />}
-            sx={{ visibility: showReset ? "visible" : "hidden" }}
-            variant="text"
-          >
-            New Conversation
-          </Button>
-        </Box>
+          New Conversation
+        </Button>
         <TwoPanelLayout>
           <ChatColumn>
             <ChatPanel

--- a/app/views/AssistantView/components/Headline/headline.styles.ts
+++ b/app/views/AssistantView/components/Headline/headline.styles.ts
@@ -1,0 +1,24 @@
+import { FONT } from "@databiosphere/findable-ui/lib/styles/common/constants/font";
+import { PALETTE } from "@databiosphere/findable-ui/lib/styles/common/constants/palette";
+import styled from "@emotion/styled";
+import { Link, Stack } from "@mui/material";
+
+export const StyledStack = styled(Stack)`
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px 16px;
+
+  h1 {
+    line-height: 56px;
+  }
+`;
+
+export const StyledLink = styled(Link)`
+  align-self: center;
+  align-items: center;
+  color: ${PALETTE.INK_LIGHT};
+  display: flex;
+  font: ${FONT.BODY_SMALL_400};
+  gap: 2px;
+  padding: 4px 0;
+` as typeof Link;

--- a/app/views/AssistantView/components/Headline/headline.tsx
+++ b/app/views/AssistantView/components/Headline/headline.tsx
@@ -1,0 +1,24 @@
+import { Title } from "@databiosphere/findable-ui/lib/components/common/Title/title";
+import { LINK_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/link";
+import { STACK_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/stack";
+import { SVG_ICON_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/svgIcon";
+import { ArrowForwardRounded } from "@mui/icons-material";
+import Link from "next/link";
+import type { JSX } from "react";
+import { StyledLink, StyledStack } from "./headline.styles";
+
+export const Headline = (): JSX.Element => {
+  return (
+    <StyledStack direction={STACK_PROPS.DIRECTION.ROW} useFlexGap>
+      <Title>Analysis Assistant (Beta)</Title>
+      <StyledLink
+        component={Link}
+        href="/learn/assistant"
+        underline={LINK_PROPS.UNDERLINE.NONE}
+      >
+        About the Assistant
+        <ArrowForwardRounded fontSize={SVG_ICON_PROPS.FONT_SIZE.XXSMALL} />
+      </StyledLink>
+    </StyledStack>
+  );
+};

--- a/app/views/AssistantView/components/Headline/headline.tsx
+++ b/app/views/AssistantView/components/Headline/headline.tsx
@@ -16,7 +16,7 @@ export const Headline = (): JSX.Element => {
         href="/learn/assistant"
         underline={LINK_PROPS.UNDERLINE.NONE}
       >
-        About the Assistant
+        <span>About the Assistant</span>
         <ArrowForwardRounded fontSize={SVG_ICON_PROPS.FONT_SIZE.XXSMALL} />
       </StyledLink>
     </StyledStack>


### PR DESCRIPTION
## Summary

Closes #1316.

- Extract the assistant view's headline (title + "About the Assistant" link) into `app/views/AssistantView/components/Headline/`.
- Apply the link treatment from the approved design: arrow icon (`ArrowForwardRounded` at `XXSMALL`), `INK_LIGHT` color, `BODY_SMALL_400` typography, no underline. Mirrors the link pattern used in hprc-data-explorer's `EntityTitle`.

## Test plan

- [x] tsc clean
- [x] lint clean
- [x] `npm test` — 502/502
- [x] Visual check on the `/assistant` page matches the design

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2007" height="977" alt="image" src="https://github.com/user-attachments/assets/e03b0eb9-a364-4ebb-a3fa-1819d5ba317e" />
