### PR TITLE
fix: hide non-assembly-scope workflows from the assistant (#1321)

### DIFF
--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -31,7 +31,7 @@ from app.models.assistant import (
     TokenUsage,
 )
 from app.services.session_service import SessionService
-from app.services.tools.catalog_data import CatalogData
+from app.services.tools.catalog_data import CatalogData, _is_assembly_scope
 from app.services.tools.catalog_tools import (
     AssistantDeps,
     check_compatibility,
@@ -765,6 +765,11 @@ class AssistantAgent:
                 workflow_value = str(value)
                 for cat in self.catalog.workflows_by_category:
                     for wf in cat.get("workflows", []):
+                        # Skip non-ASSEMBLY-scope workflows so an LLM-emitted
+                        # SCHEMA_UPDATE can't populate a handoff-capable detail
+                        # for a workflow the catalog tools hide (#1321).
+                        if not _is_assembly_scope(wf):
+                            continue
                         iwc_id = wf.get("iwcId")
                         if iwc_id and iwc_id in workflow_value:
                             # `.get("trsId", iwc_id)` would keep a None trsId;
@@ -830,6 +835,8 @@ class AssistantAgent:
         val_lower = value.lower()
         for cat in self.catalog.workflows_by_category:
             for wf in cat.get("workflows", []):
+                if not _is_assembly_scope(wf):
+                    continue
                 wf_name = (wf.get("workflowName") or "").lower()
                 if wf_name and (wf_name in val_lower or val_lower in wf_name):
                     logger.info("Workflow fallback matched name '%s'", wf_name)

--- a/backend/api/app/services/catalog_data.py
+++ b/backend/api/app/services/catalog_data.py
@@ -290,7 +290,10 @@ class CatalogData:
         (sequencing data) as unresolved.
         """
         wf = self._workflows_by_iwc_id.get(iwc_id)
-        if not wf:
+        # Fail closed for non-ASSEMBLY-scope workflows: resolving inputs for one
+        # would expose its name/TRS id/parameters by IWC id even though the
+        # listing tools hide it (#1321).
+        if not wf or not _is_assembly_scope(wf):
             raise ValueError(f"Workflow '{iwc_id}' not found")
         asm = self._assemblies_by_accession.get(accession)
         if not asm:

--- a/backend/api/app/services/catalog_data.py
+++ b/backend/api/app/services/catalog_data.py
@@ -6,6 +6,14 @@ from typing import Any, Dict, List, Optional, Set
 logger = logging.getLogger(__name__)
 
 
+def _is_assembly_scope(wf: Dict[str, Any]) -> bool:
+    """The guided single-organism/single-assembly flow can't drive ORGANISM- or
+    comparative-scoped workflows, so they're hidden from the workflow-enumeration
+    tools (matching the frontend's default ASSEMBLY-only view). Missing scope
+    defaults to ASSEMBLY."""
+    return (wf.get("scope") or "ASSEMBLY") == "ASSEMBLY"
+
+
 class CatalogData:
     """
     Loads the full BRC catalog (organisms, assemblies, workflows) into memory
@@ -175,7 +183,9 @@ class CatalogData:
                 "category": cat.get("category"),
                 "name": cat.get("name"),
                 "description": cat.get("description"),
-                "workflowCount": len(cat.get("workflows", [])),
+                "workflowCount": sum(
+                    1 for wf in cat.get("workflows", []) if _is_assembly_scope(wf)
+                ),
             }
             for cat in self.workflow_categories
         ]
@@ -187,7 +197,11 @@ class CatalogData:
                 cat.get("category", "").lower() == cat_lower
                 or cat.get("name", "").lower() == cat_lower
             ):
