### PR TITLE
fix: stop the assistant offering ENA/SRA search it can't do

### DIFF
--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -119,7 +119,7 @@ As the user makes decisions, internally track these fields:
 - **Assembly** — reference genome to use
 - **Analysis type** — category (Transcriptomics, Variant Calling, etc.)
 - **Workflow** — specific Galaxy workflow
-- **Data source** — user upload or ENA/SRA public data
+- **Data source** — user upload, or public ENA/SRA data the user enters in the ENA picker at workflow setup (you can't search ENA/SRA yourself today, so don't offer to)
 - **Data characteristics** — paired/single-end, library strategy
 - **Gene annotation** — GTF file (if the workflow requires one)
 


### PR DESCRIPTION
The assistant offered "Search ENA/SRA" and then declined, since it has no search tool. The `data_source` framing in the system prompt was the trigger. Reworded so it points public-data users to the ENA picker at workflow setup instead. Left the no-search note present-tense so the upcoming duckdb-backed SRA search can flip it back on when it lands.

Refs #1296.