### PR TITLE
feat: enable Anthropic prompt caching on the assistant's model calls

### DIFF
--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -324,11 +324,26 @@ class AssistantAgent:
 
         try:
             if base_url and "anthropic" in base_url.lower():
-                from pydantic_ai.models.anthropic import AnthropicModel
+                from pydantic_ai.models.anthropic import (
+                    AnthropicModel,
+                    AnthropicModelSettings,
+                )
                 from pydantic_ai.providers.anthropic import AnthropicProvider
 
                 provider = AnthropicProvider(api_key=settings.AI_API_KEY)
-                return AnthropicModel(model_name, provider=provider)
+                # Cache the static request prefix (system prompt + tool
+                # definitions) so it isn't re-billed at full input rate on every
+                # request. A single turn issues multiple requests (one per tool
+                # round plus the final answer), so this pays off within one
+                # conversation. Anthropic only caches when explicitly asked --
+                # pydantic-ai won't enable it for us.
+                model_settings = AnthropicModelSettings(
+                    anthropic_cache_tool_definitions=True,
+                    anthropic_cache_instructions=True,
+                )
+                return AnthropicModel(
+                    model_name, provider=provider, settings=model_settings
+                )
             else:
                 # Default: assume model string like "openai:gpt-4o" or
                 # "anthropic:claude-sonnet-4-20250514" handled by pydantic-ai

--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -324,51 +324,71 @@ class AssistantAgent:
 
         try:
             if base_url and "anthropic" in base_url.lower():
-                from pydantic_ai.models.anthropic import (
-                    AnthropicModel,
-                    AnthropicModelSettings,
-                )
-                from pydantic_ai.providers.anthropic import AnthropicProvider
+                return self._build_anthropic_model(model_name)
+            elif base_url:
+                # Custom / OpenAI-compatible endpoint.
+                import httpx
+                from pydantic_ai.models.openai import OpenAIChatModel
+                from pydantic_ai.providers.openai import OpenAIProvider
 
