### PR TITLE
fix: pass relative paths to linkml generators (#1347)

### DIFF
--- a/catalog/py_package/catalog_build/generated_schema/schema.py
+++ b/catalog/py_package/catalog_build/generated_schema/schema.py
@@ -42,7 +42,28 @@ class LinkMLMeta(RootModel):
         return key in self.root
 
 
-linkml_meta = None
+linkml_meta = LinkMLMeta(
+    {
+        "default_prefix": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/schema.yaml#",
+        "description": "Combined source data schemas.",
+        "id": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/schema.yaml#",
+        "imports": [
+            "./assemblies",
+            "./organisms",
+            "./outbreaks",
+            "./workflow_categories",
+            "./workflows",
+        ],
+        "name": "schema",
+        "prefixes": {
+            "linkml": {
+                "prefix_prefix": "linkml",
+                "prefix_reference": "https://w3id.org/linkml/",
+            }
+        },
+        "source_file": "catalog/py_package/catalog_build/schema/schema.yaml",
+    }
+)
 
 
 class OrganismPloidy(str, Enum):
@@ -278,9 +299,19 @@ class Assemblies(ConfiguredBaseModel):
     Root object containing a collection of genomic assembly definitions for the BRC Analytics platform.
     """
 
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/assemblies.yaml#",
+            "tree_root": True,
+        }
+    )
+
     assemblies: List[Assembly] = Field(
         default=...,
         description="""Collection of genomic assembly entries that will be available for analysis in the BRC Analytics platform.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "assemblies", "domain_of": ["Assemblies"]}
+        },
     )
 
 
@@ -289,9 +320,18 @@ class Assembly(ConfiguredBaseModel):
     Definition of a genomic assembly with its unique identifier.
     """
 
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/assemblies.yaml#"
+        }
+    )
+
     accession: str = Field(
         default=...,
         description="""The unique accession identifier for the assembly (e.g., GCA_000001405.28 for GRCh38), used to retrieve the assembly data from public repositories.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "accession", "domain_of": ["Assembly"]}
+        },
     )
 
 
@@ -300,9 +340,19 @@ class Organisms(ConfiguredBaseModel):
     Root object containing a collection of organism definitions for the BRC Analytics platform.
     """
 
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/organisms.yaml#",
+            "tree_root": True,
+        }
+    )
+
     organisms: List[Organism] = Field(
         default=...,
         description="""Collection of organism entries that will be available in the BRC Analytics platform.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "organisms", "domain_of": ["Organisms"]}
+        },
     )
 
 
@@ -311,12 +361,28 @@ class Organism(ConfiguredBaseModel):
     Definition of an organism with its taxonomic and genetic characteristics.
     """
 
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/organisms.yaml#"
+        }
+    )
+
     taxonomy_id: int = Field(
-        default=..., description="""An NCBI Taxonomy ID at rank 'species'."""
+        default=...,
+        description="""An NCBI Taxonomy ID at rank 'species'.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "taxonomy_id",
+                "domain_of": ["Organism", "Outbreak", "Workflow"],
+            }
+        },
     )
     ploidy: List[OrganismPloidy] = Field(
         default=...,
         description="""The possible ploidy states (number of chromosome sets) that the organism may have, which determines compatible workflows.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "ploidy", "domain_of": ["Organism", "Workflow"]}
+        },
     )
 
 
@@ -325,9 +391,19 @@ class Outbreaks(ConfiguredBaseModel):
     Root object containing a collection of pathogen definitions for the BRC Analytics platform to highlight as outbreaks/priority pathogens.
     """
 
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/outbreaks.yaml#",
+            "tree_root": True,
+        }
+    )
+
     outbreaks: List[Outbreak] = Field(
         default=...,
         description="""Collection of pathogen entries that will be displayed in the BRC Analytics platform as outbreaks/priority pathogens.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "outbreaks", "domain_of": ["Outbreaks"]}
+        },
     )
 
 
@@ -336,33 +412,76 @@ class Outbreak(ConfiguredBaseModel):
     Definition of a priority pathogen with its taxonomic classification, priority level, and associated resources.
     """
 
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/outbreaks.yaml#"
+        }
+    )
+
     name: str = Field(
         default=...,
         description="""The display name of the pathogen as it will appear in the BRC Analytics interface.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Outbreak", "WorkflowCategory", "WorkflowCollectionSpec"],
+            }
+        },
     )
     taxonomy_id: int = Field(
         default=...,
         description="""The NCBI Taxonomy ID for the pathogen. Used to link to relevant genomic data and workflows.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "taxonomy_id",
+                "domain_of": ["Organism", "Outbreak", "Workflow"],
+            }
+        },
     )
     priority: OutbreakPriority = Field(
         default=...,
         description="""The priority level of the pathogen, which determines its visibility and prominence in the BRC Analytics interface.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "priority", "domain_of": ["Outbreak"]}
+        },
     )
     resources: List[OutbreakResource] = Field(
         default=...,
         description="""Collection of external resources (references, tools, databases) related to the pathogen.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "resources", "domain_of": ["Outbreak"]}
