### PR TITLE
fix: lineage-based taxonomy matching in the assistant's compatibility tools

### DIFF
--- a/backend/api/app/services/tools/catalog_data.py
+++ b/backend/api/app/services/tools/catalog_data.py
@@ -341,9 +341,9 @@ class CatalogData:
         wf_tax = wf.get("taxonomy_id")
         if wf_tax and not self._workflow_taxon_matches(wf_tax, asm.get("taxonomy_id")):
             issues.append(
-                f"Workflow is organism-specific (taxonomy {wf_tax}) "
-                f"but assembly taxonomy {asm.get('taxonomy_id')} is not within "
-                f"its lineage"
+                f"Workflow is organism-specific (taxonomy {wf_tax}), but that "
+                f"taxon is not in the lineage of assembly taxonomy "
+                f"{asm.get('taxonomy_id')}"
             )
 
         # Gene annotation check

--- a/backend/api/app/services/tools/catalog_data.py
+++ b/backend/api/app/services/tools/catalog_data.py
@@ -10,6 +10,13 @@ from typing import Any, Dict, List, Optional, Set
 
 logger = logging.getLogger(__name__)
 
+# NOTE: the workflow/organism compatibility rule (taxonomy lineage + ploidy +
+# assembly-id requirement) below is duplicated in three other places that drift
+# out of sync -- the MCP server's catalog_data.py, the frontend's
+# AnalyzeWorkflowsView/components/Main/utils.ts, and the catalog build's
+# build-workflow-mappings.ts. #1319 was caused by that drift. Consolidating to a
+# single source of truth is tracked in #1327; until then, change all four together.
+
 # Ploidy compatibility: a workflow is compatible when its ploidy is ANY
 # or matches at least one of the organism's ploidy values.
 _PLOIDY_ANY = "ANY"

--- a/backend/api/app/services/tools/catalog_data.py
+++ b/backend/api/app/services/tools/catalog_data.py
@@ -6,7 +6,7 @@ Provides search and lookup methods used by the assistant agent's tools.
 import json
 import logging
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set
 
 logger = logging.getLogger(__name__)
 
@@ -20,11 +20,52 @@ class CatalogData:
         self.catalog_path = Path(catalog_path)
         self.organisms: List[Dict[str, Any]] = []
         self.workflows_by_category: List[Dict[str, Any]] = []
+        # Maps each taxonomy ID to the set of IDs in its lineage so a workflow
+        # annotated with an ancestor taxon (e.g. Bacteria=2) matches every
+        # organism below it (e.g. E. coli=562). Built from genome lineages.
+        self._lineage_by_tax_id: Dict[str, Set[str]] = {}
         self._load()
 
     def _load(self) -> None:
         self._load_organisms()
         self._load_workflows()
+        self._build_lineage_index()
+
+    def _build_lineage_index(self) -> None:
+        """Index each taxonomy ID to the full set of IDs in its lineage.
+
+        Lets ancestor lookups answer "is Bacteria (2) in E. coli's (562)
+        lineage?" so a workflow targeting a higher-rank taxon applies to all
+        taxa below it. When several genomes share a tax ID their lineages are
+        merged into that ID's set.
+        """
+        for org in self.organisms:
+            for genome in org.get("genomes", []):
+                lineage = genome.get("lineageTaxonomyIds") or []
+                if not lineage:
+                    continue
+                lineage_strs = [str(t) for t in lineage]
+                for tid in lineage_strs:
+                    existing = self._lineage_by_tax_id.get(tid)
+                    if existing is None:
+                        self._lineage_by_tax_id[tid] = set(lineage_strs)
+                    else:
+                        existing.update(lineage_strs)
+
+    def _workflow_taxon_matches(
+        self, workflow_tax_id: Any, target_tax_id: Optional[str]
+    ) -> bool:
+        """True if an organism-specific workflow applies to target_tax_id.
+
+        A match means the workflow's taxon is anywhere in target_tax_id's
+        lineage -- a workflow for Bacteria (2) applies to E. coli (562) and
+        every other taxon below it. Returns False when there's no organism to
+        check against or its lineage is unknown.
+        """
+        if not target_tax_id:
+            return False
+        lineage = self._lineage_by_tax_id.get(str(target_tax_id), set())
+        return str(workflow_tax_id) in lineage
 
     def _load_organisms(self) -> None:
         path = self.catalog_path / "organisms.json"
