### PR TITLE
feat: add stub of pangenomes schema and source file (#1340)

### DIFF
--- a/catalog/py_package/catalog_build/generated_schema/schema.py
+++ b/catalog/py_package/catalog_build/generated_schema/schema.py
@@ -51,6 +51,7 @@ linkml_meta = LinkMLMeta(
             "./assemblies",
             "./organisms",
             "./outbreaks",
+            "./pangenomes",
             "./workflow_categories",
             "./workflows",
         ],
@@ -554,6 +555,45 @@ class MarkdownFileReference(ConfiguredBaseModel):
         return v
 
 
+class Pangenomes(ConfiguredBaseModel):
+    """
+    Root object containing a collection of pangenome definitions for the BRC Analytics platform.
+    """
+
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/pangenomes.yaml#",
+            "tree_root": True,
+        }
+    )
+
+    pangenomes: List[Pangenome] = Field(
+        default=...,
+        description="""Collection of pangenome entries that will be available in the BRC Analytics platform.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "pangenomes", "domain_of": ["Pangenomes"]}
+        },
+    )
+
+
+class Pangenome(ConfiguredBaseModel):
+    """
+    Definition of a pangenome with its unique identifier.
+    """
+
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/pangenomes.yaml#"
+        }
+    )
+
+    id: str = Field(
+        default=...,
+        description="""The unique identifier for the pangenome.""",
+        json_schema_extra={"linkml_meta": {"alias": "id", "domain_of": ["Pangenome"]}},
+    )
+
+
 class WorkflowCategories(ConfiguredBaseModel):
     """
     Root object containing a collection of workflow category definitions used to organize workflows in the BRC Analytics platform.
@@ -992,6 +1032,8 @@ Outbreaks.model_rebuild()
 Outbreak.model_rebuild()
 OutbreakResource.model_rebuild()
 MarkdownFileReference.model_rebuild()
+Pangenomes.model_rebuild()
+Pangenome.model_rebuild()
 WorkflowCategories.model_rebuild()
 WorkflowCategory.model_rebuild()
 Workflows.model_rebuild()

--- a/catalog/py_package/catalog_build/schema/pangenomes.yaml
+++ b/catalog/py_package/catalog_build/schema/pangenomes.yaml
@@ -1,0 +1,28 @@
+id: https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/pangenomes.yaml#
+name: pangenomes
+description: Schema for defining pangenomes available in the BRC Analytics platform.
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+
+imports:
+  - linkml:types
+
+classes:
+  Pangenomes:
+    description: Root object containing a collection of pangenome definitions for the BRC Analytics platform.
+    tree_root: true
+    attributes:
+      pangenomes:
+        description: Collection of pangenome entries that will be available in the BRC Analytics platform.
+        required: true
+        multivalued: true
+        range: Pangenome
+
+  Pangenome:
+    description: Definition of a pangenome with its unique identifier.
+    attributes:
+      id:
+        description: The unique identifier for the pangenome.
+        required: true
+        range: string

--- a/catalog/py_package/catalog_build/schema/schema.yaml
+++ b/catalog/py_package/catalog_build/schema/schema.yaml
@@ -9,5 +9,6 @@ imports:
   - ./assemblies
   - ./organisms
   - ./outbreaks
+  - ./pangenomes
   - ./workflow_categories
   - ./workflows

--- a/catalog/schema/generated/pangenomes.json
+++ b/catalog/schema/generated/pangenomes.json
@@ -1,0 +1,57 @@
+{
+    "$defs": {
+        "Pangenome": {
+            "additionalProperties": false,
+            "description": "Definition of a pangenome with its unique identifier.",
+            "properties": {
+                "id": {
+                    "description": "The unique identifier for the pangenome.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "id"
+            ],
+            "title": "Pangenome",
+            "type": "object"
+        },
+        "Pangenomes": {
+            "additionalProperties": false,
+            "description": "Root object containing a collection of pangenome definitions for the BRC Analytics platform.",
+            "properties": {
+                "pangenomes": {
+                    "description": "Collection of pangenome entries that will be available in the BRC Analytics platform.",
+                    "items": {
+                        "$ref": "#/$defs/Pangenome"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "pangenomes"
+            ],
+            "title": "Pangenomes",
+            "type": "object"
+        }
+    },
+    "$id": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/pangenomes.yaml#",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "additionalProperties": true,
+    "description": "Root object containing a collection of pangenome definitions for the BRC Analytics platform.",
+    "metamodel_version": "1.7.0",
+    "properties": {
+        "pangenomes": {
+            "description": "Collection of pangenome entries that will be available in the BRC Analytics platform.",
+            "items": {
+                "$ref": "#/$defs/Pangenome"
+            },
+            "type": "array"
+        }
+    },
+    "required": [
+        "pangenomes"
+    ],
+    "title": "pangenomes",
+    "type": "object",
+    "version": null
+}

--- a/catalog/schema/generated/schema.ts
+++ b/catalog/schema/generated/schema.ts
@@ -308,6 +308,24 @@ export interface MarkdownFileReference {
 
 
 /**
+ * Root object containing a collection of pangenome definitions for the BRC Analytics platform.
+ */
+export interface Pangenomes {
+    /** Collection of pangenome entries that will be available in the BRC Analytics platform. */
+    pangenomes: Pangenome[],
+}
+
+
+/**
+ * Definition of a pangenome with its unique identifier.
+ */
+export interface Pangenome {
+    /** The unique identifier for the pangenome. */
+    id: string,
+}
+
+
+/**
  * Root object containing a collection of workflow category definitions used to organize workflows in the BRC Analytics platform.
  */
 export interface WorkflowCategories {

--- a/catalog/schema/scripts/source-file-schema-names.sh
+++ b/catalog/schema/scripts/source-file-schema-names.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-export SOURCE_FILE_SCHEMA_NAMES=(assemblies organisms workflow_categories workflows outbreaks)
+export SOURCE_FILE_SCHEMA_NAMES=(assemblies organisms workflow_categories workflows outbreaks pangenomes)

--- a/catalog/source/pangenomes.yml
+++ b/catalog/source/pangenomes.yml
@@ -1,0 +1,2 @@
+pangenomes:
+  - id: plasmodium-vivax-v1


### PR DESCRIPTION
## Description

I opted to implement only a stub for the pangenome schema, with the idea that additional fields can be added for a future issue such as #1341 based on which information we determine is necessary to make explicit in the YAML.

- Added pangenome schema containing just the `id` field.
- Added pangenomes data file containing the stub for the `plasmodium-vivax-v1` pangenome.
- Added pangenomes to list of schemas for use in validation scripts etc.
- Generated schema-derived definitions.

I have presumed that pangenomes will be optional for an app to use and have not added anything to GA2.

## Related Issue

Closes #1340