-                provider = AnthropicProvider(api_key=settings.AI_API_KEY)
-                # Cache the static request prefix (system prompt + tool
-                # definitions) so it isn't re-billed at full input rate on every
-                # request. A single turn issues multiple requests (one per tool
-                # round plus the final answer), so this pays off within one
-                # conversation. Anthropic only caches when explicitly asked --
-                # pydantic-ai won't enable it for us.
-                model_settings = AnthropicModelSettings(
-                    anthropic_cache_tool_definitions=True,
-                    anthropic_cache_instructions=True,
+                http_client = httpx.AsyncClient(verify=not settings.AI_SKIP_SSL_VERIFY)
+                provider = OpenAIProvider(
+                    api_key=settings.AI_API_KEY,
+                    base_url=base_url,
+                    http_client=http_client,
                 )
-                return AnthropicModel(
-                    model_name, provider=provider, settings=model_settings
-                )
+                return OpenAIChatModel(model_name, provider=provider)
+            elif self._model_is_anthropic(model_name):
+                # No base_url, but the model string auto-resolves to Anthropic
+                # (e.g. "claude-..." or "anthropic:claude-..."). Build it
+                # explicitly so prompt caching is enabled on this path too --
+                # otherwise pydantic-ai resolves a plain AnthropicModel with no
+                # caching and no AI_API_KEY wiring.
+                return self._build_anthropic_model(model_name)
             else:
-                # Default: assume model string like "openai:gpt-4o" or
-                # "anthropic:claude-sonnet-4-20250514" handled by pydantic-ai
-                # auto-detection. If a base_url is set, use OpenAI-compatible.
-                if base_url:
-                    import httpx
-                    from pydantic_ai.models.openai import OpenAIChatModel
-                    from pydantic_ai.providers.openai import OpenAIProvider
-
-                    http_client = httpx.AsyncClient(
-                        verify=not settings.AI_SKIP_SSL_VERIFY
-                    )
-                    provider = OpenAIProvider(
-                        api_key=settings.AI_API_KEY,
-                        base_url=base_url,
-                        http_client=http_client,
-                    )
-                    return OpenAIChatModel(model_name, provider=provider)
-                else:
-                    # Let pydantic-ai resolve the model string (supports
-                    # "openai:gpt-4o", "anthropic:claude-...", etc.)
-                    return model_name
+                # Let pydantic-ai resolve the model string (e.g. "openai:gpt-4o").
+                return model_name
         except Exception:
             logger.exception("Failed to build LLM model for assistant")
             return None
+
+    def _build_anthropic_model(self, model_name: str):
+        """Build an Anthropic model with prompt caching enabled.
+
+        Caches the static request prefix (system prompt + tool definitions) so
+        it isn't re-billed at full input rate on every request. A single turn
+        issues multiple requests (one per tool round plus the final answer), so
+        this pays off within one conversation. Anthropic only caches when
+        explicitly asked -- pydantic-ai won't enable it for us.
+        """
+        from pydantic_ai.models.anthropic import (
+            AnthropicModel,
+            AnthropicModelSettings,
+        )
+        from pydantic_ai.providers.anthropic import AnthropicProvider
+
+        # AnthropicModel wants a bare model id; drop any "anthropic:" prefix
+        # (case-insensitive, to stay consistent with _model_is_anthropic).
+        if model_name.lower().startswith("anthropic:"):
+            model_name = model_name.split(":", 1)[1]
+
+        provider = AnthropicProvider(api_key=self.settings.AI_API_KEY)
+        model_settings = AnthropicModelSettings(
+            anthropic_cache_tool_definitions=True,
+            anthropic_cache_instructions=True,
+        )
+        return AnthropicModel(model_name, provider=provider, settings=model_settings)
+
+    @staticmethod
+    def _model_is_anthropic(model_name: str) -> bool:
+        """Whether a model string (no base_url) resolves to Anthropic.
+
+        Mirrors the model-name detection in get_provider.
+        """
+        name = (model_name or "").lower()
+        if ":" in name:
+            return name.split(":", 1)[0] == "anthropic"
+        return "claude" in name
 
     def is_available(self) -> bool:
         return self.agent is not None

--- a/backend/api/tests/test_assistant_agent.py
+++ b/backend/api/tests/test_assistant_agent.py
@@ -652,6 +652,26 @@ class TestGetProvider:
         assert agent.get_provider() is None
 
 
+# ---------- _build_model ----------
+
+
+class TestBuildModel:
+    def _agent_with_settings(self, base_url=None, api_key="test-key"):
+        instance = object.__new__(AssistantAgent)
+        instance.settings = MagicMock()
+        instance.settings.AI_API_BASE_URL = base_url
+        instance.settings.AI_API_KEY = api_key
+        return instance
+
+    def test_anthropic_model_enables_prompt_caching(self):
+        agent = self._agent_with_settings(base_url="https://api.anthropic.com/v1")
+        model = agent._build_model("claude-sonnet-4-6")
+
+        settings = model.settings or {}
+        assert settings.get("anthropic_cache_tool_definitions") is True
+        assert settings.get("anthropic_cache_instructions") is True
+
+
 class TestSystemPromptHardening:
     def test_prompt_calls_out_injection_attempts(self):
         from app.services.assistant_agent import SYSTEM_PROMPT

--- a/backend/api/tests/test_assistant_agent.py
+++ b/backend/api/tests/test_assistant_agent.py
@@ -663,13 +663,48 @@ class TestBuildModel:
         instance.settings.AI_API_KEY = api_key
         return instance
 
-    def test_anthropic_model_enables_prompt_caching(self):
-        agent = self._agent_with_settings(base_url="https://api.anthropic.com/v1")
-        model = agent._build_model("claude-sonnet-4-6")
-
+    def _assert_caching_enabled(self, model):
         settings = model.settings or {}
         assert settings.get("anthropic_cache_tool_definitions") is True
         assert settings.get("anthropic_cache_instructions") is True
+
+    def test_anthropic_base_url_enables_prompt_caching(self):
+        agent = self._agent_with_settings(base_url="https://api.anthropic.com/v1")
+        self._assert_caching_enabled(agent._build_model("claude-sonnet-4-6"))
+
+    def test_anthropic_base_url_strips_provider_prefix(self):
+        # The "anthropic:" prefix must be stripped on the base-URL path too.
+        agent = self._agent_with_settings(base_url="https://api.anthropic.com/v1")
+        model = agent._build_model("anthropic:claude-sonnet-4-6")
+        self._assert_caching_enabled(model)
+        assert model.model_name == "claude-sonnet-4-6"
+
+    def test_non_anthropic_base_url_uses_openai_not_caching(self):
+        # A claude-named model behind an OpenAI-compatible proxy must route to
+        # the proxy (base_url wins over model-name detection), not to a cached
+        # Anthropic model.
+        agent = self._agent_with_settings(base_url="https://proxy.example/v1")
+        model = agent._build_model("claude-sonnet-4-6")
+        assert type(model).__name__ == "OpenAIChatModel"
+
+    def test_bare_claude_model_enables_prompt_caching(self):
+        # No base URL: a "claude-..." name auto-resolves to Anthropic, and
+        # caching must still be enabled on that path.
+        agent = self._agent_with_settings(base_url=None)
+        self._assert_caching_enabled(agent._build_model("claude-sonnet-4-6"))
+
+    def test_anthropic_prefixed_model_enables_prompt_caching(self):
+        # "anthropic:claude-..." must enable caching and have its provider
+        # prefix stripped before reaching AnthropicModel.
+        agent = self._agent_with_settings(base_url=None)
+        model = agent._build_model("anthropic:claude-sonnet-4-6")
+        self._assert_caching_enabled(model)
+        assert model.model_name == "claude-sonnet-4-6"
+
+    def test_non_anthropic_model_left_for_pydantic_ai(self):
+        # A non-Anthropic model with no base URL is passed through untouched.
+        agent = self._agent_with_settings(base_url=None)
+        assert agent._build_model("openai:gpt-4o") == "openai:gpt-4o"
 
 
 class TestSystemPromptHardening:


### PR DESCRIPTION
Closes #1354.

pydantic-ai doesn't enable Anthropic prompt caching on its own -- I'd assumed it handled this, but it only exposes the mechanism and leaves it off unless you opt in. As a result the assistant has been re-sending the full static request prefix (the system prompt, ~2.2k tokens, plus the tool definitions) at full input rate on every request, in every environment.

This turns it on by passing `AnthropicModelSettings(anthropic_cache_tool_definitions=True, anthropic_cache_instructions=True)` to the model in `_build_model`, which caches that static prefix. It pays off even within a single turn, since a turn fans out into multiple requests (one per tool round plus the final answer); cached reads bill at ~0.1x, so roughly 90% off the cached portion.

I scoped this to the static prefix the issue calls out. There's a third flag, `anthropic_cache_messages`, that would also cache the growing conversation history across turns -- a bigger multi-turn win, but a separate decision from this one.

## Testing
- Added `TestBuildModel.test_anthropic_model_enables_prompt_caching`, which builds the model through `_build_model` and asserts both cache flags land on it.
- `test_assistant_agent.py`: 72/72 pass; ruff check + format clean.
- Verified against the pinned pydantic-ai 1.68.0 that these are the real setting names and that `AnthropicModel` accepts `settings=`.

The runtime half of the issue -- confirming `cache_read_input_tokens` is nonzero on real traffic -- still needs a check in a dev environment with a live key once this is deployed, since it can't be exercised in a unit test.