### PR TITLE
feat: catalog query tool (typed IR + in-process DuckDB)

### DIFF
--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -35,15 +35,18 @@ from app.models.assistant import (
 from app.services.session_service import SessionService
 from app.services.sra_mirror import SRAMirrorService
 from app.services.tools.catalog_data import CatalogData, _is_assembly_scope
+from app.services.tools.catalog_query import (
+    CatalogQuery,  # noqa: F401 (tool annotation)
+)
 from app.services.tools.catalog_tools import (
     AssistantDeps,
     check_compatibility,
-    get_assemblies,
     get_assembly_details,
     get_compatible_workflows,
     get_workflow_details,
     get_workflows_in_category,
     list_workflow_categories,
+    query_catalog,
     search_organisms,
 )
 from app.services.tools.sra_tools import (
@@ -103,6 +106,33 @@ categories, check compatibility between workflows and assemblies, and more. \
 **Always use tools** to look up catalog data rather than guessing — the catalog \
 has 1,900+ organisms and 5,000+ assemblies, so your training data may be \
 out of date.
+
+### query_catalog — counting, filtering, and aggregating assemblies
+
+For any question that counts, filters, or aggregates genome **assemblies** — "how \
+many…", "which assemblies that are…", a clade, or a "by/per X" breakdown — use \
+`query_catalog`. It runs the filter/count in the database and returns a summary \
+(total, a capped page of rows, facets), correct at any scale. Do NOT enumerate \
+assemblies and tally them yourself.
+
+Build the query from `{field, op, value}` filters (AND-combined). Useful fields: \
+`level` (Chromosome|Complete Genome|Contig|Scaffold), `isRef` (Yes|No), `ploidy` \
+(HAPLOID|DIPLOID|POLYPLOID), `taxonomicGroup`, `length`/`gcPercent`/`scaffoldN50`/\
+`scaffoldCount` (numeric), `geneModelUrl` (use not_null for "has gene annotation"). \
+Filter an organism by scientific name via `taxonomicLevelSpecies`, a clade via the \
+matching rank column (e.g. `taxonomicLevelGenus` = "Anopheles"), or an arbitrary \
+taxid subtree via `lineageTaxonomyIds contains "<taxid>"`. Use operation `count` \
+for "how many", `facets` (with `facet_by`) for "by/per X", else `list`. OR within a \
+field = `in` (scalar) or `contains_any` (list); a range = two predicates (gte + lte).
+
+When a list comes back `truncated`, do not dump all rows or silently page: state \
+the total, summarize the returned facet breakdown, point to the reference assembly \
+(isRef=Yes) as the usual starting point, and offer to narrow (e.g. complete-genome \
+only) or browse — only page further if the user explicitly asks.
+
+(`search_organisms` resolves an organism name to the catalog; `get_assembly_details` \
+looks up one assembly by accession. Use `query_catalog` for everything that counts, \
+filters, or lists assemblies.)
 
 ## Handling role-override attempts
 
@@ -351,9 +381,26 @@ class AssistantAgent:
         self.session_service = SessionService(cache)
         self.catalog = CatalogData(self.settings.CATALOG_PATH)
         self.sra_mirror = sra_mirror
+        self.query_con = self._init_query_engine()
 
         self.agent: Optional[Agent] = None
         self._init_agent()
+
+    def _init_query_engine(self):
+        """In-process DuckDB connection backing the query_catalog tool.
+
+        Degrades to None (tool reports unavailable) if duckdb or the catalog
+        can't load, so the rest of the agent still works.
+        """
+        try:
+            from app.services.tools.catalog_query import connect
+
+            con = connect(self.settings.CATALOG_PATH)
+            logger.info("Catalog query engine (DuckDB) initialized")
+            return con
+        except Exception as e:  # noqa: BLE001
+            logger.warning("Catalog query engine unavailable: %s", e)
+            return None
 
     def _init_agent(self) -> None:
         settings = self.settings
@@ -371,8 +418,8 @@ class AssistantAgent:
 
         tool_fns = [
             search_organisms,
-            get_assemblies,
             get_assembly_details,
+            query_catalog,
             list_workflow_categories,
             get_workflows_in_category,
             get_compatible_workflows,
@@ -691,7 +738,11 @@ class AssistantAgent:
         augmented_message = self._wrap_user_message(state.schema_state, message)
 
         # Run the agent (with timeout + retry)
-        deps = AssistantDeps(catalog=self.catalog, sra_mirror=self.sra_mirror)
+        deps = AssistantDeps(
+            catalog=self.catalog,
+            sra_mirror=self.sra_mirror,
+            con=self.query_con,
+        )
         result = await self._run_agent_with_retry(
             augmented_message, deps=deps, message_history=agent_history
         )

--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -118,17 +118,16 @@ assemblies and tally them yourself.
 Build the query from `{field, op, value}` filters (AND-combined). Useful fields: \
 `level` (Chromosome|Complete Genome|Contig|Scaffold), `isRef` (Yes|No), `ploidy` \
 (HAPLOID|DIPLOID|POLYPLOID), `taxonomicGroup`, `length`/`gcPercent`/`scaffoldN50`/\
-`scaffoldCount` (numeric), `geneModelUrl` (use not_null for "has gene annotation"). \
+`scaffoldCount` (numeric). \
 Filter an organism by scientific name via `taxonomicLevelSpecies`, a clade via the \
 matching rank column (e.g. `taxonomicLevelGenus` = "Anopheles"), or an arbitrary \
 taxid subtree via `lineageTaxonomyIds contains "<taxid>"`. Use operation `count` \
 for "how many", `facets` (with `facet_by`) for "by/per X", else `list`. OR within a \
 field = `in` (scalar) or `contains_any` (list); a range = two predicates (gte + lte).
 
-When a list comes back `truncated`, do not dump all rows or silently page: state \
-the total, summarize the returned facet breakdown, point to the reference assembly \
-(isRef=Yes) as the usual starting point, and offer to narrow (e.g. complete-genome \
-only) or browse — only page further if the user explicitly asks.
+For a large or truncated result, summarize it (the total plus a short breakdown \
+by level) and offer a few ways to narrow. You can note which assembly is the \
+reference (isRef=Yes).
 
 (`search_organisms` resolves an organism name to the catalog; `get_assembly_details` \
 looks up one assembly by accession. Use `query_catalog` for everything that counts, \
@@ -175,8 +174,8 @@ see the catalog's default annotation for an assembly; the full set of \
 available GTFs (including VEuPathDB and other sources) is offered in the \
 gene-annotation step at workflow setup, sourced live from UCSC.
 
-When recommending an assembly, prefer the reference assembly if one exists, \
-especially if it has a gene annotation (GTF) available.
+When the user is choosing an assembly, you can point out which one is the \
+reference (isRef=Yes) so they can decide.
 
 ## Response guidelines
 

--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -390,15 +390,20 @@ class AssistantAgent:
 
         Degrades to None (tool reports unavailable) if duckdb or the catalog
         can't load, so the rest of the agent still works. connect() fail-softs to
-        None (with typed logging) for catalog problems; this method's try/except
-        additionally catches the ImportError connect() raises if duckdb is missing.
+        None (with typed logging) for catalog problems, so the only expected
+        failure here is the ImportError it raises when duckdb isn't installed.
+        Anything else is unexpected — keep the agent working but log a traceback
+        rather than swallow it silently.
         """
         try:
             from app.services.tools.catalog_query import connect
 
             return connect(self.settings.CATALOG_PATH)
-        except Exception as e:  # noqa: BLE001
-            logger.warning("Catalog query engine unavailable: %s", e)
+        except ImportError as e:
+            logger.warning("Catalog query engine unavailable (duckdb missing): %s", e)
+            return None
+        except Exception:
+            logger.exception("Catalog query engine failed to initialize")
             return None
 
     def _init_agent(self) -> None:

--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -125,12 +125,10 @@ contains "<taxid>"`. Use `count` for "how many", `facets` (with `facet_by`) for 
 `scaffoldN50`). OR within a field = `in` (scalar) or `contains_any` (list); a range \
 = two predicates (gte + lte).
 
-Answer "assemblies for an organism" the same way however it is phrased ("what", \
-"list", "show"): run a `list`, then give the total, a one-line breakdown by level, \
-the returned rows as a table, and a couple of ways to narrow or sort — noting which \
-assembly is the reference (isRef=Yes). The catalog already orders the page best-\
-first (reference, then largest scaffold N50), so present the rows in the order \
-returned.
+Render the result by what it contains: state the `total`; show any `facets` as a \
+short breakdown; show `rows` as a table in the order returned; if `truncated`, give \
+the total and offer to narrow or sort. Note which assembly is the reference \
+(isRef=Yes).
 
 (Use `search_organisms` to resolve an organism name, and `get_assembly_details` \
 for a single accession.)

--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -390,14 +390,13 @@ class AssistantAgent:
         """In-process DuckDB connection backing the query_catalog tool.
 
         Degrades to None (tool reports unavailable) if duckdb or the catalog
-        can't load, so the rest of the agent still works.
+        can't load, so the rest of the agent still works. connect() fail-softs to
+        None with typed logging; this guards the duckdb-not-installed case too.
         """
         try:
             from app.services.tools.catalog_query import connect
 
-            con = connect(self.settings.CATALOG_PATH)
-            logger.info("Catalog query engine (DuckDB) initialized")
-            return con
+            return connect(self.settings.CATALOG_PATH)
         except Exception as e:  # noqa: BLE001
             logger.warning("Catalog query engine unavailable: %s", e)
             return None

--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -107,31 +107,33 @@ categories, check compatibility between workflows and assemblies, and more. \
 has 1,900+ organisms and 5,000+ assemblies, so your training data may be \
 out of date.
 
-### query_catalog — counting, filtering, and aggregating assemblies
+### query_catalog — the way to count, filter, list, sort, and aggregate assemblies
 
-For any question that counts, filters, or aggregates genome **assemblies** — "how \
-many…", "which assemblies that are…", a clade, or a "by/per X" breakdown — use \
-`query_catalog`. It runs the filter/count in the database and returns a summary \
-(total, a capped page of rows, facets), correct at any scale. Do NOT enumerate \
-assemblies and tally them yourself.
+`query_catalog` answers every question about genome **assemblies**: how many, which \
+ones match attributes, a clade, a "by/per X" breakdown, or "assemblies for an \
+organism". It runs the filter/count/sort in the database and returns a correct \
+summary at any scale (total, a capped page of rows, facets).
 
-Build the query from `{field, op, value}` filters (AND-combined). Useful fields: \
-`level` (Chromosome|Complete Genome|Contig|Scaffold), `isRef` (Yes|No), `ploidy` \
+Build it from `{field, op, value}` filters (AND-combined). Useful fields: `level` \
+(Chromosome|Complete Genome|Contig|Scaffold), `isRef` (Yes|No), `ploidy` \
 (HAPLOID|DIPLOID|POLYPLOID), `taxonomicGroup`, `length`/`gcPercent`/`scaffoldN50`/\
-`scaffoldCount` (numeric). \
-Filter an organism by scientific name via `taxonomicLevelSpecies`, a clade via the \
-matching rank column (e.g. `taxonomicLevelGenus` = "Anopheles"), or an arbitrary \
-taxid subtree via `lineageTaxonomyIds contains "<taxid>"`. Use operation `count` \
-for "how many", `facets` (with `facet_by`) for "by/per X", else `list`. OR within a \
-field = `in` (scalar) or `contains_any` (list); a range = two predicates (gte + lte).
+`scaffoldCount` (numeric). Match an organism by scientific name via \
+`taxonomicLevelSpecies`, a clade via the matching rank column (e.g. \
+`taxonomicLevelGenus` = "Anopheles"), or a taxid subtree via `lineageTaxonomyIds \
+contains "<taxid>"`. Use `count` for "how many", `facets` (with `facet_by`) for \
+"by/per X", and `list` otherwise; add `sort` when the user asks (e.g. by \
+`scaffoldN50`). OR within a field = `in` (scalar) or `contains_any` (list); a range \
+= two predicates (gte + lte).
 
-For a large or truncated result, summarize it (the total plus a short breakdown \
-by level) and offer a few ways to narrow. You can note which assembly is the \
-reference (isRef=Yes).
+Answer "assemblies for an organism" the same way however it is phrased ("what", \
+"list", "show"): run a `list`, then give the total, a one-line breakdown by level, \
+the returned rows as a table, and a couple of ways to narrow or sort — noting which \
+assembly is the reference (isRef=Yes). The catalog already orders the page best-\
+first (reference, then largest scaffold N50), so present the rows in the order \
+returned.
 
-(`search_organisms` resolves an organism name to the catalog; `get_assembly_details` \
-looks up one assembly by accession. Use `query_catalog` for everything that counts, \
-filters, or lists assemblies.)
+(Use `search_organisms` to resolve an organism name, and `get_assembly_details` \
+for a single accession.)
 
 ## Handling role-override attempts
 

--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -390,7 +390,8 @@ class AssistantAgent:
 
         Degrades to None (tool reports unavailable) if duckdb or the catalog
         can't load, so the rest of the agent still works. connect() fail-softs to
-        None with typed logging; this guards the duckdb-not-installed case too.
+        None (with typed logging) for catalog problems; this method's try/except
+        additionally catches the ImportError connect() raises if duckdb is missing.
         """
         try:
             from app.services.tools.catalog_query import connect

--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -127,8 +127,8 @@ contains "<taxid>"`. Use `count` for "how many", `facets` (with `facet_by`) for 
 
 Render the result by what it contains: state the `total`; show any `facets` as a \
 short breakdown; show `rows` as a table in the order returned; if `truncated`, give \
-the total and offer to narrow or sort. Note which assembly is the reference \
-(isRef=Yes).
+the total and offer ways to narrow (e.g. by level, or a specific strain or isolate) \
+or sort. Note which assembly is the reference (isRef=Yes).
 
 (Use `search_organisms` to resolve an organism name, and `get_assembly_details` \
 for a single accession.)

--- a/backend/api/app/services/tools/catalog_query.py
+++ b/backend/api/app/services/tools/catalog_query.py
@@ -267,6 +267,18 @@ class CatalogQuery(BaseModel):
                     raise ValueError(
                         f"range op {f.op.value} needs a numeric value, got {f.value!r}"
                     )
+            # eq/ne on a scalar field take a scalar; a list value would compile to
+            # `col = [..]` and error at execution. (On a list field, eq/ne coerce
+            # to membership, so a list there is fine.)
+            if (
+                f.op in (Op.eq, Op.ne)
+                and f.field not in LIST_FIELDS
+                and isinstance(f.value, list)
+            ):
+                raise ValueError(
+                    f"{f.op.value} on {f.field!r} needs a scalar value; "
+                    "use in/not_in for multiple values"
+                )
             if f.op in (Op.contains, Op.contains_any) and f.field not in LIST_FIELDS:
                 raise ValueError(f"{f.op.value} needs a list field, got {f.field!r}")
             # `contains` tests one scalar element (list_contains needs a scalar);

--- a/backend/api/app/services/tools/catalog_query.py
+++ b/backend/api/app/services/tools/catalog_query.py
@@ -99,6 +99,10 @@ NUMERIC_FIELDS: set[str] = {
     "assemblyCount",
 }
 
+# Cap on buckets returned per faceted column (top-N by count) — keeps a facet on
+# a high-cardinality field from returning thousands of rows.
+_FACET_LIMIT = 50
+
 # Facets auto-returned on a truncated list, so the model can offer narrowing.
 _AUTO_FACET_FIELDS: dict[str, list[str]] = {
     "assembly": ["level", "isRef"],
@@ -165,8 +169,9 @@ class CatalogQuery(BaseModel):
     operation: str = "list"  # count | list | facets
     facet_by: list[str] = Field(default_factory=list)
     # Bound the page so a `list` result can never dump the corpus into context —
-    # the whole point of the summary contract is bounded output.
-    limit: int = Field(default=25, ge=1, le=100)
+    # the contract is a bounded summary; over the cap we truncate and offer to
+    # narrow rather than page, so the max matches the default.
+    limit: int = Field(default=25, ge=1, le=25)
     offset: int = Field(default=0, ge=0)
     sort: list[Sort] = Field(default_factory=list)
 
@@ -208,6 +213,8 @@ class CatalogQuery(BaseModel):
             # compiles to a comparison against NULL that silently matches nothing.
             if f.op not in (Op.is_null, Op.not_null) and f.value is None:
                 raise ValueError(f"{f.op.value} needs a value")
+            # (A None *inside* a value list — IN (NULL, ...) — is already rejected
+            # by the Filter type: list[Scalar] excludes None, so it can't occur.)
             if f.op in (Op.gt, Op.gte, Op.lt, Op.lte) and f.field not in NUMERIC_FIELDS:
                 raise ValueError(
                     f"range op {f.op.value} needs a numeric field, got {f.field!r}"
@@ -365,9 +372,11 @@ def execute(q: CatalogQuery, con) -> dict:
     def _facets(cols: list[str]) -> dict:
         out = {}
         for col in cols:
+            # Cap to the top buckets by count — a high-cardinality field (e.g.
+            # a species column) would otherwise return thousands of buckets.
             rows = con.execute(
                 f"SELECT {col} AS k, count(*) AS c FROM {q.entity} "
-                f"WHERE {where} GROUP BY {col} ORDER BY c DESC",
+                f"WHERE {where} GROUP BY {col} ORDER BY c DESC LIMIT {_FACET_LIMIT}",
                 params,
             ).fetchall()
             out[col] = {str(k): c for k, c in rows}

--- a/backend/api/app/services/tools/catalog_query.py
+++ b/backend/api/app/services/tools/catalog_query.py
@@ -82,6 +82,12 @@ ENTITY_FIELDS: dict[str, set[str]] = {
     "organism": ORGANISM_FIELDS,
 }
 
+# Entities the executor can actually run — connect() must load a table for each.
+# organism vocab is defined above but no table is loaded yet (assembly-first), so
+# querying it is rejected at validation rather than failing mid-execution. Add an
+# entity here only once connect() loads its table.
+QUERYABLE_ENTITIES: set[str] = {"assembly"}
+
 LIST_FIELDS: set[str] = {"lineageTaxonomyIds", "ploidy", "taxonomicGroup", "otherTaxa"}
 NUMERIC_FIELDS: set[str] = {
     "length",
@@ -167,6 +173,11 @@ class CatalogQuery(BaseModel):
         if self.entity not in ENTITY_FIELDS:
             raise ValueError(
                 f"unknown entity {self.entity!r}; valid: {sorted(ENTITY_FIELDS)}"
+            )
+        if self.entity not in QUERYABLE_ENTITIES:
+            raise ValueError(
+                f"entity {self.entity!r} is not queryable yet (no table loaded); "
+                f"supported: {sorted(QUERYABLE_ENTITIES)}"
             )
         if self.operation not in ("count", "list", "facets"):
             raise ValueError(f"unknown operation {self.operation!r}")

--- a/backend/api/app/services/tools/catalog_query.py
+++ b/backend/api/app/services/tools/catalog_query.py
@@ -350,9 +350,12 @@ def connect(catalog_dir: str):
 
     Concurrency invariant: the assistant's tools are sync and run on the asyncio
     event-loop thread, so this single connection is only ever touched by one
-    thread at a time and needs no lock or per-thread cursor. If tool execution is
-    ever moved to a threadpool, that invariant breaks — DuckDB does not allow
-    concurrent use of one connection across threads (use con.cursor() per thread).
+    thread at a time and needs no lock. If tool execution is ever moved to a
+    threadpool, that invariant breaks — a single DuckDBPyConnection is not safe
+    for concurrent use across threads. The fix is a per-thread connection via
+    `con.cursor()`, which returns a separate connection that shares THIS in-memory
+    database (a fresh `duckdb.connect()` would be a new, empty database without the
+    loaded table); alternatively, serialize access through a single-thread executor.
     """
     import duckdb
 

--- a/backend/api/app/services/tools/catalog_query.py
+++ b/backend/api/app/services/tools/catalog_query.py
@@ -221,6 +221,12 @@ class CatalogQuery(BaseModel):
                 )
             if f.op in (Op.contains, Op.contains_any) and f.field not in LIST_FIELDS:
                 raise ValueError(f"{f.op.value} needs a list field, got {f.field!r}")
+            # `contains` tests one scalar element (list_contains needs a scalar);
+            # a list value belongs to `contains_any`.
+            if f.op is Op.contains and isinstance(f.value, list):
+                raise ValueError(
+                    "contains needs a scalar value; use contains_any for a list"
+                )
             # `in`/`not_in`/`contains_any` over an empty list is either invalid SQL
             # (IN ()) or a silent match-nothing — require a non-empty value list.
             if (
@@ -320,13 +326,13 @@ def connect(catalog_dir: str):
     con: Optional["duckdb.DuckDBPyConnection"] = None
     try:
         con = duckdb.connect()
-        # Escape single quotes so a path containing one can't break the SQL
-        # string literal (the path is server-controlled, but cheap to harden).
-        safe_path = str(json_path).replace("'", "''")
+        # Bind the path as a parameter so DuckDB handles any special characters
+        # (no bespoke quoting needed).
         con.execute(
             "CREATE TABLE assembly AS "
-            f"SELECT * FROM read_json_auto('{safe_path}', "
-            "format='array', maximum_object_size=20000000)"
+            "SELECT * FROM read_json_auto(?, "
+            "format='array', maximum_object_size=20000000)",
+            [str(json_path)],
         )
         total = con.execute("SELECT count(*) FROM assembly").fetchone()[0]
         # The field allowlist and display projection are hand-maintained; warn

--- a/backend/api/app/services/tools/catalog_query.py
+++ b/backend/api/app/services/tools/catalog_query.py
@@ -164,8 +164,10 @@ class CatalogQuery(BaseModel):
     filters: list[Filter] = Field(default_factory=list)
     operation: str = "list"  # count | list | facets
     facet_by: list[str] = Field(default_factory=list)
-    limit: int = 25
-    offset: int = 0
+    # Bound the page so a `list` result can never dump the corpus into context —
+    # the whole point of the summary contract is bounded output.
+    limit: int = Field(default=25, ge=1, le=100)
+    offset: int = Field(default=0, ge=0)
     sort: list[Sort] = Field(default_factory=list)
 
     @model_validator(mode="after")
@@ -193,6 +195,14 @@ class CatalogQuery(BaseModel):
                 f"unknown field(s) {unknown} for entity {self.entity!r}; "
                 f"valid fields: {sorted(allowed)}"
             )
+        # GROUP BY on a list column buckets by whole-list equality (and yields
+        # list-repr keys), not per-element counts — reject it rather than mislead.
+        list_facets = sorted({c for c in self.facet_by if c in LIST_FIELDS})
+        if list_facets:
+            raise ValueError(
+                f"cannot facet on list field(s) {list_facets}; "
+                "group-by needs a scalar field"
+            )
         for f in self.filters:
             if f.op in (Op.gt, Op.gte, Op.lt, Op.lte) and f.field not in NUMERIC_FIELDS:
                 raise ValueError(
@@ -200,6 +210,14 @@ class CatalogQuery(BaseModel):
                 )
             if f.op in (Op.contains, Op.contains_any) and f.field not in LIST_FIELDS:
                 raise ValueError(f"{f.op.value} needs a list field, got {f.field!r}")
+            # `in`/`not_in`/`contains_any` over an empty list is either invalid SQL
+            # (IN ()) or a silent match-nothing — require a non-empty value list.
+            if (
+                f.op in (Op.in_, Op.not_in, Op.contains_any)
+                and isinstance(f.value, list)
+                and not f.value
+            ):
+                raise ValueError(f"{f.op.value} needs a non-empty value list")
         return self
 
 
@@ -231,13 +249,20 @@ def compile_predicate(f: Filter) -> tuple[str, list]:
     if col in LIST_FIELDS and f.op in (Op.eq, Op.ne, Op.in_, Op.not_in):
         vals = f.value if isinstance(f.value, list) else [f.value]
         expr = _list_membership(col)
-        neg = f.op in (Op.ne, Op.not_in)
-        return (f"NOT ({expr})" if neg else expr), [list(vals)]
+        if f.op in (Op.ne, Op.not_in):
+            # NULL-safe negation: a row with no value is "not a member" too, so
+            # count it — otherwise count(eq) + count(ne) wouldn't sum to total.
+            return f"(NOT ({expr}) OR {col} IS NULL)", [list(vals)]
+        return expr, [list(vals)]
     if f.op in (Op.in_, Op.not_in):
         vals = f.value if isinstance(f.value, list) else [f.value]
         ph = ", ".join(["?"] * len(vals))
-        neg = "NOT " if f.op is Op.not_in else ""
-        return f"{col} {neg}IN ({ph})", list(vals)
+        if f.op is Op.not_in:
+            return f"({col} NOT IN ({ph}) OR {col} IS NULL)", list(vals)
+        return f"{col} IN ({ph})", list(vals)
+    if f.op is Op.ne:
+        # NULL-safe inequality (SQL `col != x` drops NULL rows).
+        return f"({col} != ? OR {col} IS NULL)", [f.value]
     if f.op is Op.contains:
         return f"list_contains({col}, ?)", [f.value]
     if f.op is Op.contains_any:
@@ -290,6 +315,18 @@ def connect(catalog_dir: str):
             "format='array', maximum_object_size=20000000)"
         )
         total = con.execute("SELECT count(*) FROM assembly").fetchone()[0]
+        # The field allowlist and display projection are hand-maintained; warn
+        # loudly at boot if the catalog schema has drifted out from under them
+        # (a missing display column would otherwise crash every `list` query).
+        actual = {row[0] for row in con.execute("DESCRIBE assembly").fetchall()}
+        configured = ASSEMBLY_FIELDS | set(_DISPLAY_COLUMNS["assembly"])
+        missing = sorted(configured - actual)
+        if missing:
+            logger.warning(
+                "Catalog query: configured columns missing from the assembly "
+                "table: %s — filters/projections referencing them will error",
+                missing,
+            )
     except duckdb.IOException as exc:
         logger.error("Could not read catalog at %s: %s", json_path, exc)
     except duckdb.CatalogException as exc:

--- a/backend/api/app/services/tools/catalog_query.py
+++ b/backend/api/app/services/tools/catalog_query.py
@@ -299,13 +299,14 @@ class CatalogQuery(BaseModel):
                 raise ValueError(
                     "contains needs a scalar value; use contains_any for a list"
                 )
-            # `in`/`not_in`/`contains_any` over an empty list is either invalid SQL
-            # (IN ()) or a silent match-nothing — require a non-empty value list.
-            if (
-                f.op in (Op.in_, Op.not_in, Op.contains_any)
-                and isinstance(f.value, list)
-                and not f.value
-            ):
+            # An empty list value is never meaningful: invalid SQL (IN ()) or a
+            # silent match-nothing/everything. Reject it for every op that
+            # consumes a list — in/not_in/contains_any always, plus eq/ne when
+            # they coerce to list membership on a list field.
+            consumes_list = f.op in (Op.in_, Op.not_in, Op.contains_any) or (
+                f.op in (Op.eq, Op.ne) and f.field in LIST_FIELDS
+            )
+            if consumes_list and isinstance(f.value, list) and not f.value:
                 raise ValueError(f"{f.op.value} needs a non-empty value list")
         return self
 

--- a/backend/api/app/services/tools/catalog_query.py
+++ b/backend/api/app/services/tools/catalog_query.py
@@ -103,6 +103,49 @@ NUMERIC_FIELDS: set[str] = {
 # a high-cardinality field from returning thousands of rows.
 _FACET_LIMIT = 50
 
+# DuckDB base type names treated as numeric for the connect() schema-drift check.
+_NUMERIC_DUCKDB_TYPES = {
+    "TINYINT",
+    "SMALLINT",
+    "INTEGER",
+    "BIGINT",
+    "HUGEINT",
+    "UTINYINT",
+    "USMALLINT",
+    "UINTEGER",
+    "UBIGINT",
+    "UHUGEINT",
+    "FLOAT",
+    "DOUBLE",
+    "REAL",
+    "DECIMAL",
+    "NUMERIC",
+}
+
+
+def _schema_issues(coltypes: dict[str, str]) -> tuple[list[str], list[str]]:
+    """Compare the loaded assembly columns (name -> UPPERCASE DuckDB type) against
+    the hand-maintained allowlist. Returns (missing, mistyped):
+
+    - missing: configured columns absent from the table.
+    - mistyped: numeric fields not inferred numeric, or list fields not inferred
+      as lists — these compile to SQL that errors or mis-sorts at query time.
+    """
+    actual = set(coltypes)
+    configured = ASSEMBLY_FIELDS | set(_DISPLAY_COLUMNS["assembly"])
+    missing = sorted(configured - actual)
+    mistyped = sorted(
+        f"{c}={coltypes[c]}"
+        for c in NUMERIC_FIELDS & actual
+        if coltypes[c].split("(")[0] not in _NUMERIC_DUCKDB_TYPES
+    ) + sorted(
+        f"{c}={coltypes[c]}"
+        for c in LIST_FIELDS & actual
+        if not coltypes[c].endswith("[]")
+    )
+    return missing, mistyped
+
+
 # Facets auto-returned on a truncated list, so the model can offer narrowing.
 _AUTO_FACET_FIELDS: dict[str, list[str]] = {
     "assembly": ["level", "isRef"],
@@ -188,6 +231,8 @@ class CatalogQuery(BaseModel):
             )
         if self.operation not in ("count", "list", "facets"):
             raise ValueError(f"unknown operation {self.operation!r}")
+        if self.operation == "facets" and not self.facet_by:
+            raise ValueError("operation 'facets' needs at least one facet_by field")
         allowed = ENTITY_FIELDS[self.entity]
         referenced = (
             [f.field for f in self.filters]
@@ -343,13 +388,17 @@ def connect(catalog_dir: str):
         # gone), fail closed — disable the engine rather than serve queries that
         # would error or silently mislead. A drift is a build problem to fix, not
         # something to paper over.
-        actual = {row[0] for row in con.execute("DESCRIBE assembly").fetchall()}
-        missing = sorted((ASSEMBLY_FIELDS | set(_DISPLAY_COLUMNS["assembly"])) - actual)
-        if missing:
+        coltypes = {
+            row[0]: str(row[1]).upper()
+            for row in con.execute("DESCRIBE assembly").fetchall()
+        }
+        missing, mistyped = _schema_issues(coltypes)
+        if missing or mistyped:
             logger.error(
-                "Catalog query disabled: assembly table is missing configured "
-                "columns %s — the catalog schema has drifted from catalog_query.py",
+                "Catalog query disabled: assembly schema has drifted from "
+                "catalog_query.py — missing columns %s, mistyped %s",
                 missing,
+                mistyped,
             )
             con.close()
             return None

--- a/backend/api/app/services/tools/catalog_query.py
+++ b/backend/api/app/services/tools/catalog_query.py
@@ -253,6 +253,11 @@ def _list_membership(col: str) -> str:
     return f"len(list_intersect({col}, ?)) > 0"
 
 
+def _as_list(value) -> list:
+    """Normalize a scalar-or-list filter value to a list."""
+    return value if isinstance(value, list) else [value]
+
+
 def _compile_predicate(f: Filter) -> tuple[str, list]:
     col = f.field
     if f.op is Op.is_null:
@@ -264,27 +269,25 @@ def _compile_predicate(f: Filter) -> tuple[str, list]:
     # reading. Coercing it lets the model's natural `eq`/`in` phrasing work
     # without a failed round-trip.
     if col in LIST_FIELDS and f.op in (Op.eq, Op.ne, Op.in_, Op.not_in):
-        vals = f.value if isinstance(f.value, list) else [f.value]
         expr = _list_membership(col)
         if f.op in (Op.ne, Op.not_in):
             # NULL-safe negation: a row with no value is "not a member" too, so
             # count it — otherwise count(eq) + count(ne) wouldn't sum to total.
-            return f"(NOT ({expr}) OR {col} IS NULL)", [list(vals)]
-        return expr, [list(vals)]
+            return f"(NOT ({expr}) OR {col} IS NULL)", [_as_list(f.value)]
+        return expr, [_as_list(f.value)]
     if f.op in (Op.in_, Op.not_in):
-        vals = f.value if isinstance(f.value, list) else [f.value]
+        vals = _as_list(f.value)
         ph = ", ".join(["?"] * len(vals))
         if f.op is Op.not_in:
-            return f"({col} NOT IN ({ph}) OR {col} IS NULL)", list(vals)
-        return f"{col} IN ({ph})", list(vals)
+            return f"({col} NOT IN ({ph}) OR {col} IS NULL)", vals
+        return f"{col} IN ({ph})", vals
     if f.op is Op.ne:
         # NULL-safe inequality (SQL `col != x` drops NULL rows).
         return f"({col} != ? OR {col} IS NULL)", [f.value]
     if f.op is Op.contains:
         return f"list_contains({col}, ?)", [f.value]
     if f.op is Op.contains_any:
-        vals = f.value if isinstance(f.value, list) else [f.value]
-        return _list_membership(col), [list(vals)]
+        return _list_membership(col), [_as_list(f.value)]
     return f"{col} {_SQL_BINOP[f.op]} ?", [f.value]
 
 

--- a/backend/api/app/services/tools/catalog_query.py
+++ b/backend/api/app/services/tools/catalog_query.py
@@ -335,18 +335,21 @@ def connect(catalog_dir: str):
             [str(json_path)],
         )
         total = con.execute("SELECT count(*) FROM assembly").fetchone()[0]
-        # The field allowlist and display projection are hand-maintained; warn
-        # loudly at boot if the catalog schema has drifted out from under them
-        # (a missing display column would otherwise crash every `list` query).
+        # The field allowlist and display projection are hand-maintained against
+        # the catalog schema. If the schema has drifted (a configured column is
+        # gone), fail closed — disable the engine rather than serve queries that
+        # would error or silently mislead. A drift is a build problem to fix, not
+        # something to paper over.
         actual = {row[0] for row in con.execute("DESCRIBE assembly").fetchall()}
-        configured = ASSEMBLY_FIELDS | set(_DISPLAY_COLUMNS["assembly"])
-        missing = sorted(configured - actual)
+        missing = sorted((ASSEMBLY_FIELDS | set(_DISPLAY_COLUMNS["assembly"])) - actual)
         if missing:
-            logger.warning(
-                "Catalog query: configured columns missing from the assembly "
-                "table: %s — filters/projections referencing them will error",
+            logger.error(
+                "Catalog query disabled: assembly table is missing configured "
+                "columns %s — the catalog schema has drifted from catalog_query.py",
                 missing,
             )
+            con.close()
+            return None
     except duckdb.IOException as exc:
         logger.error("Could not read catalog at %s: %s", json_path, exc)
     except duckdb.CatalogException as exc:
@@ -398,13 +401,9 @@ def execute(q: CatalogQuery, con) -> dict:
         result["facets"] = _facets(q.facet_by)
         return result
 
+    # Display columns are validated against the table at connect() time (the
+    # engine fails closed on drift), so the projection is trusted here.
     cols = _DISPLAY_COLUMNS.get(q.entity)
-    if cols:
-        # Project only columns that actually exist, so a catalog schema drift
-        # (a renamed/dropped display column) degrades the page gracefully instead
-        # of failing every list query. connect() logs a warning when this happens.
-        present = {r[0] for r in con.execute(f"DESCRIBE {q.entity}").fetchall()}
-        cols = [c for c in cols if c in present] or None
     if q.sort:
         order = "ORDER BY " + ", ".join(
             f"{s.field} {'DESC' if s.desc else 'ASC'}" for s in q.sort

--- a/backend/api/app/services/tools/catalog_query.py
+++ b/backend/api/app/services/tools/catalog_query.py
@@ -153,12 +153,14 @@ _AUTO_FACET_FIELDS: dict[str, list[str]] = {
 # Curated projection for `list` rows (keeps tokens bounded vs SELECT *).
 _DISPLAY_COLUMNS: dict[str, list[str]] = {
     "assembly": [
+        # ploidy is intentionally omitted — it's an organism-level attribute
+        # (constant across all of an organism's assemblies), so a per-row column
+        # is redundant. It stays a filterable field, just not displayed.
         "accession",
         "taxonomicLevelSpecies",
         "strainName",
         "level",
         "isRef",
-        "ploidy",
         "length",
         "scaffoldN50",
         "geneModelUrl",

--- a/backend/api/app/services/tools/catalog_query.py
+++ b/backend/api/app/services/tools/catalog_query.py
@@ -253,7 +253,7 @@ def _list_membership(col: str) -> str:
     return f"len(list_intersect({col}, ?)) > 0"
 
 
-def compile_predicate(f: Filter) -> tuple[str, list]:
+def _compile_predicate(f: Filter) -> tuple[str, list]:
     col = f.field
     if f.op is Op.is_null:
         return f"{col} IS NULL", []
@@ -288,12 +288,12 @@ def compile_predicate(f: Filter) -> tuple[str, list]:
     return f"{col} {_SQL_BINOP[f.op]} ?", [f.value]
 
 
-def compile_where(q: CatalogQuery) -> tuple[str, list]:
+def _compile_where(q: CatalogQuery) -> tuple[str, list]:
     if not q.filters:
         return "TRUE", []
     frags, params = [], []
     for f in q.filters:
-        frag, p = compile_predicate(f)
+        frag, p = _compile_predicate(f)
         frags.append(frag)
         params.extend(p)
     return " AND ".join(frags), params
@@ -375,7 +375,7 @@ def execute(q: CatalogQuery, con) -> dict:
     (SQL identifiers can't be) — the CatalogQuery allowlist validator is what
     gates that interpolation, so don't loosen it without revisiting this.
     """
-    where, params = compile_where(q)
+    where, params = _compile_where(q)
     cap = q.limit
 
     def _facets(cols: list[str]) -> dict:
@@ -388,7 +388,7 @@ def execute(q: CatalogQuery, con) -> dict:
                 f"WHERE {where} GROUP BY {col} ORDER BY c DESC LIMIT {_FACET_LIMIT}",
                 params,
             ).fetchall()
-            out[col] = {str(k): c for k, c in rows}
+            out[col] = {("(none)" if k is None else str(k)): c for k, c in rows}
         return out
 
     total = con.execute(
@@ -420,7 +420,7 @@ def execute(q: CatalogQuery, con) -> dict:
     )
     colnames = [d[0] for d in cur.description]
     raw = cur.fetchall()
-    rows = [dict(zip(colnames, r)) for r in raw]
+    rows = [dict(zip(colnames, r, strict=True)) for r in raw]
     result["truncated"] = len(rows) > cap
     result["rows"] = rows[:cap]
     result["returned"] = len(result["rows"])

--- a/backend/api/app/services/tools/catalog_query.py
+++ b/backend/api/app/services/tools/catalog_query.py
@@ -204,6 +204,10 @@ class CatalogQuery(BaseModel):
                 "group-by needs a scalar field"
             )
         for f in self.filters:
+            # Every op except the null checks needs a value; without this, a None
+            # compiles to a comparison against NULL that silently matches nothing.
+            if f.op not in (Op.is_null, Op.not_null) and f.value is None:
+                raise ValueError(f"{f.op.value} needs a value")
             if f.op in (Op.gt, Op.gte, Op.lt, Op.lte) and f.field not in NUMERIC_FIELDS:
                 raise ValueError(
                     f"range op {f.op.value} needs a numeric field, got {f.field!r}"
@@ -309,9 +313,12 @@ def connect(catalog_dir: str):
     con: Optional["duckdb.DuckDBPyConnection"] = None
     try:
         con = duckdb.connect()
+        # Escape single quotes so a path containing one can't break the SQL
+        # string literal (the path is server-controlled, but cheap to harden).
+        safe_path = str(json_path).replace("'", "''")
         con.execute(
             "CREATE TABLE assembly AS "
-            f"SELECT * FROM read_json_auto('{json_path}', "
+            f"SELECT * FROM read_json_auto('{safe_path}', "
             "format='array', maximum_object_size=20000000)"
         )
         total = con.execute("SELECT count(*) FROM assembly").fetchone()[0]
@@ -376,12 +383,15 @@ def execute(q: CatalogQuery, con) -> dict:
         result["facets"] = _facets(q.facet_by)
         return result
 
-    order = ""
+    cols = _DISPLAY_COLUMNS.get(q.entity)
     if q.sort:
         order = "ORDER BY " + ", ".join(
             f"{s.field} {'DESC' if s.desc else 'ASC'}" for s in q.sort
         )
-    cols = _DISPLAY_COLUMNS.get(q.entity)
+    else:
+        # Deterministic default so the capped page / truncation is reproducible
+        # across runs (LIMIT without ORDER BY is unordered).
+        order = f"ORDER BY {cols[0]}" if cols else ""
     select = ", ".join(cols) if cols else "*"
     cur = con.execute(
         f"SELECT {select} FROM {q.entity} WHERE {where} {order} "

--- a/backend/api/app/services/tools/catalog_query.py
+++ b/backend/api/app/services/tools/catalog_query.py
@@ -385,7 +385,9 @@ def execute(q: CatalogQuery, con) -> dict:
             # a species column) would otherwise return thousands of buckets.
             rows = con.execute(
                 f"SELECT {col} AS k, count(*) AS c FROM {q.entity} "
-                f"WHERE {where} GROUP BY {col} ORDER BY c DESC LIMIT {_FACET_LIMIT}",
+                # `, k` is a stable tiebreaker so equal-count buckets (and which
+                # ones fall at the LIMIT boundary) don't shuffle across runs.
+                f"WHERE {where} GROUP BY {col} ORDER BY c DESC, k LIMIT {_FACET_LIMIT}",
                 params,
             ).fetchall()
             out[col] = {("(none)" if k is None else str(k)): c for k, c in rows}
@@ -404,14 +406,15 @@ def execute(q: CatalogQuery, con) -> dict:
     # Display columns are validated against the table at connect() time (the
     # engine fails closed on drift), so the projection is trusted here.
     cols = _DISPLAY_COLUMNS.get(q.entity)
-    if q.sort:
-        order = "ORDER BY " + ", ".join(
-            f"{s.field} {'DESC' if s.desc else 'ASC'}" for s in q.sort
-        )
-    else:
-        # Deterministic default so the capped page / truncation is reproducible
-        # across runs (LIMIT without ORDER BY is unordered).
-        order = f"ORDER BY {cols[0]}" if cols else ""
+    # Always order by a stable key so the capped page / truncation is reproducible
+    # (LIMIT without a total order is unordered). For an explicit sort, append that
+    # key as a tiebreaker so rows at the page boundary can't shuffle when the
+    # requested sort fields tie.
+    tiebreak = cols[0] if cols else None
+    terms = [f"{s.field} {'DESC' if s.desc else 'ASC'}" for s in q.sort]
+    if tiebreak and tiebreak not in {s.field for s in q.sort}:
+        terms.append(tiebreak)
+    order = "ORDER BY " + ", ".join(terms) if terms else ""
     select = ", ".join(cols) if cols else "*"
     cur = con.execute(
         f"SELECT {select} FROM {q.entity} WHERE {where} {order} "

--- a/backend/api/app/services/tools/catalog_query.py
+++ b/backend/api/app/services/tools/catalog_query.py
@@ -461,7 +461,10 @@ def execute(q: CatalogQuery, con) -> dict:
     terms = [f"{s.field} {'DESC' if s.desc else 'ASC'}" for s in q.sort]
     if tiebreak and tiebreak not in {s.field for s in q.sort}:
         terms.append(tiebreak)
-    order = "ORDER BY " + ", ".join(terms) if terms else ""
+    # Always emit an ORDER BY so LIMIT/OFFSET is reproducible. For assembly the
+    # tiebreak (accession) guarantees a term; `1` is a last-resort positional
+    # fallback for any future entity without display columns.
+    order = "ORDER BY " + ", ".join(terms or ["1"])
     select = ", ".join(cols) if cols else "*"
     cur = con.execute(
         f"SELECT {select} FROM {q.entity} WHERE {where} {order} "

--- a/backend/api/app/services/tools/catalog_query.py
+++ b/backend/api/app/services/tools/catalog_query.py
@@ -493,5 +493,14 @@ def execute(q: CatalogQuery, con) -> dict:
     result["rows"] = rows[:cap]
     result["returned"] = len(result["rows"])
     if result["truncated"]:
-        result["facets"] = _facets(_AUTO_FACET_FIELDS.get(q.entity, []))
+        # Auto-facets are narrowing hints: only surface a breakdown that actually
+        # discriminates (>1 bucket). A single-bucket facet (e.g. isRef={No: N}
+        # when nothing is a reference) offers no choice, so drop it.
+        auto = {
+            col: buckets
+            for col, buckets in _facets(_AUTO_FACET_FIELDS.get(q.entity, [])).items()
+            if len(buckets) > 1
+        }
+        if auto:
+            result["facets"] = auto
     return result

--- a/backend/api/app/services/tools/catalog_query.py
+++ b/backend/api/app/services/tools/catalog_query.py
@@ -348,6 +348,17 @@ def _as_list(value) -> list:
     return value if isinstance(value, list) else [value]
 
 
+def _list_text(value) -> list[str]:
+    """Stringify membership value(s) for a VARCHAR[] list column.
+
+    Every LIST_FIELDS column is VARCHAR[] (taxonomy-id lists, ploidy, ...), but
+    the model naturally passes a taxid as a JSON number — and
+    `list_contains(VARCHAR[], INTEGER)` / `list_intersect` is a DuckDB binder
+    error, not a no-match. Compare as text so a numeric taxid still works.
+    """
+    return [str(v) for v in _as_list(value)]
+
+
 def _compile_predicate(f: Filter) -> tuple[str, list]:
     col = _qi(f.field)
     if f.op is Op.is_null:
@@ -363,8 +374,8 @@ def _compile_predicate(f: Filter) -> tuple[str, list]:
         if f.op in (Op.ne, Op.not_in):
             # NULL-safe negation: a row with no value is "not a member" too, so
             # count it — otherwise count(eq) + count(ne) wouldn't sum to total.
-            return f"(NOT ({expr}) OR {col} IS NULL)", [_as_list(f.value)]
-        return expr, [_as_list(f.value)]
+            return f"(NOT ({expr}) OR {col} IS NULL)", [_list_text(f.value)]
+        return expr, [_list_text(f.value)]
     if f.op in (Op.in_, Op.not_in):
         vals = _as_list(f.value)
         ph = ", ".join(["?"] * len(vals))
@@ -375,9 +386,9 @@ def _compile_predicate(f: Filter) -> tuple[str, list]:
         # NULL-safe inequality (SQL `col != x` drops NULL rows).
         return f"({col} != ? OR {col} IS NULL)", [f.value]
     if f.op is Op.contains:
-        return f"list_contains({col}, ?)", [f.value]
+        return f"list_contains({col}, ?)", [str(f.value)]
     if f.op is Op.contains_any:
-        return _list_membership(col), [_as_list(f.value)]
+        return _list_membership(col), [_list_text(f.value)]
     return f"{col} {_SQL_BINOP[f.op]} ?", [f.value]
 
 

--- a/backend/api/app/services/tools/catalog_query.py
+++ b/backend/api/app/services/tools/catalog_query.py
@@ -14,10 +14,14 @@ Assembly-first; organism is sketched. Workflows stay on their dedicated tools.
 
 from __future__ import annotations
 
+import logging
 from enum import Enum
+from pathlib import Path
 from typing import Optional, Union
 
 from pydantic import BaseModel, Field, model_validator
+
+logger = logging.getLogger(__name__)
 
 ASSEMBLY_FIELDS: set[str] = {
     "accession",
@@ -238,16 +242,54 @@ def compile_where(q: CatalogQuery) -> tuple[str, list]:
 
 
 def connect(catalog_dir: str):
-    """Load the catalog into an in-memory DuckDB connection (assembly table)."""
+    """Load the catalog into an in-memory DuckDB connection (assembly table).
+
+    Returns the connection, or None if the catalog can't be loaded (the caller
+    degrades to a "query engine unavailable" tool response).
+
+    Concurrency invariant: the assistant's tools are sync and run on the asyncio
+    event-loop thread, so this single connection is only ever touched by one
+    thread at a time and needs no lock or per-thread cursor. If tool execution is
+    ever moved to a threadpool, that invariant breaks — DuckDB does not allow
+    concurrent use of one connection across threads (use con.cursor() per thread).
+    """
     import duckdb
 
-    con = duckdb.connect()
-    con.execute(
-        "CREATE TABLE assembly AS "
-        f"SELECT * FROM read_json_auto('{catalog_dir}/assemblies.json', "
-        "format='array', maximum_object_size=20000000)"
-    )
-    return con
+    json_path = Path(catalog_dir) / "assemblies.json"
+    if not json_path.is_file():
+        logger.warning(
+            "Catalog assemblies not found at %s — query engine disabled", json_path
+        )
+        return None
+
+    # Build into a local handle and publish only on full success, so a load
+    # failure can't leave a half-initialized connection in play. Distinct except
+    # arms give an actionable log line instead of one flattened traceback.
+    con: Optional["duckdb.DuckDBPyConnection"] = None
+    try:
+        con = duckdb.connect()
+        con.execute(
+            "CREATE TABLE assembly AS "
+            f"SELECT * FROM read_json_auto('{json_path}', "
+            "format='array', maximum_object_size=20000000)"
+        )
+        total = con.execute("SELECT count(*) FROM assembly").fetchone()[0]
+    except duckdb.IOException as exc:
+        logger.error("Could not read catalog at %s: %s", json_path, exc)
+    except duckdb.CatalogException as exc:
+        logger.error(
+            "Catalog at %s is missing an expected structure: %s", json_path, exc
+        )
+    except duckdb.Error as exc:
+        logger.error("Failed to load catalog into DuckDB from %s: %s", json_path, exc)
+    else:
+        logger.info("Catalog query engine (DuckDB) loaded: %s assemblies", f"{total:,}")
+        return con
+
+    # Reached only on a caught failure: close the opened handle and stay disabled.
+    if con is not None:
+        con.close()
+    return None
 
 
 def execute(q: CatalogQuery, con, cap: Optional[int] = None) -> dict:

--- a/backend/api/app/services/tools/catalog_query.py
+++ b/backend/api/app/services/tools/catalog_query.py
@@ -399,6 +399,12 @@ def execute(q: CatalogQuery, con) -> dict:
         return result
 
     cols = _DISPLAY_COLUMNS.get(q.entity)
+    if cols:
+        # Project only columns that actually exist, so a catalog schema drift
+        # (a renamed/dropped display column) degrades the page gracefully instead
+        # of failing every list query. connect() logs a warning when this happens.
+        present = {r[0] for r in con.execute(f"DESCRIBE {q.entity}").fetchall()}
+        cols = [c for c in cols if c in present] or None
     if q.sort:
         order = "ORDER BY " + ", ".join(
             f"{s.field} {'DESC' if s.desc else 'ASC'}" for s in q.sort

--- a/backend/api/app/services/tools/catalog_query.py
+++ b/backend/api/app/services/tools/catalog_query.py
@@ -216,10 +216,11 @@ class CatalogQuery(BaseModel):
     filters: list[Filter] = Field(default_factory=list)
     operation: Literal["count", "list", "facets"] = "list"
     facet_by: list[str] = Field(default_factory=list)
-    # Bound the page so a `list` result can never dump the corpus into context —
-    # the contract is a bounded summary; over the cap we truncate and offer to
-    # narrow rather than page, so the max matches the default.
-    limit: int = Field(default=25, ge=1, le=25)
+    # Bound the page to a small, fixed size so a `list` is always a short, fully
+    # rendered table — never a corpus dump or a variable-length one. The cap is the
+    # default (the model can't inflate it); over it we truncate and offer to narrow
+    # or sort rather than page.
+    limit: int = Field(default=10, ge=1, le=10)
     offset: int = Field(default=0, ge=0)
     sort: list[Sort] = Field(default_factory=list)
 

--- a/backend/api/app/services/tools/catalog_query.py
+++ b/backend/api/app/services/tools/catalog_query.py
@@ -310,6 +310,18 @@ _SQL_BINOP = {
 }
 
 
+def _qi(identifier: str) -> str:
+    """Quote a SQL identifier (column/table name) for safe interpolation.
+
+    Every dynamic identifier reaching the SQL string is allowlist-validated by
+    the CatalogQuery model first; quoting is defense-in-depth and also lets the
+    catalog use names that need quoting (mixed case, reserved words). DuckDB
+    folds unquoted identifiers to lower case, so quoting pins the exact case —
+    the field allowlist already carries the catalog's canonical casing.
+    """
+    return '"' + identifier.replace('"', '""') + '"'
+
+
 def _list_membership(col: str) -> str:
     """SQL truthy when list column `col` shares any element with the ? param list."""
     return f"len(list_intersect({col}, ?)) > 0"
@@ -321,7 +333,7 @@ def _as_list(value) -> list:
 
 
 def _compile_predicate(f: Filter) -> tuple[str, list]:
-    col = f.field
+    col = _qi(f.field)
     if f.op is Op.is_null:
         return f"{col} IS NULL", []
     if f.op is Op.not_null:
@@ -330,7 +342,7 @@ def _compile_predicate(f: Filter) -> tuple[str, list]:
     # membership — a list never equals a scalar, so this is the only sensible
     # reading. Coercing it lets the model's natural `eq`/`in` phrasing work
     # without a failed round-trip.
-    if col in LIST_FIELDS and f.op in (Op.eq, Op.ne, Op.in_, Op.not_in):
+    if f.field in LIST_FIELDS and f.op in (Op.eq, Op.ne, Op.in_, Op.not_in):
         expr = _list_membership(col)
         if f.op in (Op.ne, Op.not_in):
             # NULL-safe negation: a row with no value is "not a member" too, so
@@ -452,23 +464,26 @@ def execute(q: CatalogQuery, con) -> dict:
     where, params = _compile_where(q)
     cap = q.limit
 
+    entity = _qi(q.entity)
+
     def _facets(cols: list[str]) -> dict:
         out = {}
         for col in cols:
+            qcol = _qi(col)
             # Cap to the top buckets by count — a high-cardinality field (e.g.
             # a species column) would otherwise return thousands of buckets.
             rows = con.execute(
-                f"SELECT {col} AS k, count(*) AS c FROM {q.entity} "
+                f"SELECT {qcol} AS k, count(*) AS c FROM {entity} WHERE {where} "
                 # `, k` is a stable tiebreaker so equal-count buckets (and which
                 # ones fall at the LIMIT boundary) don't shuffle across runs.
-                f"WHERE {where} GROUP BY {col} ORDER BY c DESC, k LIMIT {_FACET_LIMIT}",
+                f"GROUP BY {qcol} ORDER BY c DESC, k LIMIT {_FACET_LIMIT}",
                 params,
             ).fetchall()
             out[col] = {("(none)" if k is None else str(k)): c for k, c in rows}
         return out
 
     total = con.execute(
-        f"SELECT count(*) FROM {q.entity} WHERE {where}", params
+        f"SELECT count(*) FROM {entity} WHERE {where}", params
     ).fetchone()[0]
     result: dict = {"total": total}
     if q.operation == "count":
@@ -485,18 +500,24 @@ def execute(q: CatalogQuery, con) -> dict:
     if q.sort:
         # Honor the requested sort, appending a stable key (the first display
         # column) as a tiebreaker so equal-sort rows can't shuffle at the boundary.
-        terms = [f"{s.field} {'DESC' if s.desc else 'ASC'}" for s in q.sort]
+        # NULLS LAST so a column with missing values sorts the rows with data to
+        # the top of the page (DuckDB defaults NULLs first on DESC).
+        terms = [
+            f"{_qi(s.field)} {'DESC' if s.desc else 'ASC'} NULLS LAST" for s in q.sort
+        ]
         tiebreak = cols[0] if cols else None
         if tiebreak and tiebreak not in {s.field for s in q.sort}:
-            terms.append(tiebreak)
+            terms.append(_qi(tiebreak))
         order = "ORDER BY " + ", ".join(terms)
     else:
         # No explicit sort: most-relevant-first per _DEFAULT_ORDER; fall back to a
         # stable key (or positional `1`) for any entity without a default.
-        order = "ORDER BY " + _DEFAULT_ORDER.get(q.entity, cols[0] if cols else "1")
-    select = ", ".join(cols) if cols else "*"
+        order = "ORDER BY " + _DEFAULT_ORDER.get(
+            q.entity, _qi(cols[0]) if cols else "1"
+        )
+    select = ", ".join(_qi(c) for c in cols) if cols else "*"
     cur = con.execute(
-        f"SELECT {select} FROM {q.entity} WHERE {where} {order} "
+        f"SELECT {select} FROM {entity} WHERE {where} {order} "
         f"LIMIT {cap + 1} OFFSET {q.offset}",
         params,
     )

--- a/backend/api/app/services/tools/catalog_query.py
+++ b/backend/api/app/services/tools/catalog_query.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import logging
 from enum import Enum
 from pathlib import Path
-from typing import Optional, Union
+from typing import Literal, Optional, Union
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -77,16 +77,14 @@ ORGANISM_FIELDS: set[str] = {
     "taxonomicLevelSpecies",
 }
 
+# Field vocab per entity. Only "assembly" is queryable today (see the `entity`
+# Literal on CatalogQuery and the assembly-only table in connect()); the organism
+# vocab is kept as roadmap data — to enable it, add "organism" to that Literal and
+# load its table in connect().
 ENTITY_FIELDS: dict[str, set[str]] = {
     "assembly": ASSEMBLY_FIELDS,
     "organism": ORGANISM_FIELDS,
 }
-
-# Entities the executor can actually run — connect() must load a table for each.
-# organism vocab is defined above but no table is loaded yet (assembly-first), so
-# querying it is rejected at validation rather than failing mid-execution. Add an
-# entity here only once connect() loads its table.
-QUERYABLE_ENTITIES: set[str] = {"assembly"}
 
 LIST_FIELDS: set[str] = {"lineageTaxonomyIds", "ploidy", "taxonomicGroup", "otherTaxa"}
 NUMERIC_FIELDS: set[str] = {
@@ -207,9 +205,9 @@ class Sort(BaseModel):
 class CatalogQuery(BaseModel):
     """A structured query over the BRC catalog; compiled to SQL and run."""
 
-    entity: str = "assembly"
+    entity: Literal["assembly"] = "assembly"
     filters: list[Filter] = Field(default_factory=list)
-    operation: str = "list"  # count | list | facets
+    operation: Literal["count", "list", "facets"] = "list"
     facet_by: list[str] = Field(default_factory=list)
     # Bound the page so a `list` result can never dump the corpus into context —
     # the contract is a bounded summary; over the cap we truncate and offer to
@@ -220,17 +218,8 @@ class CatalogQuery(BaseModel):
 
     @model_validator(mode="after")
     def _validate(self) -> "CatalogQuery":
-        if self.entity not in ENTITY_FIELDS:
-            raise ValueError(
-                f"unknown entity {self.entity!r}; valid: {sorted(ENTITY_FIELDS)}"
-            )
-        if self.entity not in QUERYABLE_ENTITIES:
-            raise ValueError(
-                f"entity {self.entity!r} is not queryable yet (no table loaded); "
-                f"supported: {sorted(QUERYABLE_ENTITIES)}"
-            )
-        if self.operation not in ("count", "list", "facets"):
-            raise ValueError(f"unknown operation {self.operation!r}")
+        # entity/operation are Literals — pydantic already rejects bad values and
+        # advertises the allowed set in the tool schema.
         if self.operation == "facets" and not self.facet_by:
             raise ValueError("operation 'facets' needs at least one facet_by field")
         allowed = ENTITY_FIELDS[self.entity]
@@ -260,10 +249,16 @@ class CatalogQuery(BaseModel):
                 raise ValueError(f"{f.op.value} needs a value")
             # (A None *inside* a value list — IN (NULL, ...) — is already rejected
             # by the Filter type: list[Scalar] excludes None, so it can't occur.)
-            if f.op in (Op.gt, Op.gte, Op.lt, Op.lte) and f.field not in NUMERIC_FIELDS:
-                raise ValueError(
-                    f"range op {f.op.value} needs a numeric field, got {f.field!r}"
-                )
+            if f.op in (Op.gt, Op.gte, Op.lt, Op.lte):
+                if f.field not in NUMERIC_FIELDS:
+                    raise ValueError(
+                        f"range op {f.op.value} needs a numeric field, got {f.field!r}"
+                    )
+                # bool is an int subclass, so guard it explicitly.
+                if isinstance(f.value, bool) or not isinstance(f.value, (int, float)):
+                    raise ValueError(
+                        f"range op {f.op.value} needs a numeric value, got {f.value!r}"
+                    )
             if f.op in (Op.contains, Op.contains_any) and f.field not in LIST_FIELDS:
                 raise ValueError(f"{f.op.value} needs a list field, got {f.field!r}")
             # `contains` tests one scalar element (list_contains needs a scalar);

--- a/backend/api/app/services/tools/catalog_query.py
+++ b/backend/api/app/services/tools/catalog_query.py
@@ -101,6 +101,11 @@ NUMERIC_FIELDS: set[str] = {
 # a high-cardinality field from returning thousands of rows.
 _FACET_LIMIT = 50
 
+# Max size (bytes) of a single JSON object read_json_auto will accept. The
+# catalog is one big array; this raises the per-record ceiling well above
+# DuckDB's default so a large assembly record can't trip the parser.
+_MAX_JSON_OBJECT_SIZE = 20_000_000
+
 # DuckDB base type names treated as numeric for the connect() schema-drift check.
 _NUMERIC_DUCKDB_TYPES = {
     "TINYINT",
@@ -440,7 +445,7 @@ def connect(catalog_dir: str):
         con.execute(
             "CREATE TABLE assembly AS "
             "SELECT * FROM read_json_auto(?, "
-            "format='array', maximum_object_size=20000000)",
+            f"format='array', maximum_object_size={_MAX_JSON_OBJECT_SIZE})",
             [str(json_path)],
         )
         total = con.execute("SELECT count(*) FROM assembly").fetchone()[0]

--- a/backend/api/app/services/tools/catalog_query.py
+++ b/backend/api/app/services/tools/catalog_query.py
@@ -202,6 +202,11 @@ _SQL_BINOP = {
 }
 
 
+def _list_membership(col: str) -> str:
+    """SQL truthy when list column `col` shares any element with the ? param list."""
+    return f"len(list_intersect({col}, ?)) > 0"
+
+
 def compile_predicate(f: Filter) -> tuple[str, list]:
     col = f.field
     if f.op is Op.is_null:
@@ -214,7 +219,7 @@ def compile_predicate(f: Filter) -> tuple[str, list]:
     # without a failed round-trip.
     if col in LIST_FIELDS and f.op in (Op.eq, Op.ne, Op.in_, Op.not_in):
         vals = f.value if isinstance(f.value, list) else [f.value]
-        expr = f"len(list_intersect({col}, ?)) > 0"
+        expr = _list_membership(col)
         neg = f.op in (Op.ne, Op.not_in)
         return (f"NOT ({expr})" if neg else expr), [list(vals)]
     if f.op in (Op.in_, Op.not_in):
@@ -226,7 +231,7 @@ def compile_predicate(f: Filter) -> tuple[str, list]:
         return f"list_contains({col}, ?)", [f.value]
     if f.op is Op.contains_any:
         vals = f.value if isinstance(f.value, list) else [f.value]
-        return f"len(list_intersect({col}, ?)) > 0", [list(vals)]
+        return _list_membership(col), [list(vals)]
     return f"{col} {_SQL_BINOP[f.op]} ?", [f.value]
 
 
@@ -292,10 +297,15 @@ def connect(catalog_dir: str):
     return None
 
 
-def execute(q: CatalogQuery, con, cap: Optional[int] = None) -> dict:
-    """Run a CatalogQuery against DuckDB; return the summary contract."""
+def execute(q: CatalogQuery, con) -> dict:
+    """Run a CatalogQuery against DuckDB; return the summary contract.
+
+    Entity/column/sort identifiers are interpolated into SQL, not parameterized
+    (SQL identifiers can't be) — the CatalogQuery allowlist validator is what
+    gates that interpolation, so don't loosen it without revisiting this.
+    """
     where, params = compile_where(q)
-    cap = cap or q.limit
+    cap = q.limit
 
     def _facets(cols: list[str]) -> dict:
         out = {}
@@ -333,9 +343,9 @@ def execute(q: CatalogQuery, con, cap: Optional[int] = None) -> dict:
     colnames = [d[0] for d in cur.description]
     raw = cur.fetchall()
     rows = [dict(zip(colnames, r)) for r in raw]
-    result["returned"] = min(len(rows), cap)
     result["truncated"] = len(rows) > cap
     result["rows"] = rows[:cap]
+    result["returned"] = len(result["rows"])
     if result["truncated"]:
         result["facets"] = _facets(_AUTO_FACET_FIELDS.get(q.entity, []))
     return result

--- a/backend/api/app/services/tools/catalog_query.py
+++ b/backend/api/app/services/tools/catalog_query.py
@@ -172,6 +172,13 @@ _DISPLAY_COLUMNS: dict[str, list[str]] = {
     ],
 }
 
+# Default ordering for a `list` with no explicit sort: most relevant first —
+# the reference assembly, then best quality (largest scaffold N50), with accession
+# as a stable tiebreaker. Beats ordering by an arbitrary accession id.
+_DEFAULT_ORDER: dict[str, str] = {
+    "assembly": "isRef DESC, scaffoldN50 DESC NULLS LAST, accession",
+}
+
 
 class Op(str, Enum):
     eq = "eq"
@@ -458,18 +465,20 @@ def execute(q: CatalogQuery, con) -> dict:
     # Display columns are validated against the table at connect() time (the
     # engine fails closed on drift), so the projection is trusted here.
     cols = _DISPLAY_COLUMNS.get(q.entity)
-    # Always order by a stable key so the capped page / truncation is reproducible
-    # (LIMIT without a total order is unordered). For an explicit sort, append that
-    # key as a tiebreaker so rows at the page boundary can't shuffle when the
-    # requested sort fields tie.
-    tiebreak = cols[0] if cols else None
-    terms = [f"{s.field} {'DESC' if s.desc else 'ASC'}" for s in q.sort]
-    if tiebreak and tiebreak not in {s.field for s in q.sort}:
-        terms.append(tiebreak)
-    # Always emit an ORDER BY so LIMIT/OFFSET is reproducible. For assembly the
-    # tiebreak (accession) guarantees a term; `1` is a last-resort positional
-    # fallback for any future entity without display columns.
-    order = "ORDER BY " + ", ".join(terms or ["1"])
+    # Always emit an ORDER BY so the capped page / truncation is reproducible
+    # (LIMIT without a total order is unordered).
+    if q.sort:
+        # Honor the requested sort, appending a stable key (the first display
+        # column) as a tiebreaker so equal-sort rows can't shuffle at the boundary.
+        terms = [f"{s.field} {'DESC' if s.desc else 'ASC'}" for s in q.sort]
+        tiebreak = cols[0] if cols else None
+        if tiebreak and tiebreak not in {s.field for s in q.sort}:
+            terms.append(tiebreak)
+        order = "ORDER BY " + ", ".join(terms)
+    else:
+        # No explicit sort: most-relevant-first per _DEFAULT_ORDER; fall back to a
+        # stable key (or positional `1`) for any entity without a default.
+        order = "ORDER BY " + _DEFAULT_ORDER.get(q.entity, cols[0] if cols else "1")
     select = ", ".join(cols) if cols else "*"
     cur = con.execute(
         f"SELECT {select} FROM {q.entity} WHERE {where} {order} "

--- a/backend/api/app/services/tools/catalog_query.py
+++ b/backend/api/app/services/tools/catalog_query.py
@@ -350,12 +350,14 @@ def connect(catalog_dir: str):
 
     Concurrency invariant: the assistant's tools are sync and run on the asyncio
     event-loop thread, so this single connection is only ever touched by one
-    thread at a time and needs no lock. If tool execution is ever moved to a
-    threadpool, that invariant breaks — a single DuckDBPyConnection is not safe
-    for concurrent use across threads. The fix is a per-thread connection via
-    `con.cursor()`, which returns a separate connection that shares THIS in-memory
-    database (a fresh `duckdb.connect()` would be a new, empty database without the
-    loaded table); alternatively, serialize access through a single-thread executor.
+    thread at a time and needs no lock. DuckDB connections are not thread-safe,
+    and per the DuckDB docs `cursor()` does NOT help — it is another handle on the
+    same connection, and cursors from one connection cannot run queries at the
+    same time. If tool execution is ever moved to a threadpool, "each thread must
+    have its own connection" — but a fresh `duckdb.connect()` here would be a new,
+    empty in-memory database without the loaded table, so true concurrency would
+    require loading the catalog into a file-backed/shared DuckDB database, or
+    serializing access through a single-thread executor.
     """
     import duckdb
 

--- a/backend/api/app/services/tools/catalog_query.py
+++ b/backend/api/app/services/tools/catalog_query.py
@@ -1,0 +1,299 @@
+"""Catalog Query IR + in-process DuckDB executor for the assistant.
+
+A typed, column-agnostic query the model authors and the backend compiles to SQL:
+  - `filters` is a flat list of {field, op, value}, AND-composed across fields.
+  - within a field: OR via `in`/`contains_any`; range/AND via repeated predicates.
+  - cross-field OR is deliberately not expressible.
+  - `field`/`facet_by`/`sort` are validated against a per-entity allowlist.
+  - the executor returns a summary ({total, returned, truncated, facets, rows}),
+    never the raw corpus; facets attach automatically when a list is truncated so
+    the model can offer narrowing instead of paging.
+
+Assembly-first; organism is sketched. Workflows stay on their dedicated tools.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Optional, Union
+
+from pydantic import BaseModel, Field, model_validator
+
+ASSEMBLY_FIELDS: set[str] = {
+    "accession",
+    "ncbiTaxonomyId",
+    "speciesTaxonomyId",
+    "lineageTaxonomyIds",
+    "taxonomicLevelDomain",
+    "taxonomicLevelKingdom",
+    "taxonomicLevelPhylum",
+    "taxonomicLevelClass",
+    "taxonomicLevelOrder",
+    "taxonomicLevelFamily",
+    "taxonomicLevelGenus",
+    "taxonomicLevelSpecies",
+    "taxonomicLevelStrain",
+    "taxonomicLevelSerotype",
+    "taxonomicLevelIsolate",
+    "taxonomicLevelRealm",
+    "taxonomicGroup",
+    "otherTaxa",
+    "level",
+    "isRef",
+    "ploidy",
+    "priority",
+    "priorityPathogenName",
+    "annotationStatus",
+    "length",
+    "gcPercent",
+    "scaffoldN50",
+    "scaffoldL50",
+    "scaffoldCount",
+    "chromosomes",
+    "strainName",
+    "coverage",
+    "commonName",
+    "geneModelUrl",
+}
+
+ORGANISM_FIELDS: set[str] = {
+    "ncbiTaxonomyId",
+    "commonName",
+    "assemblyCount",
+    "priority",
+    "priorityPathogenName",
+    "taxonomicGroup",
+    "taxonomicLevelDomain",
+    "taxonomicLevelKingdom",
+    "taxonomicLevelPhylum",
+    "taxonomicLevelClass",
+    "taxonomicLevelOrder",
+    "taxonomicLevelFamily",
+    "taxonomicLevelGenus",
+    "taxonomicLevelSpecies",
+}
+
+ENTITY_FIELDS: dict[str, set[str]] = {
+    "assembly": ASSEMBLY_FIELDS,
+    "organism": ORGANISM_FIELDS,
+}
+
+LIST_FIELDS: set[str] = {"lineageTaxonomyIds", "ploidy", "taxonomicGroup", "otherTaxa"}
+NUMERIC_FIELDS: set[str] = {
+    "length",
+    "gcPercent",
+    "scaffoldN50",
+    "scaffoldL50",
+    "scaffoldCount",
+    "chromosomes",
+    "assemblyCount",
+}
+
+# Facets auto-returned on a truncated list, so the model can offer narrowing.
+_AUTO_FACET_FIELDS: dict[str, list[str]] = {
+    "assembly": ["level", "isRef"],
+    "organism": ["taxonomicLevelDomain"],
+}
+
+# Curated projection for `list` rows (keeps tokens bounded vs SELECT *).
+_DISPLAY_COLUMNS: dict[str, list[str]] = {
+    "assembly": [
+        "accession",
+        "taxonomicLevelSpecies",
+        "strainName",
+        "level",
+        "isRef",
+        "ploidy",
+        "length",
+        "scaffoldN50",
+        "geneModelUrl",
+        "ucscBrowserUrl",
+    ],
+    "organism": [
+        "ncbiTaxonomyId",
+        "taxonomicLevelSpecies",
+        "commonName",
+        "assemblyCount",
+    ],
+}
+
+
+class Op(str, Enum):
+    eq = "eq"
+    ne = "ne"
+    in_ = "in"
+    not_in = "not_in"
+    gt = "gt"
+    gte = "gte"
+    lt = "lt"
+    lte = "lte"
+    contains = "contains"  # scalar value in a list column
+    contains_any = "contains_any"  # any(values) in a list column (OR within a field)
+    is_null = "is_null"
+    not_null = "not_null"
+
+
+Scalar = Union[str, int, float, bool]
+
+
+class Filter(BaseModel):
+    field: str
+    op: Op
+    value: Optional[Union[Scalar, list[Scalar]]] = None
+
+
+class Sort(BaseModel):
+    field: str
+    desc: bool = False
+
+
+class CatalogQuery(BaseModel):
+    """A structured query over the BRC catalog; compiled to SQL and run."""
+
+    entity: str = "assembly"
+    filters: list[Filter] = Field(default_factory=list)
+    operation: str = "list"  # count | list | facets
+    facet_by: list[str] = Field(default_factory=list)
+    limit: int = 25
+    offset: int = 0
+    sort: list[Sort] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _validate(self) -> "CatalogQuery":
+        if self.entity not in ENTITY_FIELDS:
+            raise ValueError(
+                f"unknown entity {self.entity!r}; valid: {sorted(ENTITY_FIELDS)}"
+            )
+        if self.operation not in ("count", "list", "facets"):
+            raise ValueError(f"unknown operation {self.operation!r}")
+        allowed = ENTITY_FIELDS[self.entity]
+        referenced = (
+            [f.field for f in self.filters]
+            + list(self.facet_by)
+            + [s.field for s in self.sort]
+        )
+        unknown = sorted({f for f in referenced if f not in allowed})
+        if unknown:
+            raise ValueError(
+                f"unknown field(s) {unknown} for entity {self.entity!r}; "
+                f"valid fields: {sorted(allowed)}"
+            )
+        for f in self.filters:
+            if f.op in (Op.gt, Op.gte, Op.lt, Op.lte) and f.field not in NUMERIC_FIELDS:
+                raise ValueError(
+                    f"range op {f.op.value} needs a numeric field, got {f.field!r}"
+                )
+            if f.op in (Op.contains, Op.contains_any) and f.field not in LIST_FIELDS:
+                raise ValueError(f"{f.op.value} needs a list field, got {f.field!r}")
+        return self
+
+
+_SQL_BINOP = {
+    Op.eq: "=",
+    Op.ne: "!=",
+    Op.gt: ">",
+    Op.gte: ">=",
+    Op.lt: "<",
+    Op.lte: "<=",
+}
+
+
+def compile_predicate(f: Filter) -> tuple[str, list]:
+    col = f.field
+    if f.op is Op.is_null:
+        return f"{col} IS NULL", []
+    if f.op is Op.not_null:
+        return f"{col} IS NOT NULL", []
+    # On a list column, scalar membership ops (eq/ne/in/not_in) mean list
+    # membership — a list never equals a scalar, so this is the only sensible
+    # reading. Coercing it lets the model's natural `eq`/`in` phrasing work
+    # without a failed round-trip.
+    if col in LIST_FIELDS and f.op in (Op.eq, Op.ne, Op.in_, Op.not_in):
+        vals = f.value if isinstance(f.value, list) else [f.value]
+        expr = f"len(list_intersect({col}, ?)) > 0"
+        neg = f.op in (Op.ne, Op.not_in)
+        return (f"NOT ({expr})" if neg else expr), [list(vals)]
+    if f.op in (Op.in_, Op.not_in):
+        vals = f.value if isinstance(f.value, list) else [f.value]
+        ph = ", ".join(["?"] * len(vals))
+        neg = "NOT " if f.op is Op.not_in else ""
+        return f"{col} {neg}IN ({ph})", list(vals)
+    if f.op is Op.contains:
+        return f"list_contains({col}, ?)", [f.value]
+    if f.op is Op.contains_any:
+        vals = f.value if isinstance(f.value, list) else [f.value]
+        return f"len(list_intersect({col}, ?)) > 0", [list(vals)]
+    return f"{col} {_SQL_BINOP[f.op]} ?", [f.value]
+
+
+def compile_where(q: CatalogQuery) -> tuple[str, list]:
+    if not q.filters:
+        return "TRUE", []
+    frags, params = [], []
+    for f in q.filters:
+        frag, p = compile_predicate(f)
+        frags.append(frag)
+        params.extend(p)
+    return " AND ".join(frags), params
+
+
+def connect(catalog_dir: str):
+    """Load the catalog into an in-memory DuckDB connection (assembly table)."""
+    import duckdb
+
+    con = duckdb.connect()
+    con.execute(
+        "CREATE TABLE assembly AS "
+        f"SELECT * FROM read_json_auto('{catalog_dir}/assemblies.json', "
+        "format='array', maximum_object_size=20000000)"
+    )
+    return con
+
+
+def execute(q: CatalogQuery, con, cap: Optional[int] = None) -> dict:
+    """Run a CatalogQuery against DuckDB; return the summary contract."""
+    where, params = compile_where(q)
+    cap = cap or q.limit
+
+    def _facets(cols: list[str]) -> dict:
+        out = {}
+        for col in cols:
+            rows = con.execute(
+                f"SELECT {col} AS k, count(*) AS c FROM {q.entity} "
+                f"WHERE {where} GROUP BY {col} ORDER BY c DESC",
+                params,
+            ).fetchall()
+            out[col] = {str(k): c for k, c in rows}
+        return out
+
+    total = con.execute(
+        f"SELECT count(*) FROM {q.entity} WHERE {where}", params
+    ).fetchone()[0]
+    result: dict = {"total": total}
+    if q.operation == "count":
+        return result
+    if q.operation == "facets":
+        result["facets"] = _facets(q.facet_by)
+        return result
+
+    order = ""
+    if q.sort:
+        order = "ORDER BY " + ", ".join(
+            f"{s.field} {'DESC' if s.desc else 'ASC'}" for s in q.sort
+        )
+    cols = _DISPLAY_COLUMNS.get(q.entity)
+    select = ", ".join(cols) if cols else "*"
+    cur = con.execute(
+        f"SELECT {select} FROM {q.entity} WHERE {where} {order} "
+        f"LIMIT {cap + 1} OFFSET {q.offset}",
+        params,
+    )
+    colnames = [d[0] for d in cur.description]
+    raw = cur.fetchall()
+    rows = [dict(zip(colnames, r)) for r in raw]
+    result["returned"] = min(len(rows), cap)
+    result["truncated"] = len(rows) > cap
+    result["rows"] = rows[:cap]
+    if result["truncated"]:
+        result["facets"] = _facets(_AUTO_FACET_FIELDS.get(q.entity, []))
+    return result

--- a/backend/api/app/services/tools/catalog_query.py
+++ b/backend/api/app/services/tools/catalog_query.py
@@ -176,9 +176,11 @@ _DISPLAY_COLUMNS: dict[str, list[str]] = {
 
 # Default ordering for a `list` with no explicit sort: most relevant first —
 # the reference assembly, then best quality (largest scaffold N50), with accession
-# as a stable tiebreaker. Beats ordering by an arbitrary accession id.
-_DEFAULT_ORDER: dict[str, str] = {
-    "assembly": "isRef DESC, scaffoldN50 DESC NULLS LAST, accession",
+# as a stable tiebreaker. Beats ordering by an arbitrary accession id. Stored as
+# (field, desc) terms so the same _qi()-quoting / NULLS LAST builder serves both
+# this and the explicit-sort path (no raw identifiers embedded in a string).
+_DEFAULT_ORDER: dict[str, list[tuple[str, bool]]] = {
+    "assembly": [("isRef", True), ("scaffoldN50", True), ("accession", False)],
 }
 
 
@@ -217,7 +219,10 @@ class CatalogQuery(BaseModel):
     entity: Literal["assembly"] = "assembly"
     filters: list[Filter] = Field(default_factory=list)
     operation: Literal["count", "list", "facets"] = "list"
-    facet_by: list[str] = Field(default_factory=list)
+    # Each facet column is a separate GROUP BY query in execute(); cap the count
+    # so one call can't fan out into a burst of DB work. Realistic group-bys use
+    # one or two columns — 4 is comfortable headroom.
+    facet_by: list[str] = Field(default_factory=list, max_length=4)
     # Bound the page to a small, fixed size so a `list` is always a short, fully
     # rendered table — never a corpus dump or a variable-length one. The cap is the
     # default (the model can't inflate it); over it we truncate and offer to narrow
@@ -320,6 +325,17 @@ def _qi(identifier: str) -> str:
     the field allowlist already carries the catalog's canonical casing.
     """
     return '"' + identifier.replace('"', '""') + '"'
+
+
+def _order_by(terms: list[tuple[str, bool]]) -> str:
+    """Build an ORDER BY body from (field, desc) terms — quoted, with NULLS LAST.
+
+    NULLS LAST so a column with missing values keeps the rows that have data at
+    the top of the page (DuckDB defaults NULLs first on DESC).
+    """
+    return ", ".join(
+        f"{_qi(field)} {'DESC' if desc else 'ASC'} NULLS LAST" for field, desc in terms
+    )
 
 
 def _list_membership(col: str) -> str:
@@ -500,21 +516,19 @@ def execute(q: CatalogQuery, con) -> dict:
     if q.sort:
         # Honor the requested sort, appending a stable key (the first display
         # column) as a tiebreaker so equal-sort rows can't shuffle at the boundary.
-        # NULLS LAST so a column with missing values sorts the rows with data to
-        # the top of the page (DuckDB defaults NULLs first on DESC).
-        terms = [
-            f"{_qi(s.field)} {'DESC' if s.desc else 'ASC'} NULLS LAST" for s in q.sort
-        ]
+        terms = [(s.field, s.desc) for s in q.sort]
         tiebreak = cols[0] if cols else None
         if tiebreak and tiebreak not in {s.field for s in q.sort}:
-            terms.append(_qi(tiebreak))
-        order = "ORDER BY " + ", ".join(terms)
+            terms.append((tiebreak, False))
+        order = "ORDER BY " + _order_by(terms)
     else:
         # No explicit sort: most-relevant-first per _DEFAULT_ORDER; fall back to a
         # stable key (or positional `1`) for any entity without a default.
-        order = "ORDER BY " + _DEFAULT_ORDER.get(
-            q.entity, _qi(cols[0]) if cols else "1"
-        )
+        default = _DEFAULT_ORDER.get(q.entity)
+        if default:
+            order = "ORDER BY " + _order_by(default)
+        else:
+            order = "ORDER BY " + (_qi(cols[0]) if cols else "1")
     select = ", ".join(_qi(c) for c in cols) if cols else "*"
     cur = con.execute(
         f"SELECT {select} FROM {entity} WHERE {where} {order} "

--- a/backend/api/app/services/tools/catalog_tools.py
+++ b/backend/api/app/services/tools/catalog_tools.py
@@ -107,7 +107,7 @@ def check_compatibility(deps: AssistantDeps, iwc_id: str, accession: str) -> str
 
 
 def query_catalog(deps: AssistantDeps, query: CatalogQuery) -> str:
-    """Count, filter, list, or aggregate genome ASSEMBLIES with a structured query.
+    """Count, filter, list, or facet (group-by) genome ASSEMBLIES with a structured query.
 
     Prefer this over enumerating assemblies yourself: it runs the filter/count in
     the database and returns a JSON summary correct at any scale. The summary

--- a/backend/api/app/services/tools/catalog_tools.py
+++ b/backend/api/app/services/tools/catalog_tools.py
@@ -110,10 +110,12 @@ def query_catalog(deps: AssistantDeps, query: CatalogQuery) -> str:
     """Count, filter, list, or aggregate genome ASSEMBLIES with a structured query.
 
     Prefer this over enumerating assemblies yourself: it runs the filter/count in
-    the database and returns a summary correct at any scale. The summary always
-    has `total`; `list` adds `rows`/`returned`/`truncated` (capped page) and
-    `facets` when truncated; `facets` adds `facets`. Use it for "how many",
-    attribute filters, clade queries, and "by/per X" breakdowns.
+    the database and returns a JSON summary correct at any scale. The summary
+    always has `total`; `list` adds `rows`/`returned`/`truncated` (capped page)
+    and `facets` when truncated; `facets` adds `facets`. Use it for "how many",
+    attribute filters, clade queries, and "by/per X" breakdowns. On a failure or
+    when the engine is unavailable it returns a short plain-text message instead
+    of JSON.
 
     The query has: entity ("assembly"), filters (a list of {field, op, value},
     AND-combined), operation ("count" | "list" | "facets"), facet_by, limit, sort.

--- a/backend/api/app/services/tools/catalog_tools.py
+++ b/backend/api/app/services/tools/catalog_tools.py
@@ -118,7 +118,8 @@ def query_catalog(deps: AssistantDeps, query: CatalogQuery) -> str:
     of JSON.
 
     The query has: entity ("assembly"), filters (a list of {field, op, value},
-    AND-combined), operation ("count" | "list" | "facets"), facet_by, limit, sort.
+    AND-combined), operation ("count" | "list" | "facets"), facet_by, limit,
+    offset, sort.
     Ops: eq, ne, in, not_in, gt/gte/lt/lte (numeric), contains/contains_any (list
     fields), is_null/not_null. OR within a field = `in` (scalar) or `contains_any`
     (list); a range = two predicates (gte + lte).

--- a/backend/api/app/services/tools/catalog_tools.py
+++ b/backend/api/app/services/tools/catalog_tools.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
@@ -11,6 +12,8 @@ from app.services.tools.catalog_query import CatalogQuery, execute
 
 if TYPE_CHECKING:
     from app.services.sra_mirror import SRAMirrorService
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -129,5 +132,6 @@ def query_catalog(deps: AssistantDeps, query: CatalogQuery) -> str:
     try:
         result = execute(query, deps.con)
     except Exception as e:  # noqa: BLE001
+        logger.warning("query_catalog execution failed: %s", e)
         return f"Query error: {e}"
     return json.dumps(result, indent=2, default=str)

--- a/backend/api/app/services/tools/catalog_tools.py
+++ b/backend/api/app/services/tools/catalog_tools.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
 from app.services.tools.catalog_data import CatalogData
+from app.services.tools.catalog_query import CatalogQuery, execute
 
 if TYPE_CHECKING:
     from app.services.sra_mirror import SRAMirrorService
@@ -16,6 +17,7 @@ if TYPE_CHECKING:
 class AssistantDeps:
     catalog: CatalogData
     sra_mirror: Optional["SRAMirrorService"] = None
+    con: Any = None  # in-process DuckDB connection for query_catalog (optional)
 
 
 def search_organisms(deps: AssistantDeps, query: str) -> str:
@@ -28,18 +30,6 @@ def search_organisms(deps: AssistantDeps, query: str) -> str:
     if not results:
         return f"No organisms found matching '{query}'."
     return json.dumps(results, indent=2)
-
-
-def get_assemblies(deps: AssistantDeps, taxonomy_id: str) -> str:
-    """Get all genome assemblies available for an organism by its NCBI taxonomy ID.
-
-    Args:
-        taxonomy_id: the NCBI taxonomy ID of the organism
-    """
-    assemblies = deps.catalog.get_assemblies_for_organism(taxonomy_id)
-    if not assemblies:
-        return f"No assemblies found for taxonomy ID {taxonomy_id}."
-    return json.dumps(assemblies, indent=2)
 
 
 def get_assembly_details(deps: AssistantDeps, accession: str) -> str:
@@ -111,3 +101,33 @@ def check_compatibility(deps: AssistantDeps, iwc_id: str, accession: str) -> str
     """
     result = deps.catalog.check_workflow_assembly_compatibility(iwc_id, accession)
     return json.dumps(result, indent=2)
+
+
+def query_catalog(deps: AssistantDeps, query: CatalogQuery) -> str:
+    """Count, filter, list, or aggregate genome ASSEMBLIES with a structured query.
+
+    Prefer this over enumerating assemblies yourself: it runs the filter/count in
+    the database and returns a summary {total, returned, truncated, facets, rows},
+    correct at any scale. Use it for "how many", attribute filters, clade queries,
+    and "by/per X" breakdowns.
+
+    The query has: entity ("assembly"), filters (a list of {field, op, value},
+    AND-combined), operation ("count" | "list" | "facets"), facet_by, limit, sort.
+    Ops: eq, ne, in, not_in, gt/gte/lt/lte (numeric), contains/contains_any (list
+    fields), is_null/not_null. OR within a field = `in` (scalar) or `contains_any`
+    (list); a range = two predicates (gte + lte).
+
+    Filter an organism by scientific name via taxonomicLevelSpecies, a clade via
+    the matching rank column (e.g. taxonomicLevelGenus). When a list comes back
+    truncated, summarize the facets and offer to narrow rather than paging.
+
+    Args:
+        query: the structured catalog query
+    """
+    if deps.con is None:
+        return "Catalog query engine is not available."
+    try:
+        result = execute(query, deps.con)
+    except Exception as e:  # noqa: BLE001
+        return f"Query error: {e}"
+    return json.dumps(result, indent=2, default=str)

--- a/backend/api/app/services/tools/catalog_tools.py
+++ b/backend/api/app/services/tools/catalog_tools.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Optional
 
 from app.services.tools.catalog_data import CatalogData
 from app.services.tools.catalog_query import CatalogQuery, execute

--- a/backend/api/app/services/tools/catalog_tools.py
+++ b/backend/api/app/services/tools/catalog_tools.py
@@ -110,9 +110,10 @@ def query_catalog(deps: AssistantDeps, query: CatalogQuery) -> str:
     """Count, filter, list, or aggregate genome ASSEMBLIES with a structured query.
 
     Prefer this over enumerating assemblies yourself: it runs the filter/count in
-    the database and returns a summary {total, returned, truncated, facets, rows},
-    correct at any scale. Use it for "how many", attribute filters, clade queries,
-    and "by/per X" breakdowns.
+    the database and returns a summary correct at any scale. The summary always
+    has `total`; `list` adds `rows`/`returned`/`truncated` (capped page) and
+    `facets` when truncated; `facets` adds `facets`. Use it for "how many",
+    attribute filters, clade queries, and "by/per X" breakdowns.
 
     The query has: entity ("assembly"), filters (a list of {field, op, value},
     AND-combined), operation ("count" | "list" | "facets"), facet_by, limit, sort.
@@ -131,7 +132,10 @@ def query_catalog(deps: AssistantDeps, query: CatalogQuery) -> str:
         return "Catalog query engine is not available."
     try:
         result = execute(query, deps.con)
-    except Exception as e:  # noqa: BLE001
-        logger.warning("query_catalog execution failed: %s", e)
-        return f"Query error: {e}"
+    except Exception:  # noqa: BLE001
+        # Log the detail; return a controlled message rather than echoing raw
+        # exception text (which can carry SQL fragments) to the model/user.
+        # Invalid queries are already rejected by validation before this runs.
+        logger.exception("query_catalog execution failed")
+        return "Query failed — try simplifying or narrowing the query."
     return json.dumps(result, indent=2, default=str)

--- a/backend/api/evals/datasets/catalog_query.py
+++ b/backend/api/evals/datasets/catalog_query.py
@@ -36,10 +36,11 @@ class QueryCatalogShape(Evaluator):
 
     @staticmethod
     def _has(blob: str, token: str) -> bool:
-        # Match at alpha boundaries so a field fragment like "level" doesn't
-        # spuriously match "taxonomiclevelgenus", while a partial value token
-        # like "neoformans" still matches inside "cryptococcus neoformans".
-        return re.search(rf"(?<![a-z]){re.escape(token)}(?![a-z])", blob) is not None
+        # Match on word boundaries so a fragment like "level" doesn't spuriously
+        # match "taxonomiclevelgenus" and a numeric token like "1773" doesn't
+        # match "17730", while a partial value token like "neoformans" still
+        # matches inside "cryptococcus neoformans".
+        return re.search(rf"\b{re.escape(token)}\b", blob) is not None
 
     def evaluate(self, ctx: EvaluatorContext) -> float:
         for name, args in getattr(ctx.output, "tool_calls", None) or []:

--- a/backend/api/evals/datasets/catalog_query.py
+++ b/backend/api/evals/datasets/catalog_query.py
@@ -65,6 +65,15 @@ _CASES = [
         "must_contain": ["anopheles"],
     },
     {
+        # the taxon must actually be applied as a filter (taxid given explicitly)
+        "name": "lookup_by_taxid",
+        "message": (
+            "Show me the genome assemblies for Mycobacterium tuberculosis (taxid 1773)."
+        ),
+        "operation": None,
+        "must_contain": ["1773"],
+    },
+    {
         "name": "count_chromosome_total",
         "message": "How many chromosome-level assemblies are there in total?",
         "operation": "count",

--- a/backend/api/evals/datasets/catalog_query.py
+++ b/backend/api/evals/datasets/catalog_query.py
@@ -1,0 +1,118 @@
+"""Catalog-query eval: does the model author a correct `query_catalog` IR?
+
+Distinct from `tool_selection` (which only checks *which* tool fires): these
+cases check the *shape* of the query the model builds for assembly questions —
+the operation and the key filter fields/values — without asserting exact counts,
+so they don't drift as the catalog snapshot changes.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Callable
+
+from pydantic_ai.models import Model
+from pydantic_evals import Case, Dataset
+from pydantic_evals.evaluators import Evaluator, EvaluatorContext
+
+from evals.model_registry import ModelEntry
+from evals.tasks import EvalDeps, make_assistant_turn_task
+
+
+@dataclass
+class QueryCatalogShape(Evaluator):
+    """1.0 if a `query_catalog` call matches the expected operation and contains
+    every required substring in its (serialized) args.
+
+    `operation` is checked only when given (a bare `list` is often left implicit
+    by the model). `must_contain` is matched against the JSON-serialized args, so
+    it catches filter field names ("isRef") and values ("Complete Genome") alike.
+    """
+
+    operation: str | None = None
+    must_contain: list[str] = field(default_factory=list)
+
+    def evaluate(self, ctx: EvaluatorContext) -> float:
+        for name, args in getattr(ctx.output, "tool_calls", None) or []:
+            if name != "query_catalog":
+                continue
+            op = str(args.get("operation", "")).lower()
+            if self.operation and op != self.operation:
+                continue
+            blob = json.dumps(args, default=str).lower()
+            if all(s.lower() in blob for s in self.must_contain):
+                return 1.0
+        return 0.0
+
+
+# Each case: a question, the expected operation (or None), and substrings that
+# must appear in the query_catalog args. Prompts adapted from the dev spike.
+_CASES = [
+    {
+        "name": "count_clade_anopheles",
+        "message": "How many assemblies do you have for Anopheles?",
+        "operation": "count",
+        "must_contain": ["anopheles"],
+    },
+    {
+        "name": "count_chromosome_total",
+        "message": "How many chromosome-level assemblies are there in total?",
+        "operation": "count",
+        "must_contain": ["chromosome"],
+    },
+    {
+        "name": "facets_by_level",
+        "message": "How many assemblies are there at each assembly level?",
+        "operation": "facets",
+        "must_contain": ["level"],
+    },
+    {
+        "name": "list_species_and_level",
+        "message": (
+            "Which complete-genome assemblies do you have for Cryptococcus neoformans?"
+        ),
+        "operation": None,
+        "must_contain": ["complete genome", "neoformans"],
+    },
+    {
+        "name": "empty_intersection_ref_and_complete",
+        "message": (
+            "Do you have a reference assembly that is also complete-genome "
+            "level for Candida albicans?"
+        ),
+        "operation": None,
+        "must_contain": ["isref", "complete genome", "albicans"],
+    },
+    {
+        "name": "reference_only_for_species",
+        "message": "Show me the reference assemblies for Plasmodium vivax.",
+        "operation": None,
+        "must_contain": ["isref", "vivax"],
+    },
+]
+
+
+def build(
+    deps: EvalDeps, entry: ModelEntry, judge_model: Model, only: list[str] | None = None
+) -> tuple[Dataset, Callable, str]:
+    cases = []
+    for c in _CASES:
+        if only and c["name"] not in only:
+            continue
+        cases.append(
+            Case(
+                name=c["name"],
+                inputs={"message": c["message"]},
+                metadata=c,
+                evaluators=[
+                    QueryCatalogShape(
+                        operation=c["operation"],
+                        must_contain=c["must_contain"],
+                    )
+                ],
+            )
+        )
+    dataset = Dataset(cases=cases)
+    task = make_assistant_turn_task(deps, entry)
+    return dataset, task, QueryCatalogShape.__name__

--- a/backend/api/evals/datasets/catalog_query.py
+++ b/backend/api/evals/datasets/catalog_query.py
@@ -9,6 +9,7 @@ so they don't drift as the catalog snapshot changes.
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import dataclass, field
 from typing import Callable
 
@@ -33,6 +34,13 @@ class QueryCatalogShape(Evaluator):
     operation: str | None = None
     must_contain: list[str] = field(default_factory=list)
 
+    @staticmethod
+    def _has(blob: str, token: str) -> bool:
+        # Match at alpha boundaries so a field fragment like "level" doesn't
+        # spuriously match "taxonomiclevelgenus", while a partial value token
+        # like "neoformans" still matches inside "cryptococcus neoformans".
+        return re.search(rf"(?<![a-z]){re.escape(token)}(?![a-z])", blob) is not None
+
     def evaluate(self, ctx: EvaluatorContext) -> float:
         for name, args in getattr(ctx.output, "tool_calls", None) or []:
             if name != "query_catalog":
@@ -41,7 +49,7 @@ class QueryCatalogShape(Evaluator):
             if self.operation and op != self.operation:
                 continue
             blob = json.dumps(args, default=str).lower()
-            if all(s.lower() in blob for s in self.must_contain):
+            if all(self._has(blob, s.lower()) for s in self.must_contain):
                 return 1.0
         return 0.0
 

--- a/backend/api/evals/datasets/tool_selection.py
+++ b/backend/api/evals/datasets/tool_selection.py
@@ -52,10 +52,9 @@ _CASES = [
         "message": (
             "Show me the genome assemblies for Mycobacterium tuberculosis (taxid 1773)."
         ),
+        # Tool-selection only: that the taxon is actually applied as a filter is
+        # asserted in the catalog_query dataset (QueryCatalogShape), its proper home.
         "expected_tool": "query_catalog",
-        # Guard that the requested taxon is actually applied as a filter, not an
-        # empty query returning the whole catalog (the taxid lives in `filters`).
-        "expected_args": {"filters": "1773"},
     },
     {
         "name": "list_workflow_categories",

--- a/backend/api/evals/datasets/tool_selection.py
+++ b/backend/api/evals/datasets/tool_selection.py
@@ -52,8 +52,7 @@ _CASES = [
         "message": (
             "Show me the genome assemblies for Mycobacterium tuberculosis (taxid 1773)."
         ),
-        "expected_tool": "get_assemblies",
-        "expected_args": {"taxonomy_id": "1773"},
+        "expected_tool": "query_catalog",
     },
     {
         "name": "list_workflow_categories",

--- a/backend/api/evals/datasets/tool_selection.py
+++ b/backend/api/evals/datasets/tool_selection.py
@@ -53,6 +53,9 @@ _CASES = [
             "Show me the genome assemblies for Mycobacterium tuberculosis (taxid 1773)."
         ),
         "expected_tool": "query_catalog",
+        # Guard that the requested taxon is actually applied as a filter, not an
+        # empty query returning the whole catalog (the taxid lives in `filters`).
+        "expected_args": {"filters": "1773"},
     },
     {
         "name": "list_workflow_categories",

--- a/backend/api/evals/specs.py
+++ b/backend/api/evals/specs.py
@@ -10,6 +10,7 @@ from typing import Callable
 
 from evals.datasets import (
     assistant_multiturn,
+    catalog_query,
     sra_assistant_multiturn,
     sra_tool_selection,
     tool_selection,
@@ -17,6 +18,7 @@ from evals.datasets import (
 
 SPECS: dict[str, Callable] = {
     "tool_selection": tool_selection.build,
+    "catalog_query": catalog_query.build,
     "assistant_multiturn": assistant_multiturn.build,
     "sra_tool_selection": sra_tool_selection.build,
     "sra_assistant_multiturn": sra_assistant_multiturn.build,

--- a/backend/api/evals/tasks.py
+++ b/backend/api/evals/tasks.py
@@ -199,7 +199,9 @@ def make_assistant_turn_task(deps: EvalDeps, entry: ModelEntry) -> Callable:
     _prepare_service(aa, entry)
 
     async def task(case_input: dict) -> AgentTurnOutput:
-        agent_deps = AssistantDeps(catalog=aa.catalog, sra_mirror=deps.sra_mirror)
+        agent_deps = AssistantDeps(
+            catalog=aa.catalog, sra_mirror=deps.sra_mirror, con=aa.query_con
+        )
         result = await aa._run_agent_with_retry(
             case_input["message"], deps=agent_deps, message_history=None
         )

--- a/backend/api/evals/tests/test_evaluators.py
+++ b/backend/api/evals/tests/test_evaluators.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from pydantic_evals.evaluators import EvaluatorContext
 
+from evals.datasets.catalog_query import QueryCatalogShape
 from evals.evaluators import FieldEquals, LowConfidence, MustMention, ToolCallMatch
 
 
@@ -149,3 +150,44 @@ def test_tool_call_match_pulls_from_metadata():
         )
         == 1.0
     )
+
+
+# ---------- QueryCatalogShape ----------
+
+
+def test_query_shape_matches_field_and_value():
+    out = _FakeRun(
+        tool_calls=[
+            ("query_catalog", {"operation": "facets", "facet_by": ["level"]}),
+        ]
+    )
+    ev = QueryCatalogShape(operation="facets", must_contain=["level"])
+    assert ev.evaluate(_ctx(out)) == 1.0
+
+
+def test_query_shape_rejects_field_fragment():
+    # faceting the wrong field must NOT satisfy must_contain=["level"]
+    out = _FakeRun(
+        tool_calls=[
+            (
+                "query_catalog",
+                {"operation": "facets", "facet_by": ["taxonomicLevelGenus"]},
+            ),
+        ]
+    )
+    ev = QueryCatalogShape(operation="facets", must_contain=["level"])
+    assert ev.evaluate(_ctx(out)) == 0.0
+
+
+def test_query_shape_numeric_token_is_digit_bounded():
+    # "1773" must not match the wrong taxid "17730"
+    out = _FakeRun(
+        tool_calls=[
+            (
+                "query_catalog",
+                {"filters": [{"field": "speciesTaxonomyId", "value": "17730"}]},
+            ),
+        ]
+    )
+    ev = QueryCatalogShape(must_contain=["1773"])
+    assert ev.evaluate(_ctx(out)) == 0.0

--- a/backend/api/tests/test_assistant_agent.py
+++ b/backend/api/tests/test_assistant_agent.py
@@ -37,6 +37,7 @@ def agent():
     instance.catalog = MagicMock()
     instance.catalog.workflows_by_category = []
     instance.sra_mirror = None
+    instance.query_con = None  # query_catalog degrades to "unavailable"
     return instance
 
 

--- a/backend/api/tests/test_catalog_query.py
+++ b/backend/api/tests/test_catalog_query.py
@@ -31,20 +31,16 @@ from app.services.tools.catalog_query import (
 # --- IR validation (no DB) ----------------------------------------------------
 
 
-def test_unknown_entity_rejected():
-    with pytest.raises(ValueError, match="unknown entity"):
-        CatalogQuery(entity="protein")
-
-
-def test_known_but_unloaded_entity_rejected():
-    # organism vocab exists but connect() loads no organism table yet — reject at
-    # validation with a clear message rather than failing mid-execution.
-    with pytest.raises(ValueError, match="not queryable yet"):
-        CatalogQuery(entity="organism")
+def test_invalid_entity_rejected():
+    # entity is a Literal["assembly"]; anything else — including the roadmap
+    # "organism" whose table isn't loaded yet — is rejected by the schema.
+    for bad in ("protein", "organism"):
+        with pytest.raises(ValueError):
+            CatalogQuery(entity=bad)
 
 
 def test_unknown_operation_rejected():
-    with pytest.raises(ValueError, match="unknown operation"):
+    with pytest.raises(ValueError):
         CatalogQuery(operation="aggregate")
 
 
@@ -61,8 +57,16 @@ def test_unknown_facet_and_sort_fields_rejected():
 
 
 def test_range_op_requires_numeric_field():
-    with pytest.raises(ValueError, match="range op"):
+    with pytest.raises(ValueError, match="numeric field"):
         CatalogQuery(filters=[Filter(field="level", op=Op.gt, value=1)])
+
+
+def test_range_op_requires_numeric_value():
+    # a numeric field with a non-numeric value (string, or bool) must be rejected
+    with pytest.raises(ValueError, match="numeric value"):
+        CatalogQuery(filters=[Filter(field="length", op=Op.gt, value="1000")])
+    with pytest.raises(ValueError, match="numeric value"):
+        CatalogQuery(filters=[Filter(field="length", op=Op.gt, value=True)])
 
 
 def test_contains_op_requires_list_field():

--- a/backend/api/tests/test_catalog_query.py
+++ b/backend/api/tests/test_catalog_query.py
@@ -102,9 +102,38 @@ def test_compile_list_membership_and_coercion():
     frag, params = compile_predicate(Filter(field="ploidy", op=Op.eq, value="DIPLOID"))
     assert frag == "len(list_intersect(ploidy, ?)) > 0"
     assert params == [["DIPLOID"]]
-    # ne on a list field coerces to negated membership
+    # ne on a list field coerces to NULL-safe negated membership
     frag, _ = compile_predicate(Filter(field="ploidy", op=Op.ne, value="DIPLOID"))
-    assert frag == "NOT (len(list_intersect(ploidy, ?)) > 0)"
+    assert frag == "(NOT (len(list_intersect(ploidy, ?)) > 0) OR ploidy IS NULL)"
+
+
+def test_compile_ne_and_not_in_are_null_safe():
+    # SQL `col != x` / `col NOT IN (...)` drop NULL rows; negation must include them.
+    frag, _ = compile_predicate(Filter(field="level", op=Op.ne, value="Contig"))
+    assert frag == "(level != ? OR level IS NULL)"
+    frag, _ = compile_predicate(Filter(field="level", op=Op.not_in, value=["Contig"]))
+    assert frag == "(level NOT IN (?) OR level IS NULL)"
+
+
+def test_facet_on_list_field_rejected():
+    with pytest.raises(ValueError, match="cannot facet on list field"):
+        CatalogQuery(operation="facets", facet_by=["ploidy"])
+
+
+def test_empty_value_list_rejected():
+    with pytest.raises(ValueError, match="non-empty value list"):
+        CatalogQuery(filters=[Filter(field="level", op=Op.in_, value=[])])
+    with pytest.raises(ValueError, match="non-empty value list"):
+        CatalogQuery(filters=[Filter(field="ploidy", op=Op.contains_any, value=[])])
+
+
+def test_limit_and_offset_bounds():
+    with pytest.raises(ValueError):
+        CatalogQuery(limit=5000)  # exceeds the page cap
+    with pytest.raises(ValueError):
+        CatalogQuery(limit=0)
+    with pytest.raises(ValueError):
+        CatalogQuery(offset=-1)
 
 
 # --- executor against a synthetic table ---------------------------------------
@@ -266,6 +295,16 @@ def test_list_field_eq_coercion_matches_contains(con):
         filters=[Filter(field="ploidy", op=Op.contains, value="DIPLOID")],
     )
     assert execute(eq_q, con) == execute(contains_q, con) == {"total": 4}
+
+
+def test_ne_includes_null_rows(con):
+    # All fixture rows have NULL strainName; `ne` must count them as "not X"
+    # (plain SQL != would drop NULLs and return 0).
+    q = CatalogQuery(
+        operation="count",
+        filters=[Filter(field="strainName", op=Op.ne, value="ABC")],
+    )
+    assert execute(q, con) == {"total": 5}
 
 
 def test_list_truncation_attaches_facets(con):

--- a/backend/api/tests/test_catalog_query.py
+++ b/backend/api/tests/test_catalog_query.py
@@ -351,3 +351,23 @@ def test_list_no_truncation_when_under_limit(con):
     assert out["returned"] == 5
     assert out["truncated"] is False
     assert "facets" not in out
+
+
+def test_list_degrades_when_display_column_missing():
+    # A table missing a display column (ucscBrowserUrl) must not crash list
+    # queries — the projection drops the absent column gracefully.
+    duckdb = pytest.importorskip("duckdb")
+    c = duckdb.connect()
+    c.execute(
+        "CREATE TABLE assembly (accession VARCHAR, taxonomicLevelSpecies VARCHAR, "
+        "strainName VARCHAR, level VARCHAR, isRef VARCHAR, ploidy VARCHAR[], "
+        "length BIGINT, scaffoldN50 BIGINT, geneModelUrl VARCHAR)"  # no ucscBrowserUrl
+    )
+    c.execute(
+        "INSERT INTO assembly VALUES ('A1','S','st','Contig','No',['HAPLOID'],1,1,'g')"
+    )
+    out = execute(CatalogQuery(operation="list"), c)
+    assert out["returned"] == 1
+    assert "ucscBrowserUrl" not in out["rows"][0]
+    assert out["rows"][0]["accession"] == "A1"
+    c.close()

--- a/backend/api/tests/test_catalog_query.py
+++ b/backend/api/tests/test_catalog_query.py
@@ -360,3 +360,20 @@ def test_connect_fails_closed_on_schema_drift(tmp_path):
     pytest.importorskip("duckdb")
     (tmp_path / "assemblies.json").write_text('[{"accession": "A1"}]')
     assert connect(str(tmp_path)) is None
+
+
+def test_explicit_sort_gets_stable_tiebreaker(con):
+    # All fixture rows share isRef ties; a sort on isRef alone is ambiguous, so a
+    # stable secondary key (accession) must make the page order reproducible.
+    q = CatalogQuery(operation="list", sort=[Sort(field="isRef")])
+    accs = [r["accession"] for r in execute(q, con)["rows"]]
+    assert accs == [r["accession"] for r in execute(q, con)["rows"]]
+    # within the "No" group (A2, A3, C2) the tiebreaker orders by accession
+    assert [a for a in accs if a in {"A2", "A3", "C2"}] == ["A2", "A3", "C2"]
+
+
+def test_facets_have_stable_order_on_count_ties(con):
+    # Contig (1) is unique, but Chromosome and Scaffold both have 2 — the tie must
+    # resolve deterministically by key, not shuffle.
+    out = execute(CatalogQuery(operation="facets", facet_by=["level"]), con)
+    assert list(out["facets"]["level"]) == ["Chromosome", "Scaffold", "Contig"]

--- a/backend/api/tests/test_catalog_query.py
+++ b/backend/api/tests/test_catalog_query.py
@@ -198,6 +198,12 @@ def test_empty_value_list_rejected():
         CatalogQuery(filters=[Filter(field="level", op=Op.in_, value=[])])
     with pytest.raises(ValueError, match="non-empty value list"):
         CatalogQuery(filters=[Filter(field="ploidy", op=Op.contains_any, value=[])])
+    # eq/ne on a list field coerce to membership, so an empty list there is the
+    # same silent always-false/always-true trap — reject it too.
+    with pytest.raises(ValueError, match="non-empty value list"):
+        CatalogQuery(filters=[Filter(field="ploidy", op=Op.eq, value=[])])
+    with pytest.raises(ValueError, match="non-empty value list"):
+        CatalogQuery(filters=[Filter(field="ploidy", op=Op.ne, value=[])])
 
 
 def test_missing_value_rejected():

--- a/backend/api/tests/test_catalog_query.py
+++ b/backend/api/tests/test_catalog_query.py
@@ -30,6 +30,13 @@ def test_unknown_entity_rejected():
         CatalogQuery(entity="protein")
 
 
+def test_known_but_unloaded_entity_rejected():
+    # organism vocab exists but connect() loads no organism table yet — reject at
+    # validation with a clear message rather than failing mid-execution.
+    with pytest.raises(ValueError, match="not queryable yet"):
+        CatalogQuery(entity="organism")
+
+
 def test_unknown_operation_rejected():
     with pytest.raises(ValueError, match="unknown operation"):
         CatalogQuery(operation="aggregate")

--- a/backend/api/tests/test_catalog_query.py
+++ b/backend/api/tests/test_catalog_query.py
@@ -139,6 +139,25 @@ def test_compile_list_membership_and_coercion():
     assert frag == '(NOT (len(list_intersect("ploidy", ?)) > 0) OR "ploidy" IS NULL)'
 
 
+def test_list_field_value_is_stringified():
+    # LIST_FIELDS columns are VARCHAR[]; a numeric value (e.g. a taxid the model
+    # passes as a JSON number) must be compared as text — list_contains/intersect
+    # on VARCHAR[] with an INTEGER is a DuckDB binder error, not a no-match.
+    _, params = _compile_predicate(
+        Filter(field="lineageTaxonomyIds", op=Op.contains, value=1773)
+    )
+    assert params == ["1773"]
+    _, params = _compile_predicate(
+        Filter(field="lineageTaxonomyIds", op=Op.contains_any, value=[1773, 5833])
+    )
+    assert params == [["1773", "5833"]]
+    # coerced scalar eq on a list field stringifies too
+    _, params = _compile_predicate(
+        Filter(field="lineageTaxonomyIds", op=Op.eq, value=1773)
+    )
+    assert params == [["1773"]]
+
+
 def test_compile_ne_and_not_in_are_null_safe():
     # SQL `col != x` / `col NOT IN (...)` drop NULL rows; negation must include them.
     frag, _ = _compile_predicate(Filter(field="level", op=Op.ne, value="Contig"))

--- a/backend/api/tests/test_catalog_query.py
+++ b/backend/api/tests/test_catalog_query.py
@@ -171,7 +171,7 @@ def test_limit_and_offset_bounds():
     with pytest.raises(ValueError):
         CatalogQuery(limit=5000)  # exceeds the page cap
     with pytest.raises(ValueError):
-        CatalogQuery(limit=26)  # just over the cap
+        CatalogQuery(limit=11)  # just over the cap (max 10)
     with pytest.raises(ValueError):
         CatalogQuery(limit=0)
     with pytest.raises(ValueError):
@@ -362,7 +362,7 @@ def test_list_truncation_attaches_facets(con):
 
 
 def test_list_no_truncation_when_under_limit(con):
-    q = CatalogQuery(operation="list", limit=25)
+    q = CatalogQuery(operation="list", limit=10)
     out = execute(q, con)
     assert out["returned"] == 5
     assert out["truncated"] is False
@@ -372,7 +372,7 @@ def test_list_no_truncation_when_under_limit(con):
 def test_default_order_is_reference_then_quality(con):
     # No explicit sort: reference assemblies first, then largest scaffold N50,
     # accession as the stable tiebreaker. (Fixture refs: C1 n50=2000, A1 n50=1000.)
-    out = execute(CatalogQuery(operation="list", limit=25), con)
+    out = execute(CatalogQuery(operation="list", limit=10), con)
     accs = [r["accession"] for r in out["rows"]]
     assert accs[:2] == ["C1", "A1"]  # both isRef=Yes, ordered by N50 desc
     refs = [r["isRef"] for r in out["rows"]]

--- a/backend/api/tests/test_catalog_query.py
+++ b/backend/api/tests/test_catalog_query.py
@@ -367,7 +367,6 @@ def test_explicit_sort_gets_stable_tiebreaker(con):
     # stable secondary key (accession) must make the page order reproducible.
     q = CatalogQuery(operation="list", sort=[Sort(field="isRef")])
     accs = [r["accession"] for r in execute(q, con)["rows"]]
-    assert accs == [r["accession"] for r in execute(q, con)["rows"]]
     # within the "No" group (A2, A3, C2) the tiebreaker orders by accession
     assert [a for a in accs if a in {"A2", "A3", "C2"}] == ["A2", "A3", "C2"]
 

--- a/backend/api/tests/test_catalog_query.py
+++ b/backend/api/tests/test_catalog_query.py
@@ -1,0 +1,288 @@
+"""Local (non-integrated) tests for the catalog query IR + DuckDB executor.
+
+These exercise the query functionality directly — no model, no network — by
+authoring CatalogQuery IRs by hand and either inspecting the compiled SQL or
+running them against a small synthetic in-memory table with known contents.
+
+The query shapes mirror the DoD example set (subtree-via-rank, OR-within-field,
+AND empty-set, numeric range, facets/group-by, list-field membership, is_null),
+but assert against a fixed fixture so they don't drift with the live catalog.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.tools.catalog_query import (
+    CatalogQuery,
+    Filter,
+    Op,
+    Sort,
+    compile_predicate,
+    execute,
+)
+
+# --- IR validation (no DB) ----------------------------------------------------
+
+
+def test_unknown_entity_rejected():
+    with pytest.raises(ValueError, match="unknown entity"):
+        CatalogQuery(entity="protein")
+
+
+def test_unknown_operation_rejected():
+    with pytest.raises(ValueError, match="unknown operation"):
+        CatalogQuery(operation="aggregate")
+
+
+def test_unknown_field_rejected():
+    with pytest.raises(ValueError, match="unknown field"):
+        CatalogQuery(filters=[Filter(field="nope", op=Op.eq, value="x")])
+
+
+def test_unknown_facet_and_sort_fields_rejected():
+    with pytest.raises(ValueError, match="unknown field"):
+        CatalogQuery(operation="facets", facet_by=["nope"])
+    with pytest.raises(ValueError, match="unknown field"):
+        CatalogQuery(sort=[Sort(field="nope")])
+
+
+def test_range_op_requires_numeric_field():
+    with pytest.raises(ValueError, match="range op"):
+        CatalogQuery(filters=[Filter(field="level", op=Op.gt, value=1)])
+
+
+def test_contains_op_requires_list_field():
+    with pytest.raises(ValueError, match="needs a list field"):
+        CatalogQuery(filters=[Filter(field="level", op=Op.contains, value="x")])
+
+
+# --- predicate compilation (no DB) --------------------------------------------
+
+
+def test_compile_scalar_and_range():
+    assert compile_predicate(Filter(field="level", op=Op.eq, value="Chromosome")) == (
+        "level = ?",
+        ["Chromosome"],
+    )
+    assert compile_predicate(Filter(field="length", op=Op.gte, value=1000)) == (
+        "length >= ?",
+        [1000],
+    )
+
+
+def test_compile_in_and_null():
+    frag, params = compile_predicate(
+        Filter(field="level", op=Op.in_, value=["Chromosome", "Complete Genome"])
+    )
+    assert frag == "level IN (?, ?)"
+    assert params == ["Chromosome", "Complete Genome"]
+    assert compile_predicate(Filter(field="geneModelUrl", op=Op.is_null)) == (
+        "geneModelUrl IS NULL",
+        [],
+    )
+
+
+def test_compile_list_membership_and_coercion():
+    # explicit contains / contains_any
+    assert compile_predicate(
+        Filter(field="ploidy", op=Op.contains, value="DIPLOID")
+    ) == (
+        "list_contains(ploidy, ?)",
+        ["DIPLOID"],
+    )
+    # scalar eq on a list field coerces to membership (no failed round-trip)
+    frag, params = compile_predicate(Filter(field="ploidy", op=Op.eq, value="DIPLOID"))
+    assert frag == "len(list_intersect(ploidy, ?)) > 0"
+    assert params == [["DIPLOID"]]
+    # ne on a list field coerces to negated membership
+    frag, _ = compile_predicate(Filter(field="ploidy", op=Op.ne, value="DIPLOID"))
+    assert frag == "NOT (len(list_intersect(ploidy, ?)) > 0)"
+
+
+# --- executor against a synthetic table ---------------------------------------
+
+
+@pytest.fixture()
+def con():
+    duckdb = pytest.importorskip("duckdb")
+    c = duckdb.connect()
+    c.execute(
+        """
+        CREATE TABLE assembly (
+            accession VARCHAR,
+            taxonomicLevelSpecies VARCHAR,
+            taxonomicLevelGenus VARCHAR,
+            strainName VARCHAR,
+            level VARCHAR,
+            isRef VARCHAR,
+            ploidy VARCHAR[],
+            length BIGINT,
+            scaffoldN50 BIGINT,
+            geneModelUrl VARCHAR,
+            ucscBrowserUrl VARCHAR
+        )
+        """
+    )
+    rows = [
+        # accession, species, genus, strain, level, isRef, ploidy, length, n50, gtf, ucsc
+        (
+            "A1",
+            "Anopheles gambiae",
+            "Anopheles",
+            None,
+            "Chromosome",
+            "Yes",
+            ["DIPLOID"],
+            2_000_000_000,
+            1000,
+            "g1",
+            "u1",
+        ),
+        (
+            "A2",
+            "Anopheles gambiae",
+            "Anopheles",
+            None,
+            "Scaffold",
+            "No",
+            ["DIPLOID"],
+            1_500_000_000,
+            900,
+            None,
+            "u2",
+        ),
+        (
+            "A3",
+            "Anopheles stephensi",
+            "Anopheles",
+            None,
+            "Contig",
+            "No",
+            ["HAPLOID"],
+            800_000,
+            500,
+            "g3",
+            "u3",
+        ),
+        (
+            "C1",
+            "Candida albicans",
+            "Candida",
+            None,
+            "Scaffold",
+            "Yes",
+            ["DIPLOID"],
+            14_000_000,
+            2000,
+            "g4",
+            "u4",
+        ),
+        (
+            "C2",
+            "Candida albicans",
+            "Candida",
+            None,
+            "Chromosome",
+            "No",
+            ["DIPLOID"],
+            14_500_000,
+            3000,
+            None,
+            "u5",
+        ),
+    ]
+    c.executemany("INSERT INTO assembly VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", rows)
+    return c
+
+
+def test_count_subtree_via_rank(con):
+    q = CatalogQuery(
+        operation="count",
+        filters=[Filter(field="taxonomicLevelGenus", op=Op.eq, value="Anopheles")],
+    )
+    assert execute(q, con) == {"total": 3}
+
+
+def test_count_or_within_field(con):
+    q = CatalogQuery(
+        operation="count",
+        filters=[
+            Filter(field="taxonomicLevelGenus", op=Op.eq, value="Anopheles"),
+            Filter(field="level", op=Op.in_, value=["Chromosome", "Contig"]),
+        ],
+    )
+    assert execute(q, con) == {"total": 2}  # A1 + A3
+
+
+def test_count_empty_intersection_is_honest_zero(con):
+    q = CatalogQuery(
+        operation="count",
+        filters=[
+            Filter(field="taxonomicLevelSpecies", op=Op.eq, value="Candida albicans"),
+            Filter(field="isRef", op=Op.eq, value="Yes"),
+            Filter(field="level", op=Op.eq, value="Complete Genome"),
+        ],
+    )
+    assert execute(q, con) == {"total": 0}
+
+
+def test_count_numeric_range(con):
+    q = CatalogQuery(
+        operation="count",
+        filters=[
+            Filter(field="length", op=Op.gte, value=1_000_000_000),
+            Filter(field="length", op=Op.lte, value=5_000_000_000),
+        ],
+    )
+    assert execute(q, con) == {"total": 2}  # A1, A2
+
+
+def test_count_is_null_for_missing_annotation(con):
+    q = CatalogQuery(
+        operation="count",
+        filters=[Filter(field="geneModelUrl", op=Op.is_null)],
+    )
+    assert execute(q, con) == {"total": 2}  # A2, C2
+
+
+def test_facets_group_by_level(con):
+    q = CatalogQuery(operation="facets", facet_by=["level"])
+    out = execute(q, con)
+    assert out["total"] == 5
+    assert out["facets"]["level"] == {
+        "Chromosome": 2,
+        "Scaffold": 2,
+        "Contig": 1,
+    }
+
+
+def test_list_field_eq_coercion_matches_contains(con):
+    # `eq` on the list field ploidy should behave like contains (membership)
+    eq_q = CatalogQuery(
+        operation="count", filters=[Filter(field="ploidy", op=Op.eq, value="DIPLOID")]
+    )
+    contains_q = CatalogQuery(
+        operation="count",
+        filters=[Filter(field="ploidy", op=Op.contains, value="DIPLOID")],
+    )
+    assert execute(eq_q, con) == execute(contains_q, con) == {"total": 4}
+
+
+def test_list_truncation_attaches_facets(con):
+    q = CatalogQuery(operation="list", limit=2)
+    out = execute(q, con)
+    assert out["total"] == 5
+    assert out["returned"] == 2
+    assert out["truncated"] is True
+    assert len(out["rows"]) == 2
+    # auto-facets attach on truncation so the model can offer narrowing
+    assert "level" in out["facets"] and "isRef" in out["facets"]
+
+
+def test_list_no_truncation_when_under_limit(con):
+    q = CatalogQuery(operation="list", limit=25)
+    out = execute(q, con)
+    assert out["returned"] == 5
+    assert out["truncated"] is False
+    assert "facets" not in out

--- a/backend/api/tests/test_catalog_query.py
+++ b/backend/api/tests/test_catalog_query.py
@@ -136,9 +136,18 @@ def test_missing_value_rejected():
     CatalogQuery(filters=[Filter(field="geneModelUrl", op=Op.is_null)])
 
 
+def test_null_in_value_list_rejected():
+    # A None element is rejected by the Filter type (list[Scalar] excludes None),
+    # so `IN (NULL, ...)` can never be constructed.
+    with pytest.raises(ValueError):
+        Filter(field="level", op=Op.in_, value=[None, "Contig"])
+
+
 def test_limit_and_offset_bounds():
     with pytest.raises(ValueError):
         CatalogQuery(limit=5000)  # exceeds the page cap
+    with pytest.raises(ValueError):
+        CatalogQuery(limit=26)  # just over the cap
     with pytest.raises(ValueError):
         CatalogQuery(limit=0)
     with pytest.raises(ValueError):

--- a/backend/api/tests/test_catalog_query.py
+++ b/backend/api/tests/test_catalog_query.py
@@ -196,54 +196,46 @@ def con():
     return c
 
 
-def test_count_subtree_via_rank(con):
+@pytest.mark.parametrize(
+    "label, filters, expected",
+    [
+        # subtree via a denormalized rank column (no lineage walk)
+        ("subtree_via_rank", [("taxonomicLevelGenus", Op.eq, "Anopheles")], 3),
+        # OR within a field via `in`, AND with another field
+        (
+            "or_within_field",
+            [
+                ("taxonomicLevelGenus", Op.eq, "Anopheles"),
+                ("level", Op.in_, ["Chromosome", "Contig"]),  # A1 + A3
+            ],
+            2,
+        ),
+        # empty intersection -> honest zero (no constraint silently dropped)
+        (
+            "empty_intersection",
+            [
+                ("taxonomicLevelSpecies", Op.eq, "Candida albicans"),
+                ("isRef", Op.eq, "Yes"),
+                ("level", Op.eq, "Complete Genome"),
+            ],
+            0,
+        ),
+        # numeric range = two predicates on the same field (A1, A2)
+        (
+            "numeric_range",
+            [("length", Op.gte, 1_000_000_000), ("length", Op.lte, 5_000_000_000)],
+            2,
+        ),
+        # is_null = "missing" (A2, C2 have no gene annotation)
+        ("is_null_missing", [("geneModelUrl", Op.is_null, None)], 2),
+    ],
+)
+def test_count_shapes(con, label, filters, expected):
     q = CatalogQuery(
         operation="count",
-        filters=[Filter(field="taxonomicLevelGenus", op=Op.eq, value="Anopheles")],
+        filters=[Filter(field=f, op=op, value=v) for f, op, v in filters],
     )
-    assert execute(q, con) == {"total": 3}
-
-
-def test_count_or_within_field(con):
-    q = CatalogQuery(
-        operation="count",
-        filters=[
-            Filter(field="taxonomicLevelGenus", op=Op.eq, value="Anopheles"),
-            Filter(field="level", op=Op.in_, value=["Chromosome", "Contig"]),
-        ],
-    )
-    assert execute(q, con) == {"total": 2}  # A1 + A3
-
-
-def test_count_empty_intersection_is_honest_zero(con):
-    q = CatalogQuery(
-        operation="count",
-        filters=[
-            Filter(field="taxonomicLevelSpecies", op=Op.eq, value="Candida albicans"),
-            Filter(field="isRef", op=Op.eq, value="Yes"),
-            Filter(field="level", op=Op.eq, value="Complete Genome"),
-        ],
-    )
-    assert execute(q, con) == {"total": 0}
-
-
-def test_count_numeric_range(con):
-    q = CatalogQuery(
-        operation="count",
-        filters=[
-            Filter(field="length", op=Op.gte, value=1_000_000_000),
-            Filter(field="length", op=Op.lte, value=5_000_000_000),
-        ],
-    )
-    assert execute(q, con) == {"total": 2}  # A1, A2
-
-
-def test_count_is_null_for_missing_annotation(con):
-    q = CatalogQuery(
-        operation="count",
-        filters=[Filter(field="geneModelUrl", op=Op.is_null)],
-    )
-    assert execute(q, con) == {"total": 2}  # A2, C2
+    assert execute(q, con) == {"total": expected}
 
 
 def test_facets_group_by_level(con):

--- a/backend/api/tests/test_catalog_query.py
+++ b/backend/api/tests/test_catalog_query.py
@@ -18,7 +18,7 @@ from app.services.tools.catalog_query import (
     Filter,
     Op,
     Sort,
-    compile_predicate,
+    _compile_predicate,
     connect,
     execute,
 )
@@ -77,23 +77,23 @@ def test_contains_rejects_list_value():
 
 
 def test_compile_scalar_and_range():
-    assert compile_predicate(Filter(field="level", op=Op.eq, value="Chromosome")) == (
+    assert _compile_predicate(Filter(field="level", op=Op.eq, value="Chromosome")) == (
         "level = ?",
         ["Chromosome"],
     )
-    assert compile_predicate(Filter(field="length", op=Op.gte, value=1000)) == (
+    assert _compile_predicate(Filter(field="length", op=Op.gte, value=1000)) == (
         "length >= ?",
         [1000],
     )
 
 
 def test_compile_in_and_null():
-    frag, params = compile_predicate(
+    frag, params = _compile_predicate(
         Filter(field="level", op=Op.in_, value=["Chromosome", "Complete Genome"])
     )
     assert frag == "level IN (?, ?)"
     assert params == ["Chromosome", "Complete Genome"]
-    assert compile_predicate(Filter(field="geneModelUrl", op=Op.is_null)) == (
+    assert _compile_predicate(Filter(field="geneModelUrl", op=Op.is_null)) == (
         "geneModelUrl IS NULL",
         [],
     )
@@ -101,26 +101,26 @@ def test_compile_in_and_null():
 
 def test_compile_list_membership_and_coercion():
     # explicit contains / contains_any
-    assert compile_predicate(
+    assert _compile_predicate(
         Filter(field="ploidy", op=Op.contains, value="DIPLOID")
     ) == (
         "list_contains(ploidy, ?)",
         ["DIPLOID"],
     )
     # scalar eq on a list field coerces to membership (no failed round-trip)
-    frag, params = compile_predicate(Filter(field="ploidy", op=Op.eq, value="DIPLOID"))
+    frag, params = _compile_predicate(Filter(field="ploidy", op=Op.eq, value="DIPLOID"))
     assert frag == "len(list_intersect(ploidy, ?)) > 0"
     assert params == [["DIPLOID"]]
     # ne on a list field coerces to NULL-safe negated membership
-    frag, _ = compile_predicate(Filter(field="ploidy", op=Op.ne, value="DIPLOID"))
+    frag, _ = _compile_predicate(Filter(field="ploidy", op=Op.ne, value="DIPLOID"))
     assert frag == "(NOT (len(list_intersect(ploidy, ?)) > 0) OR ploidy IS NULL)"
 
 
 def test_compile_ne_and_not_in_are_null_safe():
     # SQL `col != x` / `col NOT IN (...)` drop NULL rows; negation must include them.
-    frag, _ = compile_predicate(Filter(field="level", op=Op.ne, value="Contig"))
+    frag, _ = _compile_predicate(Filter(field="level", op=Op.ne, value="Contig"))
     assert frag == "(level != ? OR level IS NULL)"
-    frag, _ = compile_predicate(Filter(field="level", op=Op.not_in, value=["Contig"]))
+    frag, _ = _compile_predicate(Filter(field="level", op=Op.not_in, value=["Contig"]))
     assert frag == "(level NOT IN (?) OR level IS NULL)"
 
 
@@ -188,7 +188,7 @@ def con():
         """
     )
     rows = [
-        # accession, species, genus, strain, level, isRef, ploidy, length, n50, gtf, ucsc
+        # accession, species, genus, strain, level, isRef, ploidy, len, n50, gtf, ucsc
         (
             "A1",
             "Anopheles gambiae",

--- a/backend/api/tests/test_catalog_query.py
+++ b/backend/api/tests/test_catalog_query.py
@@ -64,6 +64,14 @@ def test_contains_op_requires_list_field():
         CatalogQuery(filters=[Filter(field="level", op=Op.contains, value="x")])
 
 
+def test_contains_rejects_list_value():
+    # contains tests a single scalar element; a list value belongs to contains_any.
+    with pytest.raises(ValueError, match="use contains_any for a list"):
+        CatalogQuery(
+            filters=[Filter(field="ploidy", op=Op.contains, value=["DIPLOID"])]
+        )
+
+
 # --- predicate compilation (no DB) --------------------------------------------
 
 

--- a/backend/api/tests/test_catalog_query.py
+++ b/backend/api/tests/test_catalog_query.py
@@ -361,6 +361,20 @@ def test_list_truncation_attaches_facets(con):
     assert "level" in out["facets"] and "isRef" in out["facets"]
 
 
+def test_auto_facets_drop_single_bucket(con):
+    # Filtered to non-reference only: isRef collapses to one bucket (no narrowing
+    # value) so it's dropped; level still discriminates and stays.
+    q = CatalogQuery(
+        operation="list",
+        filters=[Filter(field="isRef", op=Op.eq, value="No")],
+        limit=2,
+    )
+    out = execute(q, con)
+    assert out["truncated"] is True
+    assert "isRef" not in out["facets"]
+    assert "level" in out["facets"]
+
+
 def test_list_no_truncation_when_under_limit(con):
     q = CatalogQuery(operation="list", limit=10)
     out = execute(q, con)

--- a/backend/api/tests/test_catalog_query.py
+++ b/backend/api/tests/test_catalog_query.py
@@ -82,6 +82,19 @@ def test_contains_rejects_list_value():
         )
 
 
+def test_eq_ne_reject_list_value_on_scalar_field():
+    # a list value on eq/ne for a scalar field would compile to `col = [..]`
+    # and error at execution — reject up front, pointing to in/not_in.
+    with pytest.raises(ValueError, match="use in/not_in"):
+        CatalogQuery(filters=[Filter(field="level", op=Op.eq, value=["Chromosome"])])
+    with pytest.raises(ValueError, match="use in/not_in"):
+        CatalogQuery(
+            filters=[Filter(field="level", op=Op.ne, value=["Contig", "Scaffold"])]
+        )
+    # but eq/ne on a list field with a list value is fine (coerced to membership)
+    CatalogQuery(filters=[Filter(field="ploidy", op=Op.eq, value=["DIPLOID"])])
+
+
 # --- predicate compilation (no DB) --------------------------------------------
 
 

--- a/backend/api/tests/test_catalog_query.py
+++ b/backend/api/tests/test_catalog_query.py
@@ -152,6 +152,22 @@ def test_facet_on_list_field_rejected():
         CatalogQuery(operation="facets", facet_by=["ploidy"])
 
 
+def test_facet_by_count_is_capped():
+    # Each facet column is a separate GROUP BY; the schema caps how many a single
+    # call can request so it can't fan out into a burst of DB work.
+    with pytest.raises(ValueError):
+        CatalogQuery(
+            operation="facets",
+            facet_by=[
+                "level",
+                "isRef",
+                "strainName",
+                "taxonomicLevelGenus",
+                "taxonomicLevelSpecies",
+            ],
+        )
+
+
 def test_facets_requires_facet_by():
     # operation=facets with no facet_by would return an empty {} — reject it.
     with pytest.raises(ValueError, match="needs at least one facet_by"):

--- a/backend/api/tests/test_catalog_query.py
+++ b/backend/api/tests/test_catalog_query.py
@@ -19,6 +19,7 @@ from app.services.tools.catalog_query import (
     Op,
     Sort,
     compile_predicate,
+    connect,
     execute,
 )
 
@@ -353,21 +354,9 @@ def test_list_no_truncation_when_under_limit(con):
     assert "facets" not in out
 
 
-def test_list_degrades_when_display_column_missing():
-    # A table missing a display column (ucscBrowserUrl) must not crash list
-    # queries — the projection drops the absent column gracefully.
-    duckdb = pytest.importorskip("duckdb")
-    c = duckdb.connect()
-    c.execute(
-        "CREATE TABLE assembly (accession VARCHAR, taxonomicLevelSpecies VARCHAR, "
-        "strainName VARCHAR, level VARCHAR, isRef VARCHAR, ploidy VARCHAR[], "
-        "length BIGINT, scaffoldN50 BIGINT, geneModelUrl VARCHAR)"  # no ucscBrowserUrl
-    )
-    c.execute(
-        "INSERT INTO assembly VALUES ('A1','S','st','Contig','No',['HAPLOID'],1,1,'g')"
-    )
-    out = execute(CatalogQuery(operation="list"), c)
-    assert out["returned"] == 1
-    assert "ucscBrowserUrl" not in out["rows"][0]
-    assert out["rows"][0]["accession"] == "A1"
-    c.close()
+def test_connect_fails_closed_on_schema_drift(tmp_path):
+    # If the catalog is missing configured columns, the engine must disable
+    # itself (return None) rather than degrade — drift is a build problem to fix.
+    pytest.importorskip("duckdb")
+    (tmp_path / "assemblies.json").write_text('[{"accession": "A1"}]')
+    assert connect(str(tmp_path)) is None

--- a/backend/api/tests/test_catalog_query.py
+++ b/backend/api/tests/test_catalog_query.py
@@ -14,11 +14,16 @@ from __future__ import annotations
 import pytest
 
 from app.services.tools.catalog_query import (
+    _DISPLAY_COLUMNS,
+    ASSEMBLY_FIELDS,
+    LIST_FIELDS,
+    NUMERIC_FIELDS,
     CatalogQuery,
     Filter,
     Op,
     Sort,
     _compile_predicate,
+    _schema_issues,
     connect,
     execute,
 )
@@ -127,6 +132,12 @@ def test_compile_ne_and_not_in_are_null_safe():
 def test_facet_on_list_field_rejected():
     with pytest.raises(ValueError, match="cannot facet on list field"):
         CatalogQuery(operation="facets", facet_by=["ploidy"])
+
+
+def test_facets_requires_facet_by():
+    # operation=facets with no facet_by would return an empty {} — reject it.
+    with pytest.raises(ValueError, match="needs at least one facet_by"):
+        CatalogQuery(operation="facets")
 
 
 def test_empty_value_list_rejected():
@@ -360,6 +371,44 @@ def test_connect_fails_closed_on_schema_drift(tmp_path):
     pytest.importorskip("duckdb")
     (tmp_path / "assemblies.json").write_text('[{"accession": "A1"}]')
     assert connect(str(tmp_path)) is None
+
+
+def _ok_coltypes() -> dict[str, str]:
+    """A schema where every configured column is present and correctly typed."""
+    configured = ASSEMBLY_FIELDS | set(_DISPLAY_COLUMNS["assembly"])
+    out = {}
+    for c in configured:
+        if c in NUMERIC_FIELDS:
+            out[c] = "BIGINT"
+        elif c in LIST_FIELDS:
+            out[c] = "VARCHAR[]"
+        else:
+            out[c] = "VARCHAR"
+    return out
+
+
+def test_schema_issues_accepts_correct_schema():
+    missing, mistyped = _schema_issues(_ok_coltypes())
+    assert missing == [] and mistyped == []
+
+
+def test_schema_issues_flags_missing_and_mistyped():
+    cols = _ok_coltypes()
+    cols["length"] = "VARCHAR"  # numeric field inferred as text
+    cols["ploidy"] = "VARCHAR"  # list field inferred as scalar
+    del cols["isRef"]  # a configured column dropped
+    missing, mistyped = _schema_issues(cols)
+    assert "isRef" in missing
+    assert any(m.startswith("length=") for m in mistyped)
+    assert any(m.startswith("ploidy=") for m in mistyped)
+
+
+def test_schema_issues_accepts_numeric_type_variants():
+    cols = _ok_coltypes()
+    cols["gcPercent"] = "DOUBLE"
+    cols["length"] = "DECIMAL(18,3)"  # parameterized numeric type
+    _, mistyped = _schema_issues(cols)
+    assert mistyped == []
 
 
 def test_explicit_sort_gets_stable_tiebreaker(con):

--- a/backend/api/tests/test_catalog_query.py
+++ b/backend/api/tests/test_catalog_query.py
@@ -99,12 +99,13 @@ def test_eq_ne_reject_list_value_on_scalar_field():
 
 
 def test_compile_scalar_and_range():
+    # Identifiers are quoted (defense-in-depth + exact-case pinning).
     assert _compile_predicate(Filter(field="level", op=Op.eq, value="Chromosome")) == (
-        "level = ?",
+        '"level" = ?',
         ["Chromosome"],
     )
     assert _compile_predicate(Filter(field="length", op=Op.gte, value=1000)) == (
-        "length >= ?",
+        '"length" >= ?',
         [1000],
     )
 
@@ -113,10 +114,10 @@ def test_compile_in_and_null():
     frag, params = _compile_predicate(
         Filter(field="level", op=Op.in_, value=["Chromosome", "Complete Genome"])
     )
-    assert frag == "level IN (?, ?)"
+    assert frag == '"level" IN (?, ?)'
     assert params == ["Chromosome", "Complete Genome"]
     assert _compile_predicate(Filter(field="geneModelUrl", op=Op.is_null)) == (
-        "geneModelUrl IS NULL",
+        '"geneModelUrl" IS NULL',
         [],
     )
 
@@ -126,24 +127,24 @@ def test_compile_list_membership_and_coercion():
     assert _compile_predicate(
         Filter(field="ploidy", op=Op.contains, value="DIPLOID")
     ) == (
-        "list_contains(ploidy, ?)",
+        'list_contains("ploidy", ?)',
         ["DIPLOID"],
     )
     # scalar eq on a list field coerces to membership (no failed round-trip)
     frag, params = _compile_predicate(Filter(field="ploidy", op=Op.eq, value="DIPLOID"))
-    assert frag == "len(list_intersect(ploidy, ?)) > 0"
+    assert frag == 'len(list_intersect("ploidy", ?)) > 0'
     assert params == [["DIPLOID"]]
     # ne on a list field coerces to NULL-safe negated membership
     frag, _ = _compile_predicate(Filter(field="ploidy", op=Op.ne, value="DIPLOID"))
-    assert frag == "(NOT (len(list_intersect(ploidy, ?)) > 0) OR ploidy IS NULL)"
+    assert frag == '(NOT (len(list_intersect("ploidy", ?)) > 0) OR "ploidy" IS NULL)'
 
 
 def test_compile_ne_and_not_in_are_null_safe():
     # SQL `col != x` / `col NOT IN (...)` drop NULL rows; negation must include them.
     frag, _ = _compile_predicate(Filter(field="level", op=Op.ne, value="Contig"))
-    assert frag == "(level != ? OR level IS NULL)"
+    assert frag == '("level" != ? OR "level" IS NULL)'
     frag, _ = _compile_predicate(Filter(field="level", op=Op.not_in, value=["Contig"]))
-    assert frag == "(level NOT IN (?) OR level IS NULL)"
+    assert frag == '("level" NOT IN (?) OR "level" IS NULL)'
 
 
 def test_facet_on_list_field_rejected():
@@ -459,6 +460,17 @@ def test_explicit_sort_gets_stable_tiebreaker(con):
     accs = [r["accession"] for r in execute(q, con)["rows"]]
     # within the "No" group (A2, A3, C2) the tiebreaker orders by accession
     assert [a for a in accs if a in {"A2", "A3", "C2"}] == ["A2", "A3", "C2"]
+
+
+def test_explicit_sort_puts_nulls_last(con):
+    # A DESC sort on a column with missing values must keep the rows that have
+    # data at the top of the page (DuckDB defaults NULLs first on DESC).
+    # Fixture geneModelUrl: A2 and C2 are NULL; the rest have values.
+    q = CatalogQuery(operation="list", sort=[Sort(field="geneModelUrl", desc=True)])
+    gtfs = [r["geneModelUrl"] for r in execute(q, con)["rows"]]
+    # every non-null value precedes every null
+    assert gtfs[-2:] == [None, None]
+    assert all(g is not None for g in gtfs[:-2])
 
 
 def test_facets_have_stable_order_on_count_ties(con):

--- a/backend/api/tests/test_catalog_query.py
+++ b/backend/api/tests/test_catalog_query.py
@@ -369,6 +369,16 @@ def test_list_no_truncation_when_under_limit(con):
     assert "facets" not in out
 
 
+def test_default_order_is_reference_then_quality(con):
+    # No explicit sort: reference assemblies first, then largest scaffold N50,
+    # accession as the stable tiebreaker. (Fixture refs: C1 n50=2000, A1 n50=1000.)
+    out = execute(CatalogQuery(operation="list", limit=25), con)
+    accs = [r["accession"] for r in out["rows"]]
+    assert accs[:2] == ["C1", "A1"]  # both isRef=Yes, ordered by N50 desc
+    refs = [r["isRef"] for r in out["rows"]]
+    assert refs == sorted(refs, reverse=True)  # all "Yes" precede all "No"
+
+
 def test_connect_fails_closed_on_schema_drift(tmp_path):
     # If the catalog is missing configured columns, the engine must disable
     # itself (return None) rather than degrade — drift is a build problem to fix.

--- a/backend/api/tests/test_catalog_query.py
+++ b/backend/api/tests/test_catalog_query.py
@@ -127,6 +127,15 @@ def test_empty_value_list_rejected():
         CatalogQuery(filters=[Filter(field="ploidy", op=Op.contains_any, value=[])])
 
 
+def test_missing_value_rejected():
+    # ops other than is_null/not_null need a value; None would compile to a
+    # comparison against NULL that silently matches nothing.
+    with pytest.raises(ValueError, match="needs a value"):
+        CatalogQuery(filters=[Filter(field="level", op=Op.eq, value=None)])
+    # is_null needs no value
+    CatalogQuery(filters=[Filter(field="geneModelUrl", op=Op.is_null)])
+
+
 def test_limit_and_offset_bounds():
     with pytest.raises(ValueError):
         CatalogQuery(limit=5000)  # exceeds the page cap
@@ -229,7 +238,8 @@ def con():
         ),
     ]
     c.executemany("INSERT INTO assembly VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", rows)
-    return c
+    yield c
+    c.close()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #1363.

## Problem
The assistant filters and counts the catalog by **reading rows in the model's context** — the catalog tools return the full list as JSON and the LLM applies the filter/count by eye. Accurate at small N, wrong at scale, and non-deterministically so (a "complete-genome assemblies for *C. neoformans*" query returned 4 of 17 on one run and 17 on the next; empty intersections get a constraint silently dropped rather than reported as "none"). See #1363 for the full problem statement and evidence.

## Approach
Keep the model *deciding* the predicate, but move *applying* it out of its context:

- **Query model (typed IR):** the model expresses the request as a structured, typed query (fields / operations / filters) as a single `query_catalog` tool call, instead of reading and filtering rows.
- **Deterministic execution:** the backend validates the query against a per-entity field allowlist, compiles it to parameterized SQL, and runs it — so counts and filters are exact and reproducible at any catalog size.
- **Interim DuckDB executor:** an in-process DuckDB over the catalog backs the query for now; the query model is the stable contract and the executor can later swap to a hosted DB (#1192) behind it.
- **Bounded responses:** the tool returns a summary `{total, returned, truncated, facets, rows}`, never the raw corpus. Results over 10 rows are truncated, with facets attached so the assistant can offer to narrow rather than page or dump.

## Changes
- **New `app/services/tools/catalog_query.py`** — the IR (`CatalogQuery`/`Filter`/`Op`/`Sort`) with a validating model, predicate/where compilation, `connect()` (in-process DuckDB load), and `execute()` (count / list / facets; auto-facets on truncation).
- **`catalog_tools.py`** — add the `query_catalog` tool (fail-soft when DuckDB is unavailable); remove the redundant `get_assemblies`.
- **`assistant_agent.py`** — wire the DuckDB connection in (fail-soft to `None`); teach the field vocab + summarize-and-narrow rule in the system prompt.
- **`pyproject.toml` / `uv.lock`** — add the `duckdb` dependency.

Assembly entity first; organism and workflows stay on their existing tools (follow-ups). Rebased on the SRA mirror (#1302) and persistent-user-data (#1301) merges; `query_catalog` coexists with the `sra_*` tools.

### Query semantics
- **List-field membership coercion** — scalar ops (`eq`/`ne`/`in`/`not_in`) on a list field compile to list membership, so the model's natural phrasing (`ploidy = DIPLOID`) works without a failed round-trip.
- **NULL-safe negation** — `ne`/`not_in` include rows with no value, so `count(eq) + count(ne)` equals the total instead of undercounting.
- **Reproducible ordering** — a deterministic default sort plus tiebreakers (for both row pages and facet buckets) so paged/faceted results don't shuffle across runs.

### Guardrails (fail clearly, not wrong)
- **Bounded output** — `limit` is a fixed 10-row page (capped at the schema level so the model can't inflate it), `offset >= 0`.
- **Up-front validation rejections** with actionable messages — faceting a list field, empty value lists, missing values, `contains` with a list, and querying a not-yet-loaded entity (e.g. `organism`, gated by `QUERYABLE_ENTITIES`) are rejected before execution so the model gets a clean retry rather than a wrong/empty answer.
- **Fail-closed on catalog schema drift** — if a configured column is missing from the assembly table, the engine disables itself (logs an error, returns `None`) rather than serving wrong/partial results.
- **Sanitized failure** — query errors return a controlled message (and log the detail) instead of echoing raw exception text.

## Assistant behavior
Prompt changes so responses are consistent and factual:
- **Large/truncated results** lead with the total + a breakdown by level and offer a few ways to narrow (instead of sometimes dumping a reference card or pivoting to "what analysis?").
- **Reference assembly stated factually** (`isRef=Yes`) — removed the "recommended / usual starting point" framing and the full detail-card dump; it's a brief mention so the user decides.
- **Gene annotation is no longer a filter/narrowing axis** — a GTF is expected for every assembly (the few missing are a data bug to fix upstream); `geneModelUrl` stays queryable for data QC.

## Tests
- **New `tests/test_catalog_query.py` (37 cases)** — fully local, no model/network: IR validation rejections (unknown/unloaded entity, range/contains field types, empty/missing/`None` values, list-field faceting, limit/offset bounds), predicate compilation (incl. list-field coercion and NULL-safe negation), executor behavior on a synthetic fixture (subtree-via-rank, OR-within-field, AND empty-set, numeric range, `is_null`, facets/group-by, list membership, truncation auto-facets, stable ordering), and fail-closed-on-drift.
- The DoD example set was also verified through the production module against the live catalog (Anopheles 69, C. neoformans complete-genome 17, chromosome-level 610, C. albicans ref∩complete 0, …) — codified above as fixture shapes so they don't drift with the catalog snapshot.

## Eval adjustment
One tool-selection case updated for the renamed tool — the TB-by-taxid case now expects `query_catalog` (asserting the taxid is applied as a filter) instead of the removed `get_assemblies`. No other eval datasets changed.

## Future work

This lands the deterministic query path; we'll keep refining the assistant's behavior on top of it:

- **Refinement & exploration of the long tail** — richer narrow/browse flows so users can drill into the long tail of assemblies beyond the bounded summary, rather than stopping at the reference/top results.
- **Search over organisms** — extend the typed IR + executor to the organism entity (the scaffolding is already gated by `QUERYABLE_ENTITIES`), eventually subsuming `search_organisms`.
- **Merge with the SRA DuckDB mirror** — converge this in-process DuckDB executor with the SRA metadata connector (#1302) onto shared database scaffolding, so catalog and sequencing-read queries run through one query layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