+        },
     )
     description: MarkdownFileReference = Field(
         default=...,
         description="""Reference to a markdown file containing detailed information about the pathogen.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": [
+                    "Outbreak",
+                    "WorkflowCategory",
+                    "WorkflowDataRequirements",
+                ],
+            }
+        },
     )
     active: bool = Field(
         default=...,
         description="""Boolean flag that determines if the pathogen should be included in the BRC Analytics interface. Used to manage visibility as pathogen relevance changes over time.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "active", "domain_of": ["Outbreak", "Workflow"]}
+        },
     )
     highlight_descendant_taxonomy_ids: Optional[List[int]] = Field(
         default=None,
         description="""List of NCBI Taxonomy IDs for descendant taxa (e.g., specific strains or serotypes) that should be highlighted within the outbreak category.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "highlight_descendant_taxonomy_ids",
+                "domain_of": ["Outbreak"],
+            }
+        },
     )
 
 
@@ -371,17 +490,35 @@ class OutbreakResource(ConfiguredBaseModel):
     Definition of an external resource (reference, tool, database) associated with a priority pathogen.
     """
 
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/outbreaks.yaml#"
+        }
+    )
+
     url: str = Field(
         default=...,
         description="""The complete URL (including http/https protocol) to the external resource.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["OutbreakResource", "WorkflowUrlSpec"],
+            }
+        },
     )
     title: str = Field(
         default=...,
         description="""The display title for the resource link as it will appear in the BRC Analytics interface.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "title", "domain_of": ["OutbreakResource"]}
+        },
     )
     type: OutbreakResourceType = Field(
         default=...,
         description="""The category or type of the resource (e.g., REFERENCE, TOOL, DATABASE), which determines how it is displayed and organized.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "type", "domain_of": ["OutbreakResource"]}
+        },
     )
 
 
@@ -390,9 +527,18 @@ class MarkdownFileReference(ConfiguredBaseModel):
     A reference to a markdown file containing detailed content about a priority pathogen.
     """
 
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/outbreaks.yaml#"
+        }
+    )
+
     path: str = Field(
         default=...,
         description="""Relative path to the markdown file from the project root. Must end with .md extension.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "path", "domain_of": ["MarkdownFileReference"]}
+        },
     )
 
     @field_validator("path")
@@ -413,9 +559,22 @@ class WorkflowCategories(ConfiguredBaseModel):
     Root object containing a collection of workflow category definitions used to organize workflows in the BRC Analytics platform.
     """
 
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflow_categories.yaml#",
+            "tree_root": True,
+        }
+    )
+
     workflow_categories: List[WorkflowCategory] = Field(
         default=...,
         description="""Collection of workflow category entries that will be used to group and organize workflows in the BRC Analytics interface.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "workflow_categories",
+                "domain_of": ["WorkflowCategories"],
+            }
+        },
     )
 
 
@@ -424,21 +583,52 @@ class WorkflowCategory(ConfiguredBaseModel):
     Definition of a workflow category used to group related workflows for organization and display purposes.
     """
 
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflow_categories.yaml#"
+        }
+    )
+
     category: WorkflowCategoryId = Field(
         default=...,
         description="""The unique identifier for the workflow category, used to link workflows to their respective categories.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "category", "domain_of": ["WorkflowCategory"]}
+        },
     )
     name: str = Field(
         default=...,
         description="""The human-readable display name of the workflow category as it will appear in the BRC Analytics interface.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Outbreak", "WorkflowCategory", "WorkflowCollectionSpec"],
+            }
+        },
     )
     description: str = Field(
         default=...,
         description="""A detailed description of the workflow category explaining its purpose and the types of workflows it contains.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": [
+                    "Outbreak",
+                    "WorkflowCategory",
+                    "WorkflowDataRequirements",
+                ],
+            }
+        },
     )
     show_coming_soon: bool = Field(
         default=...,
         description="""Boolean flag that determines whether to display a 'Coming Soon' indicator for this category in the BRC Analytics interface when workflows in this category are not yet available.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "show_coming_soon",
+                "domain_of": ["WorkflowCategory"],
+            }
+        },
     )
 
 
@@ -447,9 +637,19 @@ class Workflows(ConfiguredBaseModel):
     Root object containing a collection of Galaxy workflow definitions for the BRC Analytics platform.
     """
 
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#",
+            "tree_root": True,
+        }
+    )
+
     workflows: List[Workflow] = Field(
         default=...,
         description="""Collection of workflow entries that will be available to users in the BRC Analytics platform.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "workflows", "domain_of": ["Workflows"]}
+        },
     )
 
 
@@ -458,53 +658,98 @@ class Workflow(ConfiguredBaseModel):
     Definition of a Galaxy workflow with its metadata, parameters, and organism compatibility information.
     """
 
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#"
+        }
+    )
+
     trs_id: str = Field(
         default=...,
         description="""The Tool Repository Service (TRS) identifier for the workflow, used to locate and retrieve the workflow from a Galaxy server.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "trs_id", "domain_of": ["Workflow"]}
+        },
     )
     categories: List[WorkflowCategoryId] = Field(
         default=...,
         description="""List of category identifiers that this workflow belongs to, determining how it is organized and displayed in the BRC Analytics interface.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "categories", "domain_of": ["Workflow"]}
+        },
     )
     workflow_name: str = Field(
         default=...,
         description="""The human-readable display name of the workflow as it will appear in the BRC Analytics interface.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "workflow_name", "domain_of": ["Workflow"]}