-                return [self._condense_workflow(wf) for wf in cat.get("workflows", [])]
+                return [
+                    self._condense_workflow(wf)
+                    for wf in cat.get("workflows", [])
+                    if _is_assembly_scope(wf)
+                ]
         return []
 
     def get_compatible_workflows(
@@ -197,6 +211,8 @@ class CatalogData:
         results = []
         for cat in self.workflow_categories:
             for wf in cat.get("workflows", []):
+                if not _is_assembly_scope(wf):
+                    continue
                 wf_ploidy = wf.get("ploidy")
                 wf_tax = wf.get("taxonomyId")
                 # Ploidy must match (None/ANY = universal)
@@ -218,7 +234,7 @@ class CatalogData:
 
     def get_workflow_details(self, iwc_id: str) -> Optional[Dict[str, Any]]:
         wf = self._workflows_by_iwc_id.get(iwc_id)
-        if wf:
+        if wf and _is_assembly_scope(wf):
             return self._condense_workflow(wf)
         return None
 
@@ -227,7 +243,7 @@ class CatalogData:
     ) -> Dict[str, Any]:
         wf = self._workflows_by_iwc_id.get(iwc_id)
         asm = self._assemblies_by_accession.get(accession)
-        if not wf:
+        if not wf or not _is_assembly_scope(wf):
             return {"compatible": False, "reason": f"Workflow '{iwc_id}' not found"}
         if not asm:
             return {"compatible": False, "reason": f"Assembly '{accession}' not found"}

--- a/backend/api/app/services/tools/catalog_data.py
+++ b/backend/api/app/services/tools/catalog_data.py
@@ -22,6 +22,13 @@ logger = logging.getLogger(__name__)
 _PLOIDY_ANY = "ANY"
 
 
+def _is_assembly_scope(wf: Dict[str, Any]) -> bool:
+    """The assistant only drives the single-organism/single-assembly flow, so it
+    only sees ASSEMBLY-scope workflows (matching the frontend's default view).
+    Organism- and comparative-scoped workflows are hidden from it."""
+    return (wf.get("scope") or "ASSEMBLY") == "ASSEMBLY"
+
+
 class CatalogData:
     def __init__(self, catalog_path: str):
         self.catalog_path = Path(catalog_path)
@@ -235,7 +242,9 @@ class CatalogData:
                 "category": cat.get("category"),
                 "name": cat.get("name"),
                 "description": cat.get("description"),
-                "workflow_count": len(cat.get("workflows", [])),
+                "workflow_count": sum(
+                    1 for wf in cat.get("workflows", []) if _is_assembly_scope(wf)
+                ),
             }
             for cat in self.workflows_by_category
         ]
@@ -247,6 +256,7 @@ class CatalogData:
                 return [
                     self._summarize_workflow(wf, cat.get("name", ""))
                     for wf in cat.get("workflows", [])
+                    if _is_assembly_scope(wf)
                 ]
         return []
 
@@ -257,6 +267,8 @@ class CatalogData:
         results = []
         for cat in self.workflows_by_category:
             for wf in cat.get("workflows", []):
+                if not _is_assembly_scope(wf):
+                    continue
                 wf_ploidy = wf.get("ploidy", _PLOIDY_ANY)
                 wf_tax = wf.get("taxonomyId")
 
@@ -272,7 +284,7 @@ class CatalogData:
     def get_workflow_details(self, iwc_id: str) -> Optional[Dict[str, Any]]:
         for cat in self.workflows_by_category:
             for wf in cat.get("workflows", []):
-                if wf.get("iwcId") == iwc_id:
+                if wf.get("iwcId") == iwc_id and _is_assembly_scope(wf):
                     return self._summarize_workflow(
                         wf, cat.get("name", ""), include_params=True
                     )

--- a/backend/api/app/services/tools/catalog_data.py
+++ b/backend/api/app/services/tools/catalog_data.py
@@ -25,7 +25,9 @@ _PLOIDY_ANY = "ANY"
 def _is_assembly_scope(wf: Dict[str, Any]) -> bool:
     """The assistant only drives the single-organism/single-assembly flow, so it
     only sees ASSEMBLY-scope workflows (matching the frontend's default view).
-    Organism- and comparative-scoped workflows are hidden from it."""
+    Organism- and comparative-scoped workflows are hidden from it. A workflow
+    with no scope set is treated as ASSEMBLY, matching the MCP server's
+    CatalogData."""
     return (wf.get("scope") or "ASSEMBLY") == "ASSEMBLY"
 
 

--- a/backend/api/tests/test_assistant_agent.py
+++ b/backend/api/tests/test_assistant_agent.py
@@ -364,6 +364,50 @@ class TestApplySchemaUpdates:
         assert result.organism.value == "Existing"
         assert result.assembly.detail == "GCF_000146045.2"
 
+    def test_organism_scope_workflow_not_resolved(self, agent):
+        # An ORGANISM-scope workflow named in a SCHEMA_UPDATE must NOT populate a
+        # handoff-capable trsId, even on an exact iwcId match -- otherwise it
+        # bypasses the scope filter on the catalog tools (#1321).
+        agent.catalog.workflows_by_category = [
+            {
+                "category": "ASSEMBLY",
+                "workflows": [
+                    {
+                        "iwcId": "assembly-with-flye",
+                        "workflowName": "Assembly with Flye",
+                        "scope": "ORGANISM",
+                        "trsId": "#workflow/github.com/iwc/assembly-with-flye/main",
+                    }
+                ],
+            }
+        ]
+        schema = AnalysisSchema()
+        result = agent._apply_schema_updates(
+            schema, {"workflow": "Assembly with Flye (assembly-with-flye)"}
+        )
+        assert result.workflow.detail is None
+
+    def test_assembly_scope_workflow_still_resolves(self, agent):
+        # Sanity: a same-shaped ASSEMBLY-scope workflow still resolves its trsId.
+        agent.catalog.workflows_by_category = [
+            {
+                "category": "TRANSCRIPTOMICS",
+                "workflows": [
+                    {
+                        "iwcId": "rnaseq-pe",
+                        "workflowName": "RNA-Seq PE",
+                        "scope": "ASSEMBLY",
+                        "trsId": "#workflow/github.com/iwc/rnaseq-pe/main",
+                    }
+                ],
+            }
+        ]
+        schema = AnalysisSchema()
+        result = agent._apply_schema_updates(
+            schema, {"workflow": "RNA-Seq PE (rnaseq-pe)"}
+        )
+        assert result.workflow.detail == "#workflow/github.com/iwc/rnaseq-pe/main"
+
 
 # ---------- compute_handoff ----------
 

--- a/backend/api/tests/test_catalog_data.py
+++ b/backend/api/tests/test_catalog_data.py
@@ -85,6 +85,7 @@ SAMPLE_WORKFLOWS = [
                 "iwcId": "rnaseq-pe",
                 "workflowName": "RNA-Seq Paired End",
                 "workflowDescription": "PE RNA-Seq analysis",
+                "scope": "ASSEMBLY",
                 "ploidy": "ANY",
                 "trsId": "#workflow/github.com/iwc/rnaseq-pe/main",
                 "parameters": [
@@ -102,6 +103,7 @@ SAMPLE_WORKFLOWS = [
                 "iwcId": "varcall-haploid",
                 "workflowName": "Variant Calling (Haploid)",
                 "workflowDescription": "Haploid variant calling",
+                "scope": "ASSEMBLY",
                 "ploidy": "HAPLOID",
                 "trsId": "#workflow/github.com/iwc/varcall-haploid/main",
                 "taxonomyId": None,
@@ -111,8 +113,23 @@ SAMPLE_WORKFLOWS = [
                 "iwcId": "varcall-diploid",
                 "workflowName": "Variant Calling (Diploid)",
                 "workflowDescription": "Diploid variant calling",
+                "scope": "ASSEMBLY",
                 "ploidy": "DIPLOID",
                 "trsId": "#workflow/github.com/iwc/varcall-diploid/main",
+                "taxonomyId": None,
+                "parameters": [],
+            },
+            {
+                # ORGANISM-scope (assembly-building) workflow: ANY ploidy and no
+                # taxonomy restriction, so it WOULD match if scope were ignored.
+                # The assistant can't drive its 0/2+-assembly flow, so it must be
+                # hidden from every catalog tool (#1321).
+                "iwcId": "assembly-with-flye",
+                "workflowName": "Assembly with Flye",
+                "workflowDescription": "Long-read de novo genome assembly",
+                "scope": "ORGANISM",
+                "ploidy": "ANY",
+                "trsId": "#workflow/github.com/iwc/assembly-with-flye/main",
                 "taxonomyId": None,
                 "parameters": [],
             },
@@ -333,6 +350,64 @@ class TestCompatibilityCheck:
         )
         assert result["compatible"] is False
         assert "not found" in result["reason"].lower()
+
+
+# ---------- Scope filtering (#1321) ----------
+
+
+class TestScopeFiltering:
+    """Non-ASSEMBLY-scope workflows are hidden from every assistant tool.
+
+    The assistant only drives the single-organism/single-assembly flow, so
+    ORGANISM- and comparative-scope workflows it can't drive must not surface
+    (matching the frontend's default ASSEMBLY-only view).
+    """
+
+    def test_organism_scope_absent_from_category_listing(self, catalog):
+        wfs = catalog.get_workflows_in_category("VARIANT_CALLING")
+        iwc_ids = {w["iwc_id"] for w in wfs}
+        assert "assembly-with-flye" not in iwc_ids
+        # only the two ASSEMBLY-scope workflows remain
+        assert len(wfs) == 2
+
+    def test_organism_scope_absent_from_compatible(self, catalog):
+        # ANY ploidy + no taxonomy restriction would match if scope were ignored.
+        wfs = catalog.get_compatible_workflows(["HAPLOID"])
+        iwc_ids = {w["iwc_id"] for w in wfs}
+        assert "assembly-with-flye" not in iwc_ids
+
+    def test_organism_scope_details_returns_none(self, catalog):
+        assert catalog.get_workflow_details("assembly-with-flye") is None
+
+    def test_organism_scope_not_counted_in_categories(self, catalog):
+        by_cat = {c["category"]: c for c in catalog.get_workflow_categories()}
+        # VARIANT_CALLING holds 3 raw workflows but one is ORGANISM-scope.
+        assert by_cat["VARIANT_CALLING"]["workflow_count"] == 2
+
+    def test_missing_scope_defaults_to_assembly(self, tmp_path):
+        # A workflow with no scope field is treated as ASSEMBLY (frontend default).
+        workflows = [
+            {
+                "category": "OTHER",
+                "name": "Other",
+                "description": "No-scope workflow",
+                "workflows": [
+                    {
+                        "iwcId": "no-scope-wf",
+                        "workflowName": "Scopeless",
+                        "workflowDescription": "Has no scope field",
+                        "ploidy": "ANY",
+                        "trsId": "#workflow/github.com/iwc/no-scope/main",
+                        "parameters": [],
+                    },
+                ],
+            },
+        ]
+        (tmp_path / "organisms.json").write_text(json.dumps([]))
+        (tmp_path / "workflows.json").write_text(json.dumps(workflows))
+        c = CatalogData(str(tmp_path))
+        assert c.get_workflow_details("no-scope-wf") is not None
+        assert c.get_workflow_categories()[0]["workflow_count"] == 1
 
 
 # ---------- Lineage-based taxonomy matching (#1319) ----------

--- a/backend/api/tests/test_mcp_catalog_scope.py
+++ b/backend/api/tests/test_mcp_catalog_scope.py
@@ -42,3 +42,10 @@ class TestMcpScopeFiltering:
         by_cat = {c["category"]: c for c in mcp_catalog.get_workflow_categories()}
         # VARIANT_CALLING holds 3 raw workflows but one is ORGANISM-scope.
         assert by_cat["VARIANT_CALLING"]["workflowCount"] == 2
+
+    def test_organism_scope_inputs_not_resolved(self, mcp_catalog):
+        # resolve_workflow_inputs must fail closed -- otherwise it leaks the
+        # hidden workflow's name/TRS id/params to any caller that knows the
+        # IWC id (#1321). Scope check fires before the assembly lookup.
+        with pytest.raises(ValueError):
+            mcp_catalog.resolve_workflow_inputs("assembly-with-flye", "GCF_000000000.0")

--- a/backend/api/tests/test_mcp_catalog_scope.py
+++ b/backend/api/tests/test_mcp_catalog_scope.py
@@ -1,0 +1,44 @@
+"""Scope filtering for the MCP-server CatalogData (#1321).
+
+The MCP server uses app.services.catalog_data.CatalogData, which is a separate
+implementation from the assistant's app.services.tools.catalog_data.CatalogData
+(covered in test_catalog_data.py). Both must hide non-ASSEMBLY-scope workflows
+the guided single-organism/single-assembly flow can't drive.
+"""
+
+import json
+
+import pytest
+
+from app.services.catalog_data import CatalogData
+from tests.test_catalog_data import SAMPLE_ORGANISMS, SAMPLE_WORKFLOWS
+
+
+@pytest.fixture
+def mcp_catalog(tmp_path):
+    (tmp_path / "organisms.json").write_text(json.dumps(SAMPLE_ORGANISMS))
+    (tmp_path / "workflows.json").write_text(json.dumps(SAMPLE_WORKFLOWS))
+    return CatalogData(str(tmp_path))
+
+
+class TestMcpScopeFiltering:
+    """The ORGANISM-scope `assembly-with-flye` fixture must not surface via MCP."""
+
+    def test_organism_scope_absent_from_category_listing(self, mcp_catalog):
+        wfs = mcp_catalog.get_workflows_in_category("VARIANT_CALLING")
+        iwc_ids = {w["iwcId"] for w in wfs}
+        assert "assembly-with-flye" not in iwc_ids
+        assert len(wfs) == 2
+
+    def test_organism_scope_absent_from_compatible(self, mcp_catalog):
+        # ANY ploidy + no taxonomy restriction would match if scope were ignored.
+        wfs = mcp_catalog.get_compatible_workflows(["HAPLOID"])
+        assert "assembly-with-flye" not in {w["iwcId"] for w in wfs}
+
+    def test_organism_scope_details_returns_none(self, mcp_catalog):
+        assert mcp_catalog.get_workflow_details("assembly-with-flye") is None
+
+    def test_organism_scope_not_counted_in_categories(self, mcp_catalog):
+        by_cat = {c["category"]: c for c in mcp_catalog.get_workflow_categories()}
+        # VARIANT_CALLING holds 3 raw workflows but one is ORGANISM-scope.
+        assert by_cat["VARIANT_CALLING"]["workflowCount"] == 2


### PR DESCRIPTION
Stacks on #1328 (the taxonomy-lineage fix) -- this branch is based on `assistant-workflow-taxonomy-lineage`, so it should merge after #1328. Until then the diff below also includes #1328's commits.

## Problem

The assistant exposes every workflow in the catalog, including the 4 ORGANISM-scoped ones (`influenza-isolates-consensus-and-subtyping-main`, `assembly-with-flye-main`, `bacterial-genome-assembly-main`, `hyphy-capheine-core-and-compare`). Those are assembly-building / comparative-genomics workflows whose 0- or 2+-assembly flow the assistant's single-organism/single-assembly model can't drive, so it lists them and then gets confused about what to do with them (#1321).

## Fix

Mirror the frontend's default view (which filters to `scope === "ASSEMBLY"`): hide non-ASSEMBLY workflows from every catalog tool. A module-level `_is_assembly_scope` helper (treating a missing scope as ASSEMBLY, like the frontend default) is applied in the four enumerating methods -- category counts, category listings, compatible-workflow search, and detail lookup.

The assistant and the MCP server use **separate** `CatalogData` implementations (`app/services/tools/catalog_data.py` and `app/services/catalog_data.py`), so the filter is applied in both (the MCP copy also guards `check_workflow_assembly_compatibility`). Thanks to @copilot-pull-request-reviewer for catching that the MCP path was initially missed.

The #1319 taxonomy/lineage logic is untouched.

## Tests

Added `scope` to the test fixtures and a `TestScopeFiltering` class asserting an ORGANISM-scoped workflow is absent from category listings and compatible-workflow results, returns `None` from detail lookup, and isn't counted in category counts -- plus a missing-scope-defaults-to-ASSEMBLY case. The assistant `CatalogData` has 45 passing tests (40 existing incl. the #1319 lineage tests + 5 new); a new `test_mcp_catalog_scope.py` adds 4 more for the MCP `CatalogData`.