@@ -207,8 +248,8 @@ class CatalogData:
                 wf_tax = wf.get("taxonomyId")
 
                 ploidy_ok = wf_ploidy == _PLOIDY_ANY or wf_ploidy in organism_ploidies
-                tax_ok = wf_tax is None or (
-                    taxonomy_id and str(wf_tax) == str(taxonomy_id)
+                tax_ok = wf_tax is None or self._workflow_taxon_matches(
+                    wf_tax, taxonomy_id
                 )
 
                 if ploidy_ok and tax_ok:
@@ -282,12 +323,14 @@ class CatalogData:
                 f"Workflow requires {wf_ploidy} but assembly is {', '.join(asm_ploidies)}"
             )
 
-        # Taxonomy check
+        # Taxonomy check: the workflow's taxon must be in the assembly's
+        # lineage, so a Bacteria-targeted workflow matches any bacterium.
         wf_tax = wf.get("taxonomy_id")
-        if wf_tax and str(wf_tax) != asm.get("taxonomy_id"):
+        if wf_tax and not self._workflow_taxon_matches(wf_tax, asm.get("taxonomy_id")):
             issues.append(
                 f"Workflow is organism-specific (taxonomy {wf_tax}) "
-                f"but assembly has taxonomy {asm.get('taxonomy_id')}"
+                f"but assembly taxonomy {asm.get('taxonomy_id')} is not within "
+                f"its lineage"
             )
 
         # Gene annotation check

--- a/backend/api/app/services/tools/catalog_data.py
+++ b/backend/api/app/services/tools/catalog_data.py
@@ -27,9 +27,10 @@ class CatalogData:
         self.catalog_path = Path(catalog_path)
         self.organisms: List[Dict[str, Any]] = []
         self.workflows_by_category: List[Dict[str, Any]] = []
-        # Maps each taxonomy ID to the set of IDs in its lineage so a workflow
-        # annotated with an ancestor taxon (e.g. Bacteria=2) matches every
-        # organism below it (e.g. E. coli=562). Built from genome lineages.
+        # Maps each taxonomy ID to its own ancestor lineage -- the IDs from the
+        # root down to and including itself, never its descendants -- so a
+        # workflow annotated with an ancestor taxon (e.g. Bacteria=2) matches
+        # every organism below it (e.g. E. coli=562). Built from genome lineages.
         self._lineage_by_tax_id: Dict[str, Set[str]] = {}
         self._load()
 
@@ -39,12 +40,16 @@ class CatalogData:
         self._build_lineage_index()
 
     def _build_lineage_index(self) -> None:
-        """Index each taxonomy ID to the full set of IDs in its lineage.
+        """Index each taxonomy ID to its own ancestor lineage (root..tid).
 
         Lets ancestor lookups answer "is Bacteria (2) in E. coli's (562)
         lineage?" so a workflow targeting a higher-rank taxon applies to all
-        taxa below it. When several genomes share a tax ID their lineages are
-        merged into that ID's set.
+        taxa below it. lineageTaxonomyIds is root-first, so each ID maps only
+        to the prefix up to and including itself -- mapping it to the full
+        lineage would pollute ancestor keys with their descendants (key "2"
+        would contain "562"), wrongly matching a descendant-targeted workflow
+        against a higher-rank organism. When several genomes share a tax ID
+        their ancestor sets are merged.
         """
         for org in self.organisms:
             for genome in org.get("genomes", []):
@@ -52,12 +57,13 @@ class CatalogData:
                 if not lineage:
                     continue
                 lineage_strs = [str(t) for t in lineage]
-                for tid in lineage_strs:
+                for i, tid in enumerate(lineage_strs):
+                    ancestors = set(lineage_strs[: i + 1])
                     existing = self._lineage_by_tax_id.get(tid)
                     if existing is None:
-                        self._lineage_by_tax_id[tid] = set(lineage_strs)
+                        self._lineage_by_tax_id[tid] = ancestors
                     else:
-                        existing.update(lineage_strs)
+                        existing.update(ancestors)
 
     def _workflow_taxon_matches(
         self, workflow_tax_id: Any, target_tax_id: Optional[str]

--- a/backend/api/tests/test_catalog_data.py
+++ b/backend/api/tests/test_catalog_data.py
@@ -449,3 +449,13 @@ class TestLineageTaxonomyMatching:
         )
         assert result["compatible"] is False
         assert any("taxonom" in issue.lower() for issue in result["issues"])
+
+    def test_ancestor_index_excludes_descendants(self, lineage_catalog):
+        # Bacteria (2) is an ancestor of E. coli (562). The lineage index for an
+        # ancestor must not pull in its descendants, or a workflow targeting a
+        # descendant taxon would wrongly match a higher-rank organism.
+        assert "562" not in lineage_catalog._lineage_by_tax_id.get("2", set())
+        # A workflow for E. coli (562) does not apply to a Bacteria (2) target...
+        assert lineage_catalog._workflow_taxon_matches(562, "2") is False
+        # ...but a Bacteria (2) workflow still applies to E. coli (562).
+        assert lineage_catalog._workflow_taxon_matches(2, "562") is True

--- a/backend/api/tests/test_catalog_data.py
+++ b/backend/api/tests/test_catalog_data.py
@@ -333,3 +333,119 @@ class TestCompatibilityCheck:
         )
         assert result["compatible"] is False
         assert "not found" in result["reason"].lower()
+
+
+# ---------- Lineage-based taxonomy matching (#1319) ----------
+
+LINEAGE_ORGANISMS = [
+    {
+        "ncbiTaxonomyId": 562,
+        "taxonomicLevelSpecies": "Escherichia coli",
+        "taxonomicLevelGenus": "Escherichia",
+        "commonName": "E. coli",
+        "assemblyCount": 1,
+        "taxonomicGroup": ["Bacteria"],
+        "genomes": [
+            {
+                "accession": "GCF_000005845.2",
+                "taxonomicLevelSpecies": "Escherichia coli",
+                "isRef": "Yes",
+                "level": "Complete Genome",
+                "ploidy": ["HAPLOID"],
+                "geneModelUrl": "https://example.com/ecoli.gtf",
+                "ncbiTaxonomyId": 562,
+                "speciesTaxonomyId": 562,
+                # Bacteria (2) is an ancestor of E. coli (562)
+                "lineageTaxonomyIds": ["1", "131567", "2", "1224", "561", "562"],
+            },
+        ],
+    },
+    {
+        "ncbiTaxonomyId": 559292,
+        "taxonomicLevelSpecies": "Saccharomyces cerevisiae",
+        "taxonomicLevelGenus": "Saccharomyces",
+        "commonName": "yeast",
+        "assemblyCount": 1,
+        "taxonomicGroup": ["Fungi"],
+        "genomes": [
+            {
+                "accession": "GCF_000146045.2",
+                "taxonomicLevelSpecies": "Saccharomyces cerevisiae",
+                "isRef": "Yes",
+                "level": "Chromosome",
+                "ploidy": ["HAPLOID"],
+                "ncbiTaxonomyId": 559292,
+                "speciesTaxonomyId": 559292,
+                # Fungal lineage -- Bacteria (2) is NOT present
+                "lineageTaxonomyIds": ["1", "131567", "2759", "4751", "4932", "559292"],
+            },
+        ],
+    },
+]
+
+LINEAGE_WORKFLOWS = [
+    {
+        "category": "ANNOTATION",
+        "name": "Annotation",
+        "description": "Annotation workflows",
+        "workflows": [
+            {
+                "iwcId": "amr-gene-detection",
+                "workflowName": "AMR Gene Detection",
+                "workflowDescription": "Bacterial AMR gene detection",
+                "ploidy": "HAPLOID",
+                "taxonomyId": 2,  # Bacteria -- applies to all descendant taxa
+                "trsId": "#workflow/github.com/iwc/amr/main",
+                "parameters": [],
+            },
+            {
+                "iwcId": "generic-assembly",
+                "workflowName": "Generic Assembly",
+                "workflowDescription": "Taxon-agnostic assembly",
+                "ploidy": "ANY",
+                "taxonomyId": None,
+                "trsId": "#workflow/github.com/iwc/assembly/main",
+                "parameters": [],
+            },
+        ],
+    },
+]
+
+
+@pytest.fixture()
+def lineage_catalog(tmp_path):
+    (tmp_path / "organisms.json").write_text(json.dumps(LINEAGE_ORGANISMS))
+    (tmp_path / "workflows.json").write_text(json.dumps(LINEAGE_WORKFLOWS))
+    return CatalogData(str(tmp_path))
+
+
+class TestLineageTaxonomyMatching:
+    def test_compatible_includes_ancestor_targeted_workflow(self, lineage_catalog):
+        # E. coli (562); AMR workflow targets Bacteria (2), which is in its
+        # lineage, so it should be returned even though 2 != 562.
+        wfs = lineage_catalog.get_compatible_workflows(["HAPLOID"], taxonomy_id="562")
+        iwc_ids = {w["iwc_id"] for w in wfs}
+        assert "amr-gene-detection" in iwc_ids
+
+    def test_compatible_excludes_unrelated_lineage(self, lineage_catalog):
+        # Yeast (559292) is a fungus; Bacteria (2) is not in its lineage, so
+        # the Bacteria-targeted AMR workflow should not be returned.
+        wfs = lineage_catalog.get_compatible_workflows(
+            ["HAPLOID"], taxonomy_id="559292"
+        )
+        iwc_ids = {w["iwc_id"] for w in wfs}
+        assert "amr-gene-detection" not in iwc_ids
+
+    def test_check_compatible_with_descendant_assembly(self, lineage_catalog):
+        result = lineage_catalog.check_workflow_assembly_compatibility(
+            "amr-gene-detection", "GCF_000005845.2"
+        )
+        assert result["compatible"] is True
+        assert result["issues"] == []
+
+    def test_check_incompatible_with_unrelated_assembly(self, lineage_catalog):
+        result = lineage_catalog.check_workflow_assembly_compatibility(
+            "amr-gene-detection", "GCF_000146045.2"
+        )
+        assert result["compatible"] is False
+        assert any("taxonom" in issue.lower() for issue in result["issues"])

--- a/catalog/build/ts/build-workflow-mappings.ts
+++ b/catalog/build/ts/build-workflow-mappings.ts
@@ -18,14 +18,19 @@ type AssemblyForCompatibility = {
 };
 
 /**
- * NOTE: The compatibility functions below are intentionally duplicated from:
- * - app/apis/catalog/brc-analytics-catalog/common/utils.ts (workflowPloidyMatchesOrganismPloidy)
- * - app/views/AnalyzeWorkflowsView/components/Main/utils.ts (workflowIsCompatibleWithAssembly, workflowRequiresAssemblyId)
+ * NOTE: This workflow/assembly compatibility rule (taxonomy lineage + ploidy +
+ * assembly-id requirement) is duplicated in four places that drift out of sync:
+ * - this file (build time)
+ * - app/views/AnalyzeWorkflowsView/components/Main/utils.ts (frontend runtime;
+ *   shares only workflowPloidyMatchesOrganismPloidy from common/utils.ts)
+ * - backend/api/app/services/catalog_data.py (MCP server)
+ * - backend/api/app/services/tools/catalog_data.py (assistant agent)
  *
- * They cannot be imported directly because this build script uses generics to work with both
- * BRC and GA2 assembly types, while the app functions have concrete type signatures.
- * If you modify the compatibility logic, update BOTH locations to keep them in sync.
- * Consider creating a shared utility module to avoid duplication.
+ * The TS copies can't import each other today only because this build script is
+ * generic over BRC/GA2 assembly types while the app function has a concrete
+ * signature -- a single generic in common/ would fix that. #1319 was caused by
+ * this drift. If you change the rule, update all four. Consolidating to a single
+ * source of truth is tracked in #1327.
  */
 
 // Helper function to check if workflow requires ASSEMBLY_ID parameter


### PR DESCRIPTION
The assistant refused to run a workflow on an organism it was perfectly valid for -- it wanted the workflow's annotated taxon id to *exactly* equal the organism's taxon id, so a workflow for Bacteria (taxon 2) got rejected on E. coli (562). It should match when the workflow's taxon is anywhere in the organism's lineage.

Turns out this same fix already landed months ago in the other three places this logic lives (the frontend view, the catalog build script, and the MCP server's `catalog_data.py`) -- the assistant agent's own copy in `tools/catalog_data.py` just got missed. This brings it in line, mirroring the MCP server's lineage-index approach: build a `_lineage_by_tax_id` index from each genome's `lineageTaxonomyIds`, then match on lineage membership in `get_compatible_workflows` and `check_workflow_assembly_compatibility`.

Verified against the real catalog (AMR/Bacteria → E. coli now compatible; a fungal assembly is still correctly rejected) and with new lineage tests. The second commit just adds NOTE comments flagging the 4-way duplication, with consolidation tracked in #1327.

Closes #1319.