+        },
     )
     workflow_description: str = Field(
         default=...,
         description="""A detailed description of the workflow's purpose, functionality, and expected outputs for users.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "workflow_description", "domain_of": ["Workflow"]}
+        },
     )
     ploidy: WorkflowPloidy = Field(
         default=...,
         description="""The ploidy state (number of chromosome sets) that this workflow is designed to work with, ensuring compatibility with organism data.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "ploidy", "domain_of": ["Organism", "Workflow"]}
+        },
     )
     scope: Optional[WorkflowScope] = Field(
         default=None,
         description="""The scope level at which this workflow operates, determining where it is displayed in the UI and what the first configuration step should be. Defaults to ASSEMBLY for backward compatibility.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "scope", "domain_of": ["Workflow"]}
+        },
     )
     assembly_count_min: Optional[int] = Field(
         default=None,
         description="""The minimum number of genome assemblies a user must select for this workflow. Defaults to 1 for ASSEMBLY-scope workflows; must be set explicitly for ORGANISM and SEQUENCE scope. Use 0 for workflows that take no user-selected assemblies (e.g. assembly-building or curated-FASTA workflows).""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "assembly_count_min", "domain_of": ["Workflow"]}
+        },
     )
     assembly_count_max: Optional[int] = Field(
         default=None,
         description="""The maximum number of genome assemblies a user may select for this workflow. Null/absent means no upper limit. Defaults to 1 for ASSEMBLY-scope workflows; must be set explicitly for ORGANISM and SEQUENCE scope.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "assembly_count_max", "domain_of": ["Workflow"]}
+        },
     )
     taxonomy_id: Optional[int] = Field(
         default=None,
         description="""The NCBI Taxonomy ID of the organism this workflow is designed for. If specified, the workflow will be available for all assemblies with this ID in their taxonomic lineage.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "taxonomy_id",
+                "domain_of": ["Organism", "Outbreak", "Workflow"],
+            }
+        },
     )
     parameters: List[WorkflowParameter] = Field(
         default=...,
         description="""Collection of input parameters that will be passed to the workflow when it is executed, including data sources and configuration options.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "parameters", "domain_of": ["Workflow"]}
+        },
     )
     active: bool = Field(
         default=...,
         description="""Boolean flag that determines if the workflow should be included in the BRC Analytics interface. Used to manage visibility of workflows that may be under development or deprecated.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "active", "domain_of": ["Outbreak", "Workflow"]}
+        },
     )
     iwc_id: str = Field(
         default=...,
         description="""The Intergalactic Workflow Commission (IWC) identifier for the workflow, used to link to the workflow's page on the IWC website.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "iwc_id", "domain_of": ["Workflow"]}
+        },
     )
 
 
@@ -513,21 +758,55 @@ class WorkflowDataRequirements(ConfiguredBaseModel):
     Specification of data requirements for a workflow parameter, such as library strategy and layout.
     """
 
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#"
+        }
+    )
+
     library_strategy: Optional[List[LibraryStrategy]] = Field(
         default=None,
         description="""The library strategy values that are acceptable for this parameter (e.g., 'WGS', 'RNA-Seq').""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "library_strategy",
+                "domain_of": ["WorkflowDataRequirements"],
+            }
+        },
     )
     library_layout: Optional[LibraryLayout] = Field(
         default=None,
         description="""The library layout that is required for this parameter (e.g., 'PAIRED', 'SINGLE').""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "library_layout",
+                "domain_of": ["WorkflowDataRequirements"],
+            }
+        },
     )
     library_source: Optional[List[LibrarySource]] = Field(
         default=None,
         description="""The library source values that are acceptable for this parameter (e.g., 'GENOMIC', 'TRANSCRIPTOMIC SINGLE CELL').""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "library_source",
+                "domain_of": ["WorkflowDataRequirements"],
+            }
+        },
     )
     description: Optional[str] = Field(
         default=None,
         description="""A descriptive text to provide additional context about the data requirements, useful for non-standard library strategies like 'OTHER'.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "description",
+                "domain_of": [
+                    "Outbreak",
+                    "WorkflowCategory",
+                    "WorkflowDataRequirements",
+                ],
+            }
+        },
     )
 
 
@@ -552,18 +831,42 @@ class WorkflowCollectionSpec(ConfiguredBaseModel):
     ```
     """
 
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#"
+        }
+    )
+
     collection_type: CollectionType = Field(
         default=...,
         description="""The type of Galaxy collection to create. Currently only 'list' is supported. Determines the structure of the collection.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "collection_type",
+                "domain_of": ["WorkflowCollectionSpec"],
+            }
+        },
     )
     elements: List[WorkflowUrlSpec] = Field(
         default=...,
         description="""Array of URL specifications that will become elements in the collection. Each element represents a file to include in the collection. Must contain at least one element.""",
         min_length=1,
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "elements",
+                "domain_of": ["WorkflowCollectionSpec"],
+            }
+        },
     )
     name: Optional[str] = Field(
         default=None,
         description="""Optional identifier for the collection, used as the collection name in Galaxy. If not provided, defaults to 'Collection'.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "name",
+                "domain_of": ["Outbreak", "WorkflowCategory", "WorkflowCollectionSpec"],
+            }
+        },
     )
 
 
@@ -572,29 +875,59 @@ class WorkflowParameter(ConfiguredBaseModel):
     Definition of an input parameter for a Galaxy workflow, specifying how the parameter value should be determined when the workflow is executed.
     """
 
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#"
+        }
+    )
+
     key: str = Field(
         default=...,
         description="""The identifier for the parameter as expected by the Galaxy workflow, used to map the parameter value to the correct input.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "key", "domain_of": ["WorkflowParameter"]}
+        },
     )
     variable: Optional[WorkflowParameterVariable] = Field(
         default=None,
         description="""A predefined variable that will be substituted as the value of the parameter at runtime, such as assembly information.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "variable", "domain_of": ["WorkflowParameter"]}
+        },
     )
     collection_spec: Optional[WorkflowCollectionSpec] = Field(
         default=None,
         description="""A collection specification for the parameter, allowing multiple files from external sources to be provided as a Galaxy collection.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "collection_spec",
+                "domain_of": ["WorkflowParameter"],
+            }
+        },
     )
     url_spec: Optional[WorkflowUrlSpec] = Field(
         default=None,
         description="""A direct URL specification for the parameter, allowing for external data sources to be provided to the workflow.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "url_spec", "domain_of": ["WorkflowParameter"]}
+        },
     )
     data_requirements: Optional[WorkflowDataRequirements] = Field(
         default=None,
         description="""Specifications for the data requirements of this parameter, such as library strategy and layout.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "data_requirements",
+                "domain_of": ["WorkflowParameter"],
+            }
+        },
     )
     type_guide: Optional[Any] = Field(
         default=None,
         description="""Arbitrary data describing the expected type and format of the parameter, intended as a reference for catalog maintainers and not used in workflow execution.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "type_guide", "domain_of": ["WorkflowParameter"]}
+        },
     )
 
 
@@ -603,25 +936,49 @@ class WorkflowUrlSpec(ConfiguredBaseModel):
     Definition of a URL-based data source for a workflow parameter, typically used for reference data or external resources.
     """
 
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
+        {
+            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#"
+        }
+    )
+
     ext: str = Field(
         default=...,
         description="""The file extension of the resource at the URL, which determines how Galaxy will interpret the data (e.g., 'fasta', 'gff', 'tabular').""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "ext", "domain_of": ["WorkflowUrlSpec"]}
+        },
     )
     src: str = Field(
         default=...,
         description="""The source type for the parameter, typically 'url' to indicate an external URL source rather than a Galaxy dataset or other source type.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "src", "domain_of": ["WorkflowUrlSpec"]}
+        },
     )
     url: str = Field(
         default=...,
         description="""The complete URL (including http/https protocol) to the external resource that will be used as input to the workflow.""",
+        json_schema_extra={
+            "linkml_meta": {
+                "alias": "url",
+                "domain_of": ["OutbreakResource", "WorkflowUrlSpec"],
+            }
+        },
     )
     db_key: Optional[str] = Field(
         default=None,
         description="""Optional database key (genome build) to associate with this file, used by Galaxy to link the file to a specific reference genome.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "db_key", "domain_of": ["WorkflowUrlSpec"]}
+        },
     )
     md5: Optional[str] = Field(
         default=None,
         description="""Optional MD5 checksum hash for file integrity verification.""",
+        json_schema_extra={
+            "linkml_meta": {"alias": "md5", "domain_of": ["WorkflowUrlSpec"]}
+        },
     )
 
 

--- a/catalog/py_package/catalog_build/generated_schema/schema.py
+++ b/catalog/py_package/catalog_build/generated_schema/schema.py
@@ -42,28 +42,7 @@ class LinkMLMeta(RootModel):
         return key in self.root
 
 
-linkml_meta = LinkMLMeta(
-    {
-        "default_prefix": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/schema.yaml#",
-        "description": "Combined source data schemas.",
-        "id": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/schema.yaml#",
-        "imports": [
-            "./assemblies",
-            "./organisms",
-            "./outbreaks",
-            "./workflow_categories",
-            "./workflows",
-        ],
-        "name": "schema",
-        "prefixes": {
-            "linkml": {
-                "prefix_prefix": "linkml",
-                "prefix_reference": "https://w3id.org/linkml/",
-            }
-        },
-        "source_file": "/home/danielle/Documents/brc-analytics/brc-analytics/catalog/py_package/catalog_build/schema_utils/../schema/schema.yaml",
-    }
-)
+linkml_meta = None
 
 
 class OrganismPloidy(str, Enum):
@@ -299,19 +278,9 @@ class Assemblies(ConfiguredBaseModel):
     Root object containing a collection of genomic assembly definitions for the BRC Analytics platform.
     """
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/assemblies.yaml#",
-            "tree_root": True,
-        }
-    )
-
     assemblies: List[Assembly] = Field(
         default=...,
         description="""Collection of genomic assembly entries that will be available for analysis in the BRC Analytics platform.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "assemblies", "domain_of": ["Assemblies"]}
-        },
     )
 
 
@@ -320,18 +289,9 @@ class Assembly(ConfiguredBaseModel):
     Definition of a genomic assembly with its unique identifier.
     """
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/assemblies.yaml#"
-        }
-    )
-
     accession: str = Field(
         default=...,
         description="""The unique accession identifier for the assembly (e.g., GCA_000001405.28 for GRCh38), used to retrieve the assembly data from public repositories.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "accession", "domain_of": ["Assembly"]}
-        },
     )
 
 
@@ -340,19 +300,9 @@ class Organisms(ConfiguredBaseModel):
     Root object containing a collection of organism definitions for the BRC Analytics platform.
     """
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/organisms.yaml#",
-            "tree_root": True,
-        }
-    )
-
     organisms: List[Organism] = Field(
         default=...,
         description="""Collection of organism entries that will be available in the BRC Analytics platform.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "organisms", "domain_of": ["Organisms"]}
-        },
     )
 
 
@@ -361,28 +311,12 @@ class Organism(ConfiguredBaseModel):
     Definition of an organism with its taxonomic and genetic characteristics.
     """
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/organisms.yaml#"
-        }
-    )
-
     taxonomy_id: int = Field(
-        default=...,
-        description="""An NCBI Taxonomy ID at rank 'species'.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "taxonomy_id",
-                "domain_of": ["Organism", "Outbreak", "Workflow"],
-            }
-        },
+        default=..., description="""An NCBI Taxonomy ID at rank 'species'."""
     )
     ploidy: List[OrganismPloidy] = Field(
         default=...,
         description="""The possible ploidy states (number of chromosome sets) that the organism may have, which determines compatible workflows.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "ploidy", "domain_of": ["Organism", "Workflow"]}
-        },
     )
 
 
@@ -391,19 +325,9 @@ class Outbreaks(ConfiguredBaseModel):
     Root object containing a collection of pathogen definitions for the BRC Analytics platform to highlight as outbreaks/priority pathogens.
     """
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/outbreaks.yaml#",
-            "tree_root": True,
-        }
-    )
-
     outbreaks: List[Outbreak] = Field(
         default=...,
         description="""Collection of pathogen entries that will be displayed in the BRC Analytics platform as outbreaks/priority pathogens.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "outbreaks", "domain_of": ["Outbreaks"]}
-        },
     )
 
 
@@ -412,76 +336,33 @@ class Outbreak(ConfiguredBaseModel):
     Definition of a priority pathogen with its taxonomic classification, priority level, and associated resources.
     """
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/outbreaks.yaml#"
-        }
-    )
-
     name: str = Field(
         default=...,
         description="""The display name of the pathogen as it will appear in the BRC Analytics interface.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "name",
-                "domain_of": ["Outbreak", "WorkflowCategory", "WorkflowCollectionSpec"],
-            }
-        },
     )
     taxonomy_id: int = Field(
         default=...,
         description="""The NCBI Taxonomy ID for the pathogen. Used to link to relevant genomic data and workflows.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "taxonomy_id",
-                "domain_of": ["Organism", "Outbreak", "Workflow"],
-            }
-        },
     )
     priority: OutbreakPriority = Field(
         default=...,
         description="""The priority level of the pathogen, which determines its visibility and prominence in the BRC Analytics interface.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "priority", "domain_of": ["Outbreak"]}
-        },
     )
     resources: List[OutbreakResource] = Field(
         default=...,
         description="""Collection of external resources (references, tools, databases) related to the pathogen.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "resources", "domain_of": ["Outbreak"]}
-        },
     )
     description: MarkdownFileReference = Field(
         default=...,
         description="""Reference to a markdown file containing detailed information about the pathogen.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "description",
-                "domain_of": [
-                    "Outbreak",
-                    "WorkflowCategory",
-                    "WorkflowDataRequirements",
-                ],
-            }
-        },
     )
     active: bool = Field(
         default=...,
         description="""Boolean flag that determines if the pathogen should be included in the BRC Analytics interface. Used to manage visibility as pathogen relevance changes over time.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "active", "domain_of": ["Outbreak", "Workflow"]}
-        },
     )
     highlight_descendant_taxonomy_ids: Optional[List[int]] = Field(
         default=None,
         description="""List of NCBI Taxonomy IDs for descendant taxa (e.g., specific strains or serotypes) that should be highlighted within the outbreak category.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "highlight_descendant_taxonomy_ids",
-                "domain_of": ["Outbreak"],
-            }
-        },
     )
 
 
@@ -490,35 +371,17 @@ class OutbreakResource(ConfiguredBaseModel):
     Definition of an external resource (reference, tool, database) associated with a priority pathogen.
     """
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/outbreaks.yaml#"
-        }
-    )
-
     url: str = Field(
         default=...,
         description="""The complete URL (including http/https protocol) to the external resource.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "url",
-                "domain_of": ["OutbreakResource", "WorkflowUrlSpec"],
-            }
-        },
     )
     title: str = Field(
         default=...,
         description="""The display title for the resource link as it will appear in the BRC Analytics interface.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "title", "domain_of": ["OutbreakResource"]}
-        },
     )
     type: OutbreakResourceType = Field(
         default=...,
         description="""The category or type of the resource (e.g., REFERENCE, TOOL, DATABASE), which determines how it is displayed and organized.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "type", "domain_of": ["OutbreakResource"]}
-        },
     )
 
 
@@ -527,18 +390,9 @@ class MarkdownFileReference(ConfiguredBaseModel):
     A reference to a markdown file containing detailed content about a priority pathogen.
     """
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/outbreaks.yaml#"
-        }
-    )
-
     path: str = Field(
         default=...,
         description="""Relative path to the markdown file from the project root. Must end with .md extension.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "path", "domain_of": ["MarkdownFileReference"]}
-        },
     )
 
     @field_validator("path")
@@ -559,22 +413,9 @@ class WorkflowCategories(ConfiguredBaseModel):
     Root object containing a collection of workflow category definitions used to organize workflows in the BRC Analytics platform.
     """
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflow_categories.yaml#",
-            "tree_root": True,
-        }
-    )
-
     workflow_categories: List[WorkflowCategory] = Field(
         default=...,
         description="""Collection of workflow category entries that will be used to group and organize workflows in the BRC Analytics interface.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "workflow_categories",
-                "domain_of": ["WorkflowCategories"],
-            }
-        },
     )
 
 
@@ -583,52 +424,21 @@ class WorkflowCategory(ConfiguredBaseModel):
     Definition of a workflow category used to group related workflows for organization and display purposes.
     """
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflow_categories.yaml#"
-        }
-    )
-
     category: WorkflowCategoryId = Field(
         default=...,
         description="""The unique identifier for the workflow category, used to link workflows to their respective categories.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "category", "domain_of": ["WorkflowCategory"]}
-        },
     )
     name: str = Field(
         default=...,
         description="""The human-readable display name of the workflow category as it will appear in the BRC Analytics interface.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "name",
-                "domain_of": ["Outbreak", "WorkflowCategory", "WorkflowCollectionSpec"],
-            }
-        },
     )
     description: str = Field(
         default=...,
         description="""A detailed description of the workflow category explaining its purpose and the types of workflows it contains.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "description",
-                "domain_of": [
-                    "Outbreak",
-                    "WorkflowCategory",
-                    "WorkflowDataRequirements",
-                ],
-            }
-        },
     )
     show_coming_soon: bool = Field(
         default=...,
         description="""Boolean flag that determines whether to display a 'Coming Soon' indicator for this category in the BRC Analytics interface when workflows in this category are not yet available.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "show_coming_soon",
-                "domain_of": ["WorkflowCategory"],
-            }
-        },
     )
 
 
@@ -637,19 +447,9 @@ class Workflows(ConfiguredBaseModel):
     Root object containing a collection of Galaxy workflow definitions for the BRC Analytics platform.
     """
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#",
-            "tree_root": True,
-        }
-    )
-
     workflows: List[Workflow] = Field(
         default=...,
         description="""Collection of workflow entries that will be available to users in the BRC Analytics platform.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "workflows", "domain_of": ["Workflows"]}
-        },
     )
 
 
@@ -658,98 +458,53 @@ class Workflow(ConfiguredBaseModel):
     Definition of a Galaxy workflow with its metadata, parameters, and organism compatibility information.
     """
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#"
-        }
-    )
-
     trs_id: str = Field(
         default=...,
         description="""The Tool Repository Service (TRS) identifier for the workflow, used to locate and retrieve the workflow from a Galaxy server.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "trs_id", "domain_of": ["Workflow"]}
-        },
     )
     categories: List[WorkflowCategoryId] = Field(
         default=...,
         description="""List of category identifiers that this workflow belongs to, determining how it is organized and displayed in the BRC Analytics interface.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "categories", "domain_of": ["Workflow"]}
-        },
     )
     workflow_name: str = Field(
         default=...,
         description="""The human-readable display name of the workflow as it will appear in the BRC Analytics interface.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "workflow_name", "domain_of": ["Workflow"]}
-        },
     )
     workflow_description: str = Field(
         default=...,
         description="""A detailed description of the workflow's purpose, functionality, and expected outputs for users.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "workflow_description", "domain_of": ["Workflow"]}
-        },
     )
     ploidy: WorkflowPloidy = Field(
         default=...,
         description="""The ploidy state (number of chromosome sets) that this workflow is designed to work with, ensuring compatibility with organism data.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "ploidy", "domain_of": ["Organism", "Workflow"]}
-        },
     )
     scope: Optional[WorkflowScope] = Field(
         default=None,
         description="""The scope level at which this workflow operates, determining where it is displayed in the UI and what the first configuration step should be. Defaults to ASSEMBLY for backward compatibility.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "scope", "domain_of": ["Workflow"]}
-        },
     )
     assembly_count_min: Optional[int] = Field(
         default=None,
         description="""The minimum number of genome assemblies a user must select for this workflow. Defaults to 1 for ASSEMBLY-scope workflows; must be set explicitly for ORGANISM and SEQUENCE scope. Use 0 for workflows that take no user-selected assemblies (e.g. assembly-building or curated-FASTA workflows).""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "assembly_count_min", "domain_of": ["Workflow"]}
-        },
     )
     assembly_count_max: Optional[int] = Field(
         default=None,
         description="""The maximum number of genome assemblies a user may select for this workflow. Null/absent means no upper limit. Defaults to 1 for ASSEMBLY-scope workflows; must be set explicitly for ORGANISM and SEQUENCE scope.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "assembly_count_max", "domain_of": ["Workflow"]}
-        },
     )
     taxonomy_id: Optional[int] = Field(
         default=None,
         description="""The NCBI Taxonomy ID of the organism this workflow is designed for. If specified, the workflow will be available for all assemblies with this ID in their taxonomic lineage.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "taxonomy_id",
-                "domain_of": ["Organism", "Outbreak", "Workflow"],
-            }
-        },
     )
     parameters: List[WorkflowParameter] = Field(
         default=...,
         description="""Collection of input parameters that will be passed to the workflow when it is executed, including data sources and configuration options.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "parameters", "domain_of": ["Workflow"]}
-        },
     )
     active: bool = Field(
         default=...,
         description="""Boolean flag that determines if the workflow should be included in the BRC Analytics interface. Used to manage visibility of workflows that may be under development or deprecated.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "active", "domain_of": ["Outbreak", "Workflow"]}
-        },
     )
     iwc_id: str = Field(
         default=...,
         description="""The Intergalactic Workflow Commission (IWC) identifier for the workflow, used to link to the workflow's page on the IWC website.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "iwc_id", "domain_of": ["Workflow"]}
-        },
     )
 
 
@@ -758,55 +513,21 @@ class WorkflowDataRequirements(ConfiguredBaseModel):
     Specification of data requirements for a workflow parameter, such as library strategy and layout.
     """
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#"
-        }
-    )
-
     library_strategy: Optional[List[LibraryStrategy]] = Field(
         default=None,
         description="""The library strategy values that are acceptable for this parameter (e.g., 'WGS', 'RNA-Seq').""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "library_strategy",
-                "domain_of": ["WorkflowDataRequirements"],
-            }
-        },
     )
     library_layout: Optional[LibraryLayout] = Field(
         default=None,
         description="""The library layout that is required for this parameter (e.g., 'PAIRED', 'SINGLE').""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "library_layout",
-                "domain_of": ["WorkflowDataRequirements"],
-            }
-        },
     )
     library_source: Optional[List[LibrarySource]] = Field(
         default=None,
         description="""The library source values that are acceptable for this parameter (e.g., 'GENOMIC', 'TRANSCRIPTOMIC SINGLE CELL').""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "library_source",
-                "domain_of": ["WorkflowDataRequirements"],
-            }
-        },
     )
     description: Optional[str] = Field(
         default=None,
         description="""A descriptive text to provide additional context about the data requirements, useful for non-standard library strategies like 'OTHER'.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "description",
-                "domain_of": [
-                    "Outbreak",
-                    "WorkflowCategory",
-                    "WorkflowDataRequirements",
-                ],
-            }
-        },
     )
 
 
@@ -831,42 +552,18 @@ class WorkflowCollectionSpec(ConfiguredBaseModel):
     ```
     """
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#"
-        }
-    )
-
     collection_type: CollectionType = Field(
         default=...,
         description="""The type of Galaxy collection to create. Currently only 'list' is supported. Determines the structure of the collection.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "collection_type",
-                "domain_of": ["WorkflowCollectionSpec"],
-            }
-        },
     )
     elements: List[WorkflowUrlSpec] = Field(
         default=...,
         description="""Array of URL specifications that will become elements in the collection. Each element represents a file to include in the collection. Must contain at least one element.""",
         min_length=1,
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "elements",
-                "domain_of": ["WorkflowCollectionSpec"],
-            }
-        },
     )
     name: Optional[str] = Field(
         default=None,
         description="""Optional identifier for the collection, used as the collection name in Galaxy. If not provided, defaults to 'Collection'.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "name",
-                "domain_of": ["Outbreak", "WorkflowCategory", "WorkflowCollectionSpec"],
-            }
-        },
     )
 
 
@@ -875,59 +572,29 @@ class WorkflowParameter(ConfiguredBaseModel):
     Definition of an input parameter for a Galaxy workflow, specifying how the parameter value should be determined when the workflow is executed.
     """
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#"
-        }
-    )
-
     key: str = Field(
         default=...,
         description="""The identifier for the parameter as expected by the Galaxy workflow, used to map the parameter value to the correct input.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "key", "domain_of": ["WorkflowParameter"]}
-        },
     )
     variable: Optional[WorkflowParameterVariable] = Field(
         default=None,
         description="""A predefined variable that will be substituted as the value of the parameter at runtime, such as assembly information.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "variable", "domain_of": ["WorkflowParameter"]}
-        },
     )
     collection_spec: Optional[WorkflowCollectionSpec] = Field(
         default=None,
         description="""A collection specification for the parameter, allowing multiple files from external sources to be provided as a Galaxy collection.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "collection_spec",
-                "domain_of": ["WorkflowParameter"],
-            }
-        },
     )
     url_spec: Optional[WorkflowUrlSpec] = Field(
         default=None,
         description="""A direct URL specification for the parameter, allowing for external data sources to be provided to the workflow.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "url_spec", "domain_of": ["WorkflowParameter"]}
-        },
     )
     data_requirements: Optional[WorkflowDataRequirements] = Field(
         default=None,
         description="""Specifications for the data requirements of this parameter, such as library strategy and layout.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "data_requirements",
-                "domain_of": ["WorkflowParameter"],
-            }
-        },
     )
     type_guide: Optional[Any] = Field(
         default=None,
         description="""Arbitrary data describing the expected type and format of the parameter, intended as a reference for catalog maintainers and not used in workflow execution.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "type_guide", "domain_of": ["WorkflowParameter"]}
-        },
     )
 
 
@@ -936,49 +603,25 @@ class WorkflowUrlSpec(ConfiguredBaseModel):
     Definition of a URL-based data source for a workflow parameter, typically used for reference data or external resources.
     """
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://github.com/galaxyproject/brc-analytics/blob/main/catalog/py_package/catalog_build/schema/workflows.yaml#"
-        }
-    )
-
     ext: str = Field(
         default=...,
         description="""The file extension of the resource at the URL, which determines how Galaxy will interpret the data (e.g., 'fasta', 'gff', 'tabular').""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "ext", "domain_of": ["WorkflowUrlSpec"]}
-        },
     )
     src: str = Field(
         default=...,
         description="""The source type for the parameter, typically 'url' to indicate an external URL source rather than a Galaxy dataset or other source type.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "src", "domain_of": ["WorkflowUrlSpec"]}
-        },
     )
     url: str = Field(
         default=...,
         description="""The complete URL (including http/https protocol) to the external resource that will be used as input to the workflow.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "url",
-                "domain_of": ["OutbreakResource", "WorkflowUrlSpec"],
-            }
-        },
     )
     db_key: Optional[str] = Field(
         default=None,
         description="""Optional database key (genome build) to associate with this file, used by Galaxy to link the file to a specific reference genome.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "db_key", "domain_of": ["WorkflowUrlSpec"]}
-        },
     )
     md5: Optional[str] = Field(
         default=None,
         description="""Optional MD5 checksum hash for file integrity verification.""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "md5", "domain_of": ["WorkflowUrlSpec"]}
-        },
     )
 
 

--- a/catalog/py_package/catalog_build/schema_utils/gen_schema.py
+++ b/catalog/py_package/catalog_build/schema_utils/gen_schema.py
@@ -5,6 +5,7 @@ from linkml.generators import JsonSchemaGenerator, PydanticGenerator
 
 from .gen_typescript import TypescriptGeneratorFixed
 
+# A relative path is used to ensure that no absolute paths are included in generated files
 SCHEMA_DIR = os.path.relpath(
     os.path.join(os.path.dirname(os.path.realpath(__file__)), "../schema")
 )

--- a/catalog/py_package/catalog_build/schema_utils/gen_schema.py
+++ b/catalog/py_package/catalog_build/schema_utils/gen_schema.py
@@ -1,15 +1,20 @@
 import os.path
 from argparse import ArgumentParser
 
-from linkml.generators import JsonSchemaGenerator, PydanticGenerator
+from linkml.generators import JsonSchemaGenerator, PydanticGenerator, pydanticgen
 
 from .gen_typescript import TypescriptGeneratorFixed
 
 SCHEMA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../schema")
 
-# Mapping from name to tuple of generator class and output file extension
+# Mapping from name to tuple of generator constructor and output file extension
 GENERATOR_TYPES = {
-    "Pydantic": (PydanticGenerator, "py"),
+    "Pydantic": (
+        lambda path: PydanticGenerator(
+            path, metadata_mode=pydanticgen.MetadataMode.NONE
+        ),
+        "py",
+    ),
     "TypeScript": (TypescriptGeneratorFixed, "ts"),
     "JSON Schema": (JsonSchemaGenerator, "json"),
 }

--- a/catalog/py_package/catalog_build/schema_utils/gen_schema.py
+++ b/catalog/py_package/catalog_build/schema_utils/gen_schema.py
@@ -1,22 +1,17 @@
 import os.path
 from argparse import ArgumentParser
 
-from linkml.generators import JsonSchemaGenerator, PydanticGenerator, pydanticgen
+from linkml.generators import JsonSchemaGenerator, PydanticGenerator
 
 from .gen_typescript import TypescriptGeneratorFixed
 
-SCHEMA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../schema")
+SCHEMA_DIR = os.path.relpath(
+    os.path.join(os.path.dirname(os.path.realpath(__file__)), "../schema")
+)
 
-# Mapping from name to tuple of generator constructor and output file extension
+# Mapping from name to tuple of generator class and output file extension
 GENERATOR_TYPES = {
-    "Pydantic": (
-        lambda path: PydanticGenerator(
-            # LinkML metadata is omitted, as it's unlikely to be useful and includes awkward absolute paths
-            path,
-            metadata_mode=pydanticgen.MetadataMode.NONE,
-        ),
-        "py",
-    ),
+    "Pydantic": (PydanticGenerator, "py"),
     "TypeScript": (TypescriptGeneratorFixed, "ts"),
     "JSON Schema": (JsonSchemaGenerator, "json"),
 }

--- a/catalog/py_package/catalog_build/schema_utils/gen_schema.py
+++ b/catalog/py_package/catalog_build/schema_utils/gen_schema.py
@@ -11,7 +11,9 @@ SCHEMA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../schem
 GENERATOR_TYPES = {
     "Pydantic": (
         lambda path: PydanticGenerator(
-            path, metadata_mode=pydanticgen.MetadataMode.NONE
+            # LinkML metadata is omitted, as it's unlikely to be useful and includes awkward absolute paths
+            path,
+            metadata_mode=pydanticgen.MetadataMode.NONE,
         ),
         "py",
     ),


### PR DESCRIPTION
## Description

Updates the script that generates definitions from the LinkML schemas to pass relative paths to the generators, thus preventing absolute paths from appearing in the generated Pydantic definitions.

## Related Issue

Closes #1347
