### PR TITLE
feat: user chip account menu + fix account page layouts

### DIFF
--- a/app/components/Layout/components/Header/components/AuthButton/authButton.styles.ts
+++ b/app/components/Layout/components/Header/components/AuthButton/authButton.styles.ts
@@ -1,8 +1,39 @@
-import styled from "@emotion/styled";
+import { Button, styled } from "@mui/material";
 
-export const AuthButtonWrapper = styled.div`
-  align-items: center;
-  display: flex;
-  gap: 8px;
-  white-space: nowrap;
-`;
+// Clickable, pill-shaped user chip (avatar + name + caret) that anchors the
+// account menu. Reads as a grouped control rather than loose text next to a
+// button, and visually separates the account from the nav links.
+export const UserChip = styled(Button)(({ theme }) => ({
+  // The avatar is the Button's startIcon, whose default rule
+  // (.MuiButton-startIcon > :nth-of-type(1)) forces a 20px font on its child and
+  // ties a plain .MuiAvatar-root override on specificity. Scope to the startIcon
+  // context so the initials actually shrink to fit the 28px circle.
+  "& .MuiButton-startIcon .MuiAvatar-root": {
+    backgroundColor: theme.palette.primary.main,
+    color: theme.palette.primary.contrastText,
+    fontSize: 12,
+    fontWeight: 600,
+    height: 28,
+    width: 28,
+  },
+  "& .MuiButton-startIcon, & .MuiButton-endIcon": {
+    margin: 0,
+  },
+  "&:hover": {
+    backgroundColor: theme.palette.action.selected,
+  },
+  backgroundColor: theme.palette.action.hover,
+  borderRadius: 9999,
+  gap: "6px",
+  minWidth: 0,
+  padding: "4px 10px 4px 4px",
+  textTransform: "none",
+}));
+
+// Rendered as <li> because MUI Menu places children inside a <ul>; a <div> here
+// would be invalid list markup.
+export const UserMenuHeader = styled("li")({
+  display: "flex",
+  flexDirection: "column",
+  padding: "8px 16px",
+});

--- a/app/components/Layout/components/Header/components/AuthButton/authButton.tsx
+++ b/app/components/Layout/components/Header/components/AuthButton/authButton.tsx
@@ -1,18 +1,44 @@
 import { useAuth } from "@/providers/authentication";
-import { Button, Menu, MenuItem, Typography } from "@mui/material";
+import KeyboardArrowDownRoundedIcon from "@mui/icons-material/KeyboardArrowDownRounded";
+import LogoutRoundedIcon from "@mui/icons-material/LogoutRounded";
+import {
+  Avatar,
+  Button,
+  Divider,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
+  Typography,
+} from "@mui/material";
 import { useRouter } from "next/router";
-import { JSX, MouseEvent, useState } from "react";
-import { AuthButtonWrapper } from "./authButton.styles";
+import { JSX, MouseEvent, useId, useState } from "react";
+import { UserChip, UserMenuHeader } from "./authButton.styles";
 
 /**
- * Header auth button — shows Sign In or user name + Sign Out.
- * @returns auth button element, or null while loading.
+ * Build up-to-two-letter initials from a display name.
+ * @param name - User display name.
+ * @returns Uppercased initials, or "?" when unavailable.
+ */
+function getInitials(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "?";
+  const last = parts.length > 1 ? parts[parts.length - 1][0] : "";
+  return (parts[0][0] + last).toUpperCase();
+}
+
+/**
+ * Header auth control — Sign In when logged out, or a clickable user chip that
+ * opens the account menu (name/email, account links, Sign out) when logged in.
+ * @returns auth control element, or null while loading.
  */
 export function AuthButton(): JSX.Element | null {
   const { isAuthenticated, isConfigured, isLoading, login, logout, user } =
     useAuth();
   const router = useRouter();
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const menuButtonId = useId();
+  const menuId = useId();
 
   if (!isConfigured || isLoading) return null;
 
@@ -25,6 +51,7 @@ export function AuthButton(): JSX.Element | null {
   }
 
   const isMenuOpen = !!anchorEl;
+  const displayName = user?.name || user?.preferred_username || "Account";
 
   function handleMenuOpen(event: MouseEvent<HTMLElement>): void {
     setAnchorEl(event.currentTarget);
@@ -45,22 +72,41 @@ export function AuthButton(): JSX.Element | null {
   }
 
   return (
-    <AuthButtonWrapper>
-      <Button
-        color="primary"
+    <>
+      <UserChip
+        aria-controls={isMenuOpen ? menuId : undefined}
+        aria-expanded={isMenuOpen || undefined}
+        aria-haspopup="menu"
+        color="inherit"
+        endIcon={<KeyboardArrowDownRoundedIcon fontSize="small" />}
+        id={menuButtonId}
         onClick={handleMenuOpen}
-        size="small"
+        startIcon={<Avatar>{getInitials(displayName)}</Avatar>}
         variant="text"
       >
-        {user?.name}
-      </Button>
+        {displayName}
+      </UserChip>
       <Menu
         anchorEl={anchorEl}
         anchorOrigin={{ horizontal: "right", vertical: "bottom" }}
+        id={menuId}
         onClose={handleMenuClose}
         open={isMenuOpen}
+        slotProps={{
+          list: { "aria-labelledby": menuButtonId },
+          paper: { sx: { minWidth: 220 } },
+        }}
         transformOrigin={{ horizontal: "right", vertical: "top" }}
       >
+        <UserMenuHeader role="presentation">
+          <Typography variant="subtitle2">{displayName}</Typography>
+          {user?.email && (
+            <Typography color="text.secondary" variant="caption">
+              {user.email}
+            </Typography>
+          )}
+        </UserMenuHeader>
+        <Divider component="li" />
         <MenuItem onClick={() => navigateTo("/data/favorites")}>
           Favorites
         </MenuItem>
@@ -73,9 +119,14 @@ export function AuthButton(): JSX.Element | null {
         <MenuItem onClick={() => navigateTo("/account/preferences")}>
           Preferences
         </MenuItem>
-        <MenuItem onClick={handleLogout}>Sign Out</MenuItem>
+        <Divider component="li" />
+        <MenuItem onClick={handleLogout}>
+          <ListItemIcon>
+            <LogoutRoundedIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Sign out</ListItemText>
+        </MenuItem>
       </Menu>
-      <Typography variant="body2">{user?.email}</Typography>
-    </AuthButtonWrapper>
+    </>
   );
 }

--- a/pages/account/preferences.tsx
+++ b/pages/account/preferences.tsx
@@ -1,4 +1,5 @@
 import { SectionHero } from "@/components/Layout/components/AppLayout/components/Section/components/SectionHero/sectionHero";
+import { StyledPagesMain } from "@/components/Layout/components/Main/main.styles";
 import { useAuth } from "@/providers/authentication";
 import { brcAPIClient } from "@/services/brc-api-client";
 import { Breadcrumb } from "@databiosphere/findable-ui/lib/components/common/Breadcrumbs/breadcrumbs";
@@ -155,3 +156,5 @@ export default function PreferencesPage(): JSX.Element {
     </>
   );
 }
+
+PreferencesPage.Main = StyledPagesMain;

--- a/pages/account/workflow-runs.tsx
+++ b/pages/account/workflow-runs.tsx
@@ -1,4 +1,5 @@
 import { SectionHero } from "@/components/Layout/components/AppLayout/components/Section/components/SectionHero/sectionHero";
+import { StyledPagesMain } from "@/components/Layout/components/Main/main.styles";
 import { useAuth } from "@/providers/authentication";
 import { brcAPIClient } from "@/services/brc-api-client";
 import { WorkflowRunResponse } from "@/types/api";
@@ -170,3 +171,5 @@ export default function WorkflowRunsPage(): JSX.Element {
     </>
   );
 }
+
+WorkflowRunsPage.Main = StyledPagesMain;

--- a/pages/assistant/saved.tsx
+++ b/pages/assistant/saved.tsx
@@ -1,4 +1,5 @@
 import { SectionHero } from "@/components/Layout/components/AppLayout/components/Section/components/SectionHero/sectionHero";
+import { StyledPagesMain } from "@/components/Layout/components/Main/main.styles";
 import { useAuth } from "@/providers/authentication";
 import { brcAPIClient } from "@/services/brc-api-client";
 import { SavedAnalysisSummary } from "@/types/api";
@@ -197,3 +198,5 @@ export default function SavedAnalysesPage(): JSX.Element {
     </>
   );
 }
+
+SavedAnalysesPage.Main = StyledPagesMain;

--- a/pages/data/favorites.tsx
+++ b/pages/data/favorites.tsx
@@ -1,5 +1,6 @@
 import { sanitizeEntityId } from "@/apis/catalog/common/utils";
 import { SectionHero } from "@/components/Layout/components/AppLayout/components/Section/components/SectionHero/sectionHero";
+import { StyledPagesMain } from "@/components/Layout/components/Main/main.styles";
 import { useAssemblyFavorites } from "@/hooks/useAssemblyFavorites";
 import { useAuth } from "@/providers/authentication";
 import { getEntity } from "@/services/workflows/query";
@@ -130,3 +131,5 @@ export default function FavoritesPage(): JSX.Element {
     </>
   );
 }
+
+FavoritesPage.Main = StyledPagesMain;


### PR DESCRIPTION
Refreshes the account UI now that login is live on dev, and picks up two things at once.

The signed-in header used to be a plain name button with the user's email floating next to it as raw text -- it looked out of place and crowded the nav on narrow widths. This swaps it for an avatar chip that opens the account menu, with name and email in a header. The menu keeps the links that landed while this branch sat (Favorites, Saved Analyses, Workflow Runs, Preferences) plus Sign out.

Separately, the four account pages were rendering hero and content side by side instead of stacked -- they never set a Main layout, so they fell through to findable-ui's default row Main. Setting StyledPagesMain like every other content page fixes the stacking and the page background.

Rebased onto current main (the branch was ~120 commits behind, from before the Next 16 / findable-ui v54 bump).
