### PR TITLE
refactor: entity-keyed catalog query schema (single-source per-entity descriptor)

### DIFF
--- a/backend/api/app/services/tools/catalog_query.py
+++ b/backend/api/app/services/tools/catalog_query.py
@@ -15,6 +15,8 @@ Assembly-first; organism is sketched. Workflows stay on their dedicated tools.
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
+from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from typing import Literal, Optional, Union
@@ -23,78 +25,156 @@ from pydantic import BaseModel, Field, model_validator
 
 logger = logging.getLogger(__name__)
 
-ASSEMBLY_FIELDS: set[str] = {
-    "accession",
-    "ncbiTaxonomyId",
-    "speciesTaxonomyId",
-    "lineageTaxonomyIds",
-    "taxonomicLevelDomain",
-    "taxonomicLevelKingdom",
-    "taxonomicLevelPhylum",
-    "taxonomicLevelClass",
-    "taxonomicLevelOrder",
-    "taxonomicLevelFamily",
-    "taxonomicLevelGenus",
-    "taxonomicLevelSpecies",
-    "taxonomicLevelStrain",
-    "taxonomicLevelSerotype",
-    "taxonomicLevelIsolate",
-    "taxonomicLevelRealm",
-    "taxonomicGroup",
-    "otherTaxa",
-    "level",
-    "isRef",
-    "ploidy",
-    "priority",
-    "priorityPathogenName",
-    "annotationStatus",
-    "length",
-    "gcPercent",
-    "scaffoldN50",
-    "scaffoldL50",
-    "scaffoldCount",
-    "chromosomes",
-    "strainName",
-    "coverage",
-    "commonName",
-    "geneModelUrl",
-}
 
-ORGANISM_FIELDS: set[str] = {
-    "ncbiTaxonomyId",
-    "commonName",
-    "assemblyCount",
-    "priority",
-    "priorityPathogenName",
-    "taxonomicGroup",
-    "taxonomicLevelDomain",
-    "taxonomicLevelKingdom",
-    "taxonomicLevelPhylum",
-    "taxonomicLevelClass",
-    "taxonomicLevelOrder",
-    "taxonomicLevelFamily",
-    "taxonomicLevelGenus",
-    "taxonomicLevelSpecies",
-}
+class FieldType(str, Enum):
+    """How a queryable field is typed — decides how a filter compiles to SQL.
 
-# Field vocab per entity. Only "assembly" is queryable today (see the `entity`
-# Literal on CatalogQuery and the assembly-only table in connect()); the organism
-# vocab is kept as roadmap data — to enable it, add "organism" to that Literal and
-# load its table in connect().
-ENTITY_FIELDS: dict[str, set[str]] = {
-    "assembly": ASSEMBLY_FIELDS,
-    "organism": ORGANISM_FIELDS,
-}
+    The same column name can be typed differently per entity (e.g. otherTaxa is a
+    VARCHAR[] on assembly but scalar on organism), which is why types are declared
+    per entity in ENTITY_SCHEMA rather than in one global set.
+    """
 
-LIST_FIELDS: set[str] = {"lineageTaxonomyIds", "ploidy", "taxonomicGroup", "otherTaxa"}
-NUMERIC_FIELDS: set[str] = {
-    "length",
-    "gcPercent",
-    "scaffoldN50",
-    "scaffoldL50",
-    "scaffoldCount",
-    "chromosomes",
-    "assemblyCount",
+    SCALAR = "scalar"  # plain column: eq/ne/in/not_in (no range)
+    NUMERIC = "numeric"  # scalar that also supports range ops (gt/gte/lt/lte)
+    LIST = "list"  # VARCHAR[] column: membership; eq/in coerce to membership
+
+
+# Bare aliases so the per-entity field tables below read like a schema.
+SCALAR, NUMERIC, LIST = FieldType.SCALAR, FieldType.NUMERIC, FieldType.LIST
+
+
+@dataclass
+class EntitySchema:
+    """The catalog schema for one entity, declared once.
+
+    Each queryable field is declared with its FieldType; the derived views
+    (`field_names` / `list_fields` / `numeric_fields` / `configured_columns`) are
+    computed from that single declaration, so the allowlist, list-ness and
+    numeric-ness can never drift apart.
+    """
+
+    # Field name -> type. The model may filter / sort / facet on exactly these.
+    fields: dict[str, FieldType]
+    # Curated projection for `list` rows (bounded tokens vs SELECT *). May include
+    # display-only columns absent from `fields` (e.g. ucscBrowserUrl) — shown but
+    # not filterable; connect()'s drift check still requires them to exist.
+    display: tuple[str, ...]
+    # Default ordering for a `list` with no explicit sort, as (field, desc) terms.
+    default_order: tuple[tuple[str, bool], ...] = ()
+    # Facets auto-returned on a truncated list so the model can offer narrowing.
+    auto_facets: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        self.field_names: set[str] = set(self.fields)
+        self.list_fields: set[str] = {
+            f for f, t in self.fields.items() if t is FieldType.LIST
+        }
+        self.numeric_fields: set[str] = {
+            f for f, t in self.fields.items() if t is FieldType.NUMERIC
+        }
+        self.configured_columns: set[str] = self.field_names | set(self.display)
+        # Fail at import on a misdeclared schema rather than late with malformed
+        # SQL or an IndexError: a `list` always needs a projection, and every
+        # column named for ordering/faceting must be a configured column (so the
+        # connect() drift check guarantees it exists in the table).
+        if not self.display:
+            raise ValueError("EntitySchema.display must be non-empty")
+        referenced = {field for field, _ in self.default_order} | set(self.auto_facets)
+        unknown = referenced - self.configured_columns
+        if unknown:
+            raise ValueError(
+                f"EntitySchema default_order/auto_facets reference unknown "
+                f"column(s) {sorted(unknown)}"
+            )
+
+
+# Single source of truth for the catalog schema the query engine knows about.
+# Only "assembly" is queryable today (see the `entity` Literal on CatalogQuery and
+# the assembly-only table in connect()); the organism schema is kept as roadmap
+# data — to enable it, add "organism" to that Literal and load its table.
+ENTITY_SCHEMA: dict[str, EntitySchema] = {
+    "assembly": EntitySchema(
+        fields={
+            "accession": SCALAR,
+            "ncbiTaxonomyId": SCALAR,
+            "speciesTaxonomyId": SCALAR,
+            "lineageTaxonomyIds": LIST,
+            "taxonomicLevelDomain": SCALAR,
+            "taxonomicLevelKingdom": SCALAR,
+            "taxonomicLevelPhylum": SCALAR,
+            "taxonomicLevelClass": SCALAR,
+            "taxonomicLevelOrder": SCALAR,
+            "taxonomicLevelFamily": SCALAR,
+            "taxonomicLevelGenus": SCALAR,
+            "taxonomicLevelSpecies": SCALAR,
+            "taxonomicLevelStrain": SCALAR,
+            "taxonomicLevelSerotype": SCALAR,
+            "taxonomicLevelIsolate": SCALAR,
+            "taxonomicLevelRealm": SCALAR,
+            "taxonomicGroup": LIST,
+            "otherTaxa": LIST,
+            "level": SCALAR,
+            "isRef": SCALAR,
+            "ploidy": LIST,
+            "priority": SCALAR,
+            "priorityPathogenName": SCALAR,
+            "annotationStatus": SCALAR,
+            "length": NUMERIC,
+            "gcPercent": NUMERIC,
+            "scaffoldN50": NUMERIC,
+            "scaffoldL50": NUMERIC,
+            "scaffoldCount": NUMERIC,
+            "chromosomes": NUMERIC,
+            "strainName": SCALAR,
+            "coverage": SCALAR,
+            "commonName": SCALAR,
+            "geneModelUrl": SCALAR,
+        },
+        # ploidy is intentionally omitted from display — it's an organism-level
+        # attribute (constant across an organism's assemblies), so a per-row column
+        # is redundant. It stays a filterable field, just not displayed.
+        display=(
+            "accession",
+            "taxonomicLevelSpecies",
+            "strainName",
+            "level",
+            "isRef",
+            "length",
+            "scaffoldN50",
+            "geneModelUrl",
+            "ucscBrowserUrl",
+        ),
+        # Most relevant first: the reference assembly, then best quality (largest
+        # scaffold N50), with accession as a stable tiebreaker — beats ordering by
+        # an arbitrary accession id.
+        default_order=(("isRef", True), ("scaffoldN50", True), ("accession", False)),
+        auto_facets=("level", "isRef"),
+    ),
+    "organism": EntitySchema(
+        fields={
+            "ncbiTaxonomyId": SCALAR,
+            "commonName": SCALAR,
+            "assemblyCount": NUMERIC,
+            "priority": SCALAR,
+            "priorityPathogenName": SCALAR,
+            "taxonomicGroup": LIST,
+            "taxonomicLevelDomain": SCALAR,
+            "taxonomicLevelKingdom": SCALAR,
+            "taxonomicLevelPhylum": SCALAR,
+            "taxonomicLevelClass": SCALAR,
+            "taxonomicLevelOrder": SCALAR,
+            "taxonomicLevelFamily": SCALAR,
+            "taxonomicLevelGenus": SCALAR,
+            "taxonomicLevelSpecies": SCALAR,
+        },
+        display=(
+            "ncbiTaxonomyId",
+            "taxonomicLevelSpecies",
+            "commonName",
+            "assemblyCount",
+        ),
+        auto_facets=("taxonomicLevelDomain",),
+    ),
 }
 
 # Cap on buckets returned per faceted column (top-N by count) — keeps a facet on
@@ -126,67 +206,33 @@ _NUMERIC_DUCKDB_TYPES = {
 }
 
 
-def _schema_issues(coltypes: dict[str, str]) -> tuple[list[str], list[str]]:
-    """Compare the loaded assembly columns (name -> UPPERCASE DuckDB type) against
-    the hand-maintained allowlist. Returns (missing, mistyped):
+def _schema_issues(
+    coltypes: dict[str, str], entity: str
+) -> tuple[list[str], list[str]]:
+    """Compare an entity's loaded columns (name -> UPPERCASE DuckDB type) against
+    its declared schema. Returns (missing, mistyped):
 
     - missing: configured columns absent from the table.
     - mistyped: numeric fields not inferred numeric, or list fields not inferred
       as lists — these compile to SQL that errors or mis-sorts at query time.
+
+    Scoped to the entity's own fields: a column that is a list on another entity
+    (e.g. assembly's otherTaxa) must not be flagged just because it appears as a
+    scalar here.
     """
+    schema = ENTITY_SCHEMA[entity]
     actual = set(coltypes)
-    configured = ASSEMBLY_FIELDS | set(_DISPLAY_COLUMNS["assembly"])
-    missing = sorted(configured - actual)
+    missing = sorted(schema.configured_columns - actual)
     mistyped = sorted(
         f"{c}={coltypes[c]}"
-        for c in NUMERIC_FIELDS & actual
+        for c in schema.numeric_fields & actual
         if coltypes[c].split("(")[0] not in _NUMERIC_DUCKDB_TYPES
     ) + sorted(
         f"{c}={coltypes[c]}"
-        for c in LIST_FIELDS & actual
+        for c in schema.list_fields & actual
         if not coltypes[c].endswith("[]")
     )
     return missing, mistyped
-
-
-# Facets auto-returned on a truncated list, so the model can offer narrowing.
-_AUTO_FACET_FIELDS: dict[str, list[str]] = {
-    "assembly": ["level", "isRef"],
-    "organism": ["taxonomicLevelDomain"],
-}
-
-# Curated projection for `list` rows (keeps tokens bounded vs SELECT *).
-_DISPLAY_COLUMNS: dict[str, list[str]] = {
-    "assembly": [
-        # ploidy is intentionally omitted — it's an organism-level attribute
-        # (constant across all of an organism's assemblies), so a per-row column
-        # is redundant. It stays a filterable field, just not displayed.
-        "accession",
-        "taxonomicLevelSpecies",
-        "strainName",
-        "level",
-        "isRef",
-        "length",
-        "scaffoldN50",
-        "geneModelUrl",
-        "ucscBrowserUrl",
-    ],
-    "organism": [
-        "ncbiTaxonomyId",
-        "taxonomicLevelSpecies",
-        "commonName",
-        "assemblyCount",
-    ],
-}
-
-# Default ordering for a `list` with no explicit sort: most relevant first —
-# the reference assembly, then best quality (largest scaffold N50), with accession
-# as a stable tiebreaker. Beats ordering by an arbitrary accession id. Stored as
-# (field, desc) terms so the same _qi()-quoting / NULLS LAST builder serves both
-# this and the explicit-sort path (no raw identifiers embedded in a string).
-_DEFAULT_ORDER: dict[str, list[tuple[str, bool]]] = {
-    "assembly": [("isRef", True), ("scaffoldN50", True), ("accession", False)],
-}
 
 
 class Op(str, Enum):
@@ -242,7 +288,8 @@ class CatalogQuery(BaseModel):
         # advertises the allowed set in the tool schema.
         if self.operation == "facets" and not self.facet_by:
             raise ValueError("operation 'facets' needs at least one facet_by field")
-        allowed = ENTITY_FIELDS[self.entity]
+        schema = ENTITY_SCHEMA[self.entity]
+        allowed = schema.field_names
         referenced = (
             [f.field for f in self.filters]
             + list(self.facet_by)
@@ -256,7 +303,9 @@ class CatalogQuery(BaseModel):
             )
         # GROUP BY on a list column buckets by whole-list equality (and yields
         # list-repr keys), not per-element counts — reject it rather than mislead.
-        list_facets = sorted({c for c in self.facet_by if c in LIST_FIELDS})
+        list_fields = schema.list_fields
+        numeric_fields = schema.numeric_fields
+        list_facets = sorted({c for c in self.facet_by if c in list_fields})
         if list_facets:
             raise ValueError(
                 f"cannot facet on list field(s) {list_facets}; "
@@ -270,7 +319,7 @@ class CatalogQuery(BaseModel):
             # (A None *inside* a value list — IN (NULL, ...) — is already rejected
             # by the Filter type: list[Scalar] excludes None, so it can't occur.)
             if f.op in (Op.gt, Op.gte, Op.lt, Op.lte):
-                if f.field not in NUMERIC_FIELDS:
+                if f.field not in numeric_fields:
                     raise ValueError(
                         f"range op {f.op.value} needs a numeric field, got {f.field!r}"
                     )
@@ -284,14 +333,14 @@ class CatalogQuery(BaseModel):
             # to membership, so a list there is fine.)
             if (
                 f.op in (Op.eq, Op.ne)
-                and f.field not in LIST_FIELDS
+                and f.field not in list_fields
                 and isinstance(f.value, list)
             ):
                 raise ValueError(
                     f"{f.op.value} on {f.field!r} needs a scalar value; "
                     "use in/not_in for multiple values"
                 )
-            if f.op in (Op.contains, Op.contains_any) and f.field not in LIST_FIELDS:
+            if f.op in (Op.contains, Op.contains_any) and f.field not in list_fields:
                 raise ValueError(f"{f.op.value} needs a list field, got {f.field!r}")
             # `contains` tests one scalar element (list_contains needs a scalar);
             # a list value belongs to `contains_any`.
@@ -304,7 +353,7 @@ class CatalogQuery(BaseModel):
             # consumes a list — in/not_in/contains_any always, plus eq/ne when
             # they coerce to list membership on a list field.
             consumes_list = f.op in (Op.in_, Op.not_in, Op.contains_any) or (
-                f.op in (Op.eq, Op.ne) and f.field in LIST_FIELDS
+                f.op in (Op.eq, Op.ne) and f.field in list_fields
             )
             if consumes_list and isinstance(f.value, list) and not f.value:
                 raise ValueError(f"{f.op.value} needs a non-empty value list")
@@ -333,7 +382,7 @@ def _qi(identifier: str) -> str:
     return '"' + identifier.replace('"', '""') + '"'
 
 
-def _order_by(terms: list[tuple[str, bool]]) -> str:
+def _order_by(terms: Sequence[tuple[str, bool]]) -> str:
     """Build an ORDER BY body from (field, desc) terms — quoted, with NULLS LAST.
 
     NULLS LAST so a column with missing values keeps the rows that have data at
@@ -357,7 +406,7 @@ def _as_list(value) -> list:
 def _list_text(value) -> list[str]:
     """Stringify membership value(s) for a VARCHAR[] list column.
 
-    Every LIST_FIELDS column is VARCHAR[] (taxonomy-id lists, ploidy, ...), but
+    Every list-typed column is VARCHAR[] (taxonomy-id lists, ploidy, ...), but
     the model naturally passes a taxid as a JSON number — and
     `list_contains(VARCHAR[], INTEGER)` / `list_intersect` is a DuckDB binder
     error, not a no-match. Compare as text so a numeric taxid still works.
@@ -365,7 +414,7 @@ def _list_text(value) -> list[str]:
     return [str(v) for v in _as_list(value)]
 
 
-def _compile_predicate(f: Filter) -> tuple[str, list]:
+def _compile_predicate(f: Filter, entity: str) -> tuple[str, list]:
     col = _qi(f.field)
     if f.op is Op.is_null:
         return f"{col} IS NULL", []
@@ -375,7 +424,12 @@ def _compile_predicate(f: Filter) -> tuple[str, list]:
     # membership — a list never equals a scalar, so this is the only sensible
     # reading. Coercing it lets the model's natural `eq`/`in` phrasing work
     # without a failed round-trip.
-    if f.field in LIST_FIELDS and f.op in (Op.eq, Op.ne, Op.in_, Op.not_in):
+    if f.field in ENTITY_SCHEMA[entity].list_fields and f.op in (
+        Op.eq,
+        Op.ne,
+        Op.in_,
+        Op.not_in,
+    ):
         expr = _list_membership(col)
         if f.op in (Op.ne, Op.not_in):
             # NULL-safe negation: a row with no value is "not a member" too, so
@@ -403,7 +457,7 @@ def _compile_where(q: CatalogQuery) -> tuple[str, list]:
         return "TRUE", []
     frags, params = [], []
     for f in q.filters:
-        frag, p = _compile_predicate(f)
+        frag, p = _compile_predicate(f, q.entity)
         frags.append(frag)
         params.extend(p)
     return " AND ".join(frags), params
@@ -459,7 +513,7 @@ def connect(catalog_dir: str):
             row[0]: str(row[1]).upper()
             for row in con.execute("DESCRIBE assembly").fetchall()
         }
-        missing, mistyped = _schema_issues(coltypes)
+        missing, mistyped = _schema_issues(coltypes, "assembly")
         if missing or mistyped:
             logger.error(
                 "Catalog query disabled: assembly schema has drifted from "
@@ -499,7 +553,7 @@ def execute(q: CatalogQuery, con) -> dict:
 
     entity = _qi(q.entity)
 
-    def _facets(cols: list[str]) -> dict:
+    def _facets(cols: Sequence[str]) -> dict:
         out = {}
         for col in cols:
             qcol = _qi(col)
@@ -527,26 +581,24 @@ def execute(q: CatalogQuery, con) -> dict:
 
     # Display columns are validated against the table at connect() time (the
     # engine fails closed on drift), so the projection is trusted here.
-    cols = _DISPLAY_COLUMNS.get(q.entity)
+    schema = ENTITY_SCHEMA[q.entity]
+    cols = schema.display
     # Always emit an ORDER BY so the capped page / truncation is reproducible
     # (LIMIT without a total order is unordered).
     if q.sort:
         # Honor the requested sort, appending a stable key (the first display
         # column) as a tiebreaker so equal-sort rows can't shuffle at the boundary.
         terms = [(s.field, s.desc) for s in q.sort]
-        tiebreak = cols[0] if cols else None
-        if tiebreak and tiebreak not in {s.field for s in q.sort}:
+        tiebreak = cols[0]
+        if tiebreak not in {s.field for s in q.sort}:
             terms.append((tiebreak, False))
         order = "ORDER BY " + _order_by(terms)
     else:
-        # No explicit sort: most-relevant-first per _DEFAULT_ORDER; fall back to a
-        # stable key (or positional `1`) for any entity without a default.
-        default = _DEFAULT_ORDER.get(q.entity)
-        if default:
-            order = "ORDER BY " + _order_by(default)
-        else:
-            order = "ORDER BY " + (_qi(cols[0]) if cols else "1")
-    select = ", ".join(_qi(c) for c in cols) if cols else "*"
+        # No explicit sort: most-relevant-first per the entity's default_order;
+        # fall back to the first display column for an entity without a default.
+        default = schema.default_order
+        order = "ORDER BY " + (_order_by(default) if default else _qi(cols[0]))
+    select = ", ".join(_qi(c) for c in cols)
     cur = con.execute(
         f"SELECT {select} FROM {entity} WHERE {where} {order} "
         f"LIMIT {cap + 1} OFFSET {q.offset}",
@@ -564,7 +616,7 @@ def execute(q: CatalogQuery, con) -> dict:
         # when nothing is a reference) offers no choice, so drop it.
         auto = {
             col: buckets
-            for col, buckets in _facets(_AUTO_FACET_FIELDS.get(q.entity, [])).items()
+            for col, buckets in _facets(schema.auto_facets).items()
             if len(buckets) > 1
         }
         if auto:

--- a/backend/api/tests/test_catalog_query.py
+++ b/backend/api/tests/test_catalog_query.py
@@ -14,11 +14,10 @@ from __future__ import annotations
 import pytest
 
 from app.services.tools.catalog_query import (
-    _DISPLAY_COLUMNS,
-    ASSEMBLY_FIELDS,
-    LIST_FIELDS,
-    NUMERIC_FIELDS,
+    ENTITY_SCHEMA,
+    SCALAR,
     CatalogQuery,
+    EntitySchema,
     Filter,
     Op,
     Sort,
@@ -100,11 +99,15 @@ def test_eq_ne_reject_list_value_on_scalar_field():
 
 def test_compile_scalar_and_range():
     # Identifiers are quoted (defense-in-depth + exact-case pinning).
-    assert _compile_predicate(Filter(field="level", op=Op.eq, value="Chromosome")) == (
+    assert _compile_predicate(
+        Filter(field="level", op=Op.eq, value="Chromosome"), "assembly"
+    ) == (
         '"level" = ?',
         ["Chromosome"],
     )
-    assert _compile_predicate(Filter(field="length", op=Op.gte, value=1000)) == (
+    assert _compile_predicate(
+        Filter(field="length", op=Op.gte, value=1000), "assembly"
+    ) == (
         '"length" >= ?',
         [1000],
     )
@@ -112,11 +115,14 @@ def test_compile_scalar_and_range():
 
 def test_compile_in_and_null():
     frag, params = _compile_predicate(
-        Filter(field="level", op=Op.in_, value=["Chromosome", "Complete Genome"])
+        Filter(field="level", op=Op.in_, value=["Chromosome", "Complete Genome"]),
+        "assembly",
     )
     assert frag == '"level" IN (?, ?)'
     assert params == ["Chromosome", "Complete Genome"]
-    assert _compile_predicate(Filter(field="geneModelUrl", op=Op.is_null)) == (
+    assert _compile_predicate(
+        Filter(field="geneModelUrl", op=Op.is_null), "assembly"
+    ) == (
         '"geneModelUrl" IS NULL',
         [],
     )
@@ -125,44 +131,53 @@ def test_compile_in_and_null():
 def test_compile_list_membership_and_coercion():
     # explicit contains / contains_any
     assert _compile_predicate(
-        Filter(field="ploidy", op=Op.contains, value="DIPLOID")
+        Filter(field="ploidy", op=Op.contains, value="DIPLOID"), "assembly"
     ) == (
         'list_contains("ploidy", ?)',
         ["DIPLOID"],
     )
     # scalar eq on a list field coerces to membership (no failed round-trip)
-    frag, params = _compile_predicate(Filter(field="ploidy", op=Op.eq, value="DIPLOID"))
+    frag, params = _compile_predicate(
+        Filter(field="ploidy", op=Op.eq, value="DIPLOID"), "assembly"
+    )
     assert frag == 'len(list_intersect("ploidy", ?)) > 0'
     assert params == [["DIPLOID"]]
     # ne on a list field coerces to NULL-safe negated membership
-    frag, _ = _compile_predicate(Filter(field="ploidy", op=Op.ne, value="DIPLOID"))
+    frag, _ = _compile_predicate(
+        Filter(field="ploidy", op=Op.ne, value="DIPLOID"), "assembly"
+    )
     assert frag == '(NOT (len(list_intersect("ploidy", ?)) > 0) OR "ploidy" IS NULL)'
 
 
 def test_list_field_value_is_stringified():
-    # LIST_FIELDS columns are VARCHAR[]; a numeric value (e.g. a taxid the model
+    # List-typed columns are VARCHAR[]; a numeric value (e.g. a taxid the model
     # passes as a JSON number) must be compared as text — list_contains/intersect
     # on VARCHAR[] with an INTEGER is a DuckDB binder error, not a no-match.
     _, params = _compile_predicate(
-        Filter(field="lineageTaxonomyIds", op=Op.contains, value=1773)
+        Filter(field="lineageTaxonomyIds", op=Op.contains, value=1773), "assembly"
     )
     assert params == ["1773"]
     _, params = _compile_predicate(
-        Filter(field="lineageTaxonomyIds", op=Op.contains_any, value=[1773, 5833])
+        Filter(field="lineageTaxonomyIds", op=Op.contains_any, value=[1773, 5833]),
+        "assembly",
     )
     assert params == [["1773", "5833"]]
     # coerced scalar eq on a list field stringifies too
     _, params = _compile_predicate(
-        Filter(field="lineageTaxonomyIds", op=Op.eq, value=1773)
+        Filter(field="lineageTaxonomyIds", op=Op.eq, value=1773), "assembly"
     )
     assert params == [["1773"]]
 
 
 def test_compile_ne_and_not_in_are_null_safe():
     # SQL `col != x` / `col NOT IN (...)` drop NULL rows; negation must include them.
-    frag, _ = _compile_predicate(Filter(field="level", op=Op.ne, value="Contig"))
+    frag, _ = _compile_predicate(
+        Filter(field="level", op=Op.ne, value="Contig"), "assembly"
+    )
     assert frag == '("level" != ? OR "level" IS NULL)'
-    frag, _ = _compile_predicate(Filter(field="level", op=Op.not_in, value=["Contig"]))
+    frag, _ = _compile_predicate(
+        Filter(field="level", op=Op.not_in, value=["Contig"]), "assembly"
+    )
     assert frag == '("level" NOT IN (?) OR "level" IS NULL)'
 
 
@@ -456,14 +471,15 @@ def test_connect_fails_closed_on_schema_drift(tmp_path):
     assert connect(str(tmp_path)) is None
 
 
-def _ok_coltypes() -> dict[str, str]:
-    """A schema where every configured column is present and correctly typed."""
-    configured = ASSEMBLY_FIELDS | set(_DISPLAY_COLUMNS["assembly"])
+def _ok_coltypes(entity: str = "assembly") -> dict[str, str]:
+    """A schema where every column the entity is configured for is present and
+    correctly typed (numeric -> BIGINT, list -> VARCHAR[], else VARCHAR)."""
+    schema = ENTITY_SCHEMA[entity]
     out = {}
-    for c in configured:
-        if c in NUMERIC_FIELDS:
+    for c in schema.configured_columns:
+        if c in schema.numeric_fields:
             out[c] = "BIGINT"
-        elif c in LIST_FIELDS:
+        elif c in schema.list_fields:
             out[c] = "VARCHAR[]"
         else:
             out[c] = "VARCHAR"
@@ -471,7 +487,7 @@ def _ok_coltypes() -> dict[str, str]:
 
 
 def test_schema_issues_accepts_correct_schema():
-    missing, mistyped = _schema_issues(_ok_coltypes())
+    missing, mistyped = _schema_issues(_ok_coltypes(), "assembly")
     assert missing == [] and mistyped == []
 
 
@@ -480,7 +496,7 @@ def test_schema_issues_flags_missing_and_mistyped():
     cols["length"] = "VARCHAR"  # numeric field inferred as text
     cols["ploidy"] = "VARCHAR"  # list field inferred as scalar
     del cols["isRef"]  # a configured column dropped
-    missing, mistyped = _schema_issues(cols)
+    missing, mistyped = _schema_issues(cols, "assembly")
     assert "isRef" in missing
     assert any(m.startswith("length=") for m in mistyped)
     assert any(m.startswith("ploidy=") for m in mistyped)
@@ -490,8 +506,75 @@ def test_schema_issues_accepts_numeric_type_variants():
     cols = _ok_coltypes()
     cols["gcPercent"] = "DOUBLE"
     cols["length"] = "DECIMAL(18,3)"  # parameterized numeric type
-    _, mistyped = _schema_issues(cols)
+    _, mistyped = _schema_issues(cols, "assembly")
     assert mistyped == []
+
+
+# --- per-entity type classification -------------------------------------------
+
+
+def test_type_classification_is_entity_scoped():
+    # Derived views are subsets of the entity's declared fields (by construction).
+    for schema in ENTITY_SCHEMA.values():
+        assert schema.list_fields <= schema.field_names
+        assert schema.numeric_fields <= schema.field_names
+    # The classifications genuinely diverge: otherTaxa is a list on assembly but
+    # not even a field on organism; assemblyCount is numeric only on organism;
+    # taxonomicGroup is a list on both.
+    asm, org = ENTITY_SCHEMA["assembly"], ENTITY_SCHEMA["organism"]
+    assert "otherTaxa" in asm.list_fields
+    assert "otherTaxa" not in org.list_fields
+    assert "assemblyCount" in org.numeric_fields
+    assert "assemblyCount" not in asm.numeric_fields
+    assert "taxonomicGroup" in asm.list_fields
+    assert "taxonomicGroup" in org.list_fields
+
+
+def test_entity_schema_rejects_misdeclaration():
+    # A `list` always needs a projection.
+    with pytest.raises(ValueError, match="display must be non-empty"):
+        EntitySchema(fields={"a": SCALAR}, display=())
+    # default_order / auto_facets must name configured columns (caught at import,
+    # not late as malformed SQL).
+    with pytest.raises(ValueError, match="unknown column"):
+        EntitySchema(fields={"a": SCALAR}, display=("a",), auto_facets=("ghost",))
+    with pytest.raises(ValueError, match="unknown column"):
+        EntitySchema(
+            fields={"a": SCALAR}, display=("a",), default_order=(("ghost", True),)
+        )
+    # A display-only column (absent from fields) is a valid order/facet target.
+    EntitySchema(
+        fields={"a": SCALAR}, display=("a", "b"), default_order=(("b", False),)
+    )
+
+
+def test_compile_predicate_respects_entity_type():
+    # Same field, same op — but otherTaxa is a list on assembly (eq coerces to
+    # membership) and a scalar on organism (eq stays a plain `=`).
+    frag_asm, _ = _compile_predicate(
+        Filter(field="otherTaxa", op=Op.eq, value="x"), "assembly"
+    )
+    assert frag_asm == 'len(list_intersect("otherTaxa", ?)) > 0'
+    frag_org, params_org = _compile_predicate(
+        Filter(field="otherTaxa", op=Op.eq, value="x"), "organism"
+    )
+    assert frag_org == '"otherTaxa" = ?'
+    assert params_org == ["x"]
+
+
+def test_schema_issues_ignores_other_entity_list_field():
+    # organisms.json carries a scalar otherTaxa column. It's a list field on
+    # assembly but not queryable on organism, so the organism drift check must not
+    # flag it as mistyped (which would wrongly disable the engine).
+    cols = _ok_coltypes("organism")
+    cols["otherTaxa"] = "VARCHAR"  # present in the table, scalar, not in org fields
+    missing, mistyped = _schema_issues(cols, "organism")
+    assert missing == [] and mistyped == []
+    # The same scalar otherTaxa IS flagged under assembly, where it's a list field.
+    asm = _ok_coltypes()
+    asm["otherTaxa"] = "VARCHAR"
+    _, asm_mistyped = _schema_issues(asm, "assembly")
+    assert any(m.startswith("otherTaxa=") for m in asm_mistyped)
 
 
 def test_explicit_sort_gets_stable_tiebreaker(con):


### PR DESCRIPTION
## What & why
The assistant's catalog query engine classified fields as list/numeric via two **global** sets (`LIST_FIELDS`, `NUMERIC_FIELDS`) shared across entities. That assumes a column name has the same type in every entity — which is false: `otherTaxa` is a `VARCHAR[]` on assembly but scalar on organism. Enabling the organism entity (#1371) needs per-entity type resolution.

## Change
Replace the global sets — and the parallel `ENTITY_FIELDS` / `_DISPLAY_COLUMNS` / `_DEFAULT_ORDER` / `_AUTO_FACET_FIELDS` dicts — with a **single `ENTITY_SCHEMA` keyed by entity**. Each queryable field is declared once with a `FieldType` (`SCALAR`/`NUMERIC`/`LIST`); `field_names`, `list_fields`, `numeric_fields` and `configured_columns` are **derived** in `__post_init__`, so the allowlist and the type classifications can't drift apart. The validator, predicate compiler, schema-drift check and executor all read from the descriptor.

```python
ENTITY_SCHEMA = {
  "assembly": EntitySchema(
    fields={"accession": SCALAR, "scaffoldN50": NUMERIC, "ploidy": LIST, ...},
    display=(...), default_order=(...), auto_facets=(...),
  ),
  "organism": EntitySchema(fields={"assemblyCount": NUMERIC, "taxonomicGroup": LIST, ...}, ...),
}
```

## Notes
- **Behavior-preserving for assembly** — field classifications are unchanged (verified: `coverage`/taxids stay scalar, `assemblyCount` numeric only on organism, `otherTaxa` list only on assembly).
- Prerequisite for the organism entity in #1371; organism schema is declared here but not yet queryable (the `entity` Literal stays assembly-only until #1371 loads its table).
- The catalog schema is **not** in LinkML (that schema is intentionally minimal); the authoritative copy is the hand-written TS `entities.ts`. Unifying those is out of scope.

## Testing
- `pytest backend/api/tests/test_catalog_query.py` → 43 passed
- `ruff check` / `ruff format --check` clean

Closes #1373

🤖 Generated with [Claude Code](https://claude.com/claude-code)