### PR TITLE
fix: assistant schema panel/status polish and GTF requirement handling

### DIFF
--- a/app/components/Assistant/ChatPanel/chatPanel.tsx
+++ b/app/components/Assistant/ChatPanel/chatPanel.tsx
@@ -81,8 +81,9 @@ export const ChatPanel = ({
         {!isRestoring && messages.length === 0 && (
           <Box sx={{ p: 4, textAlign: "center" }}>
             <Typography color="text.secondary" variant="body1">
-              Welcome! I can help you explore BRC Analytics data and set up
-              analyses. Try asking about organisms, assemblies, or workflows.
+              Welcome! I can help you explore the BRC catalog -- organisms,
+              assemblies, and workflows -- and set up an analysis to run in
+              Galaxy. Try naming an organism or an analysis type to get started.
             </Typography>
           </Box>
         )}

--- a/app/components/Assistant/SchemaPanel/schemaPanel.tsx
+++ b/app/components/Assistant/SchemaPanel/schemaPanel.tsx
@@ -146,8 +146,9 @@ export const SchemaPanel = ({
       {isEmpty && (
         <Box sx={{ pb: 1, pt: 2, px: 2 }}>
           <Typography color="text.secondary" variant="body2">
-            Tell the assistant what you&apos;re working on (an organism, a
-            paper, a kind of analysis) and it&apos;ll help fill these in:
+            Tell the assistant what you&apos;re working on (an organism, an
+            analysis type, or the kind of data you have) and it&apos;ll help
+            fill these in:
           </Typography>
         </Box>
       )}

--- a/app/components/Assistant/SchemaPanel/schemaPanel.tsx
+++ b/app/components/Assistant/SchemaPanel/schemaPanel.tsx
@@ -69,17 +69,30 @@ const PLACEHOLDER_SCHEMA: AnalysisSchema = {
 /**
  * Get the status indicator for a schema field.
  * @param props - Component props
+ * @param props.optional - Whether the field is optional (not required to hand off)
  * @param props.status - Field status
  * @returns Status chip element
  */
-function StatusIndicator({ status }: { status: FieldStatus }): JSX.Element {
+function StatusIndicator({
+  optional,
+  status,
+}: {
+  optional: boolean;
+  status: FieldStatus;
+}): JSX.Element {
   if (status === "filled") {
     return <Chip color="success" label="Done" size="small" />;
   }
   if (status === "needs_attention") {
     return <Chip color="warning" label="Attention" size="small" />;
   }
-  return <Chip label="Pending" size="small" variant="outlined" />;
+  return (
+    <Chip
+      label={optional ? "Optional" : "Pending"}
+      size="small"
+      variant="outlined"
+    />
+  );
 }
 
 /**
@@ -154,7 +167,10 @@ export const SchemaPanel = ({
                 }}
               >
                 <Typography variant="body2">{FIELD_LABELS[key]}</Typography>
-                <StatusIndicator status={field.status} />
+                <StatusIndicator
+                  optional={OPTIONAL_FIELDS.includes(key)}
+                  status={field.status}
+                />
               </Box>
               {field.value && (
                 <FieldValue variant="body2">{field.value}</FieldValue>

--- a/app/components/Assistant/SchemaPanel/schemaPanel.tsx
+++ b/app/components/Assistant/SchemaPanel/schemaPanel.tsx
@@ -117,7 +117,7 @@ export const SchemaPanel = ({
   const isEmpty = !schema;
   const activeSchema = schema ?? PLACEHOLDER_SCHEMA;
 
-  const filledCount = REQUIRED_FIELDS.filter(
+  const filledCount = FIELD_ORDER.filter(
     (key) => activeSchema[key].status === "filled"
   ).length;
 
@@ -126,7 +126,7 @@ export const SchemaPanel = ({
       <PanelHeader>
         <Typography variant="subtitle1">Analysis Setup</Typography>
         <Typography color="text.secondary" variant="caption">
-          {filledCount} / {REQUIRED_FIELDS.length} configured
+          {filledCount} / {FIELD_ORDER.length} configured
         </Typography>
       </PanelHeader>
 

--- a/app/components/Assistant/SchemaPanel/schemaPanel.tsx
+++ b/app/components/Assistant/SchemaPanel/schemaPanel.tsx
@@ -71,14 +71,17 @@ const PLACEHOLDER_SCHEMA: AnalysisSchema = {
  * @param props - Component props
  * @param props.optional - Whether the field is optional (not required to hand off)
  * @param props.status - Field status
+ * @param props.workflowSelected - Whether a workflow has been chosen yet
  * @returns Status chip element
  */
 function StatusIndicator({
   optional,
   status,
+  workflowSelected,
 }: {
   optional: boolean;
   status: FieldStatus;
+  workflowSelected: boolean;
 }): JSX.Element {
   if (status === "filled") {
     return <Chip color="success" label="Done" size="small" />;
@@ -86,9 +89,11 @@ function StatusIndicator({
   if (status === "needs_attention") {
     return <Chip color="warning" label="Attention" size="small" />;
   }
+  // Only call an optional field "Optional" once a workflow is chosen -- until
+  // then we don't yet know whether it (e.g. a GTF) will turn out to be required.
   return (
     <Chip
-      label={optional ? "Optional" : "Pending"}
+      label={optional && workflowSelected ? "Optional" : "Pending"}
       size="small"
       variant="outlined"
     />
@@ -171,6 +176,7 @@ export const SchemaPanel = ({
                 <StatusIndicator
                   optional={OPTIONAL_FIELDS.includes(key)}
                   status={field.status}
+                  workflowSelected={activeSchema.workflow.status === "filled"}
                 />
               </Box>
               {field.value && (

--- a/app/docs/learn/assistant.mdx
+++ b/app/docs/learn/assistant.mdx
@@ -32,6 +32,6 @@ The assistant is focused on the catalog-to-Galaxy setup flow described above. It
 - Help with analyses or workflows that aren't in the BRC catalog, or build a custom analysis pipeline from scratch.
 - Work with organisms, assemblies, or annotation files that aren't already in the catalog.
 - Interpret your results, write or summarize papers, or answer general research questions.
-- Browse external resources (like UCSC genome browser tracks) on your behalf.
+- Browse external resources (like UCSC Genome Browser tracks) on your behalf.
 
 If you need something it can't do, [open an issue](https://github.com/galaxyproject/brc-analytics/issues) and let us know -- it helps us prioritize.

--- a/app/docs/learn/assistant.mdx
+++ b/app/docs/learn/assistant.mdx
@@ -24,3 +24,14 @@ The assistant is in **beta**. Like any AI tool, it can make mistakes -- double-c
 4. **Hand off to the workflow stepper.** When the setup is ready, the assistant hands you off to the workflow stepper with your selections pre-filled. From there you can review everything and launch in Galaxy.
 
 If the assistant doesn't have what you're looking for -- for example, an organism or assembly that isn't in the catalog -- it will say so. You can browse the [catalog](/data/organisms) directly, or [open an issue](https://github.com/galaxyproject/brc-analytics/issues) to request that we add it.
+
+## What it can't do (yet)
+
+The assistant is focused on the catalog-to-Galaxy setup flow described above. It can't:
+
+- Help with analyses or workflows that aren't in the BRC catalog, or build a custom analysis pipeline from scratch.
+- Work with organisms, assemblies, or annotation files that aren't already in the catalog.
+- Interpret your results, write or summarize papers, or answer general research questions.
+- Browse external resources (like UCSC genome browser tracks) on your behalf.
+
+If you need something it can't do, [open an issue](https://github.com/galaxyproject/brc-analytics/issues) and let us know -- it helps us prioritize.

--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -802,7 +802,40 @@ class AssistantAgent:
 
             setattr(schema, key, field)
 
+        self._reflect_gene_annotation_requirement(schema)
+
         return schema
+
+    def _reflect_gene_annotation_requirement(self, schema: AnalysisSchema) -> None:
+        """Mark gene annotation as needing attention when the selected workflow
+        actually requires a GTF, so the panel doesn't render a required
+        annotation as "Optional" (#1324/#1331). Workflows that take no GTF leave
+        it empty/optional; a filled annotation is left untouched.
+        """
+        if (
+            schema.workflow.status != FieldStatus.FILLED
+            or schema.gene_annotation.status == FieldStatus.FILLED
+        ):
+            return
+        if self._workflow_requires_gene_model(schema.workflow.detail):
+            schema.gene_annotation.status = FieldStatus.NEEDS_ATTENTION
+        elif schema.gene_annotation.status == FieldStatus.NEEDS_ATTENTION:
+            # Workflow changed to one that no longer needs a GTF.
+            schema.gene_annotation.status = FieldStatus.EMPTY
+
+    def _workflow_requires_gene_model(self, workflow_ref: Optional[str]) -> bool:
+        """True when the workflow (matched by trsId or iwcId) takes a
+        GENE_MODEL_URL parameter."""
+        if not workflow_ref:
+            return False
+        for cat in self.catalog.workflows_by_category:
+            for wf in cat.get("workflows", []):
+                if workflow_ref in (wf.get("trsId"), wf.get("iwcId")):
+                    return any(
+                        p.get("variable") == "GENE_MODEL_URL"
+                        for p in wf.get("parameters", [])
+                    )
+        return False
 
     def _find_assembly_accession(
         self, value: str, schema: AnalysisSchema

--- a/backend/api/tests/test_assistant_agent.py
+++ b/backend/api/tests/test_assistant_agent.py
@@ -408,6 +408,48 @@ class TestApplySchemaUpdates:
         )
         assert result.workflow.detail == "#workflow/github.com/iwc/rnaseq-pe/main"
 
+    def test_gene_annotation_needs_attention_when_workflow_requires_gtf(self, agent):
+        # A GTF-requiring workflow must not leave gene annotation looking optional
+        # (#1324/#1331) -- it should surface as needing attention.
+        agent.catalog.workflows_by_category = [
+            {
+                "category": "TRANSCRIPTOMICS",
+                "workflows": [
+                    {
+                        "iwcId": "rnaseq-pe",
+                        "trsId": "trs-rnaseq",
+                        "parameters": [{"variable": "GENE_MODEL_URL"}],
+                    }
+                ],
+            }
+        ]
+        result = agent._apply_schema_updates(
+            AnalysisSchema(), {"workflow": "RNA-Seq (rnaseq-pe)"}
+        )
+        assert result.workflow.status == FieldStatus.FILLED
+        assert result.gene_annotation.status == FieldStatus.NEEDS_ATTENTION
+
+    def test_gene_annotation_stays_optional_when_workflow_has_no_gtf(self, agent):
+        # A workflow with no GENE_MODEL_URL param leaves gene annotation empty so
+        # the panel can render it as "Optional".
+        agent.catalog.workflows_by_category = [
+            {
+                "category": "ASSEMBLY",
+                "workflows": [
+                    {
+                        "iwcId": "asm-only",
+                        "trsId": "trs-asm",
+                        "parameters": [{"variable": "ASSEMBLY_ID"}],
+                    }
+                ],
+            }
+        ]
+        result = agent._apply_schema_updates(
+            AnalysisSchema(), {"workflow": "Assembly (asm-only)"}
+        )
+        assert result.workflow.status == FieldStatus.FILLED
+        assert result.gene_annotation.status == FieldStatus.EMPTY
+
 
 # ---------- compute_handoff ----------
 


### PR DESCRIPTION
## Description

This PR updates the Analysis Assistant setup/status UX and scope copy, and corrects gene-annotation status behavior when workflows require a GTF.

- Fixed the schema panel configured counter so it reflects all rendered rows (including gene annotation), matching what users see.
- Updated gene annotation status presentation so optional cases show **Optional** instead of looking incomplete.
- Tightened assistant empty-state and welcome copy to better reflect the actual catalog → Galaxy workflow.
- Expanded the learn page with clearer assistant limitations copy.
- Added backend status handling so `gene_annotation` correctly reflects workflow `GENE_MODEL_URL` requirements (required-and-missing now surfaces as **Attention**, while truly optional workflows remain **Optional**).

## Related Issue

Issue linking is handled separately by the system.