### PR TITLE
feat: split configure inputs side panel into organism details and assembly details sections (#1351)

### DIFF
--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/SideColumn/sideColumn.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/SideColumn/sideColumn.tsx
@@ -7,6 +7,7 @@ import { CollapsableSection } from "@databiosphere/findable-ui/lib/components/co
 import { JSX } from "react";
 import {
   buildAssemblyDetails,
+  buildOrganismDetails,
   buildWorkflowConfiguration,
   buildWorkflowDetails,
 } from "../../../../../../viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders";
@@ -16,6 +17,7 @@ import { Props } from "./types";
 export const SideColumn = ({
   configuredInput,
   configuredSteps,
+  organism,
   workflow,
 }: Props): JSX.Element => {
   const assembly = useAssembly();
@@ -25,6 +27,11 @@ export const SideColumn = ({
         <CollapsableSection key="workflow-details" title="Workflow Details">
           <KeyValuePairs {...buildWorkflowDetails(workflow)} />
         </CollapsableSection>
+        {organism && (
+          <CollapsableSection key="organism-details" title="Organism Details">
+            <KeyValuePairs {...buildOrganismDetails(organism)} />
+          </CollapsableSection>
+        )}
         {assembly && (
           <CollapsableSection key="assembly-details" title="Assembly Details">
             <KeyValuePairs {...buildAssemblyDetails(assembly)} />

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/SideColumn/types.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/SideColumn/types.ts
@@ -1,7 +1,7 @@
-import { Workflow } from "../../../../../../apis/catalog/brc-analytics-catalog/common/entities";
-import { StepConfig } from "../../../../../../components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/types";
-import { Organism } from "../../../../../../views/OrganismView/types";
-import { ConfiguredInput } from "../../../../../../views/WorkflowInputsView/hooks/UseConfigureInputs/types";
+import type { Workflow } from "../../../../../../apis/catalog/brc-analytics-catalog/common/entities";
+import type { StepConfig } from "../../../../../../components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/types";
+import type { Organism } from "../../../../../../views/OrganismView/types";
+import type { ConfiguredInput } from "../../../../../../views/WorkflowInputsView/hooks/UseConfigureInputs/types";
 
 export interface Props {
   configuredInput: ConfiguredInput;

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/SideColumn/types.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/SideColumn/types.ts
@@ -1,9 +1,11 @@
 import { Workflow } from "../../../../../../apis/catalog/brc-analytics-catalog/common/entities";
 import { StepConfig } from "../../../../../../components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/types";
+import { Organism } from "../../../../../../views/OrganismView/types";
 import { ConfiguredInput } from "../../../../../../views/WorkflowInputsView/hooks/UseConfigureInputs/types";
 
 export interface Props {
   configuredInput: ConfiguredInput;
   configuredSteps: StepConfig[];
+  organism?: Organism;
   workflow: Workflow;
 }

--- a/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
@@ -7,6 +7,7 @@ import { COLUMN_IDENTIFIER } from "@databiosphere/findable-ui/lib/components/Tab
 import { CHIP_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/chip";
 import { replaceParameters } from "@databiosphere/findable-ui/lib/utils/replaceParameters";
 import { ColumnDef, RowData } from "@tanstack/react-table";
+import { Organism } from "app/views/OrganismView/types";
 import { LinkProps } from "next/link";
 import Router from "next/router";
 import { ComponentProps } from "react";
@@ -22,6 +23,7 @@ import {
   Outbreak,
   Workflow,
 } from "../../../../apis/catalog/brc-analytics-catalog/common/entities";
+import { OUTBREAK_PRIORITY } from "../../../../apis/catalog/brc-analytics-catalog/common/schema-entities";
 import {
   getGenomeOrganismId,
   getOrganismId,
@@ -119,46 +121,12 @@ export const buildAssemblyDetails = (
 ): ComponentProps<typeof C.KeyValuePairs> => {
   const keyValuePairs = new Map<Key, Value>();
   keyValuePairs.set(
-    BRC_DATA_CATALOG_CATEGORY_LABEL.TAXONOMIC_LEVEL_SPECIES,
-    C.Link({
-      label: assembly.taxonomicLevelSpecies,
-      url: `${ROUTES.ORGANISMS}/${encodeURIComponent(sanitizeEntityId(assembly.speciesTaxonomyId))}`,
-    })
-  );
-  const strain = getGenomeStrainText(assembly);
-  if (strain) {
-    keyValuePairs.set(
-      BRC_DATA_CATALOG_CATEGORY_LABEL.TAXONOMIC_LEVEL_STRAIN,
-      strain
-    );
-  }
-  const serotype = getGenomeSerotypeText(assembly);
-  if (serotype) {
-    keyValuePairs.set(
-      BRC_DATA_CATALOG_CATEGORY_LABEL.TAXONOMIC_LEVEL_SEROTYPE,
-      serotype
-    );
-  }
-  const isolate = getGenomeIsolateText(assembly);
-  if (isolate) {
-    keyValuePairs.set(
-      BRC_DATA_CATALOG_CATEGORY_LABEL.TAXONOMIC_LEVEL_ISOLATE,
-      isolate
-    );
-  }
-  keyValuePairs.set(
     BRC_DATA_CATALOG_CATEGORY_LABEL.ACCESSION,
     C.CopyText({
       children: assembly.accession,
       value: assembly.accession,
     })
   );
-  if ("priorityPathogenName" in assembly) {
-    keyValuePairs.set(
-      BRC_DATA_CATALOG_CATEGORY_LABEL.PRIORITY_PATHOGEN_NAME,
-      C.Chip(buildPriorityPathogen(assembly))
-    );
-  }
   return {
     KeyElType: C.KeyElType,
     KeyValuesElType: (props) => C.Stack({ ...props, gap: 4 }),
@@ -346,6 +314,64 @@ export const buildOrganismAssemblyTaxonomyIds = (
 };
 
 /**
+ * Build props for the organism details KeyValuePairs component.
+ * @param organism - Organism details (mapped from an assembly or organism source).
+ * @returns Props to be used for the KeyValuePairs component.
+ */
+export const buildOrganismDetails = (
+  organism: Organism
+): ComponentProps<typeof C.KeyValuePairs> => {
+  const {
+    ncbiTaxonomyId,
+    priorityPathogenName,
+    taxonomicLevelIsolate,
+    taxonomicLevelSerotype,
+    taxonomicLevelSpecies,
+    taxonomicLevelStrain,
+  } = organism;
+
+  const keyValuePairs = new Map<Key, Value>();
+
+  keyValuePairs.set(
+    BRC_DATA_CATALOG_CATEGORY_LABEL.TAXONOMIC_LEVEL_SPECIES,
+    C.Link({
+      label: taxonomicLevelSpecies,
+      url: `${ROUTES.ORGANISMS}/${encodeURIComponent(sanitizeEntityId(ncbiTaxonomyId))}`,
+    })
+  );
+  const taxonomicLevels: [Key, string[] | undefined][] = [
+    [
+      BRC_DATA_CATALOG_CATEGORY_LABEL.TAXONOMIC_LEVEL_STRAIN,
+      taxonomicLevelStrain,
+    ],
+    [
+      BRC_DATA_CATALOG_CATEGORY_LABEL.TAXONOMIC_LEVEL_SEROTYPE,
+      taxonomicLevelSerotype,
+    ],
+    [
+      BRC_DATA_CATALOG_CATEGORY_LABEL.TAXONOMIC_LEVEL_ISOLATE,
+      taxonomicLevelIsolate,
+    ],
+  ];
+  for (const [label, values] of taxonomicLevels) {
+    if (values?.length) keyValuePairs.set(label, values.join(", "));
+  }
+  if (priorityPathogenName) {
+    keyValuePairs.set(
+      BRC_DATA_CATALOG_CATEGORY_LABEL.PRIORITY_PATHOGEN_NAME,
+      C.Chip(buildPriorityPathogen(organism))
+    );
+  }
+
+  return {
+    KeyElType: C.KeyElType,
+    KeyValuesElType: (props) => C.Stack({ ...props, gap: 4 }),
+    ValueElType: C.ValueElType,
+    keyValuePairs,
+  };
+};
+
+/**
  * Build props for the species cell.
  * @param organism - Organism entity.
  * @returns Props to be used for the cell.
@@ -416,12 +442,15 @@ export const buildPriority = (
 
 /**
  * Build props for the priority pathogen cell.
- * @param entity - Genome or organism entity.
+ * @param entity - Source carrying priority pathogen fields.
+ * @param entity.priority - Priority.
+ * @param entity.priorityPathogenName - Priority pathogen name.
  * @returns Props to be used for the Chip component.
  */
-export const buildPriorityPathogen = (
-  entity: BRCDataCatalogGenome | BRCDataCatalogOrganism
-): ComponentProps<typeof C.Chip> => {
+export const buildPriorityPathogen = (entity: {
+  priority?: OUTBREAK_PRIORITY | null;
+  priorityPathogenName?: string | null;
+}): ComponentProps<typeof C.Chip> => {
   const { priority, priorityPathogenName } = entity;
   return {
     color: getPriorityColor(priority),

--- a/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
@@ -23,7 +23,7 @@ import {
   Outbreak,
   Workflow,
 } from "../../../../apis/catalog/brc-analytics-catalog/common/entities";
-import { OUTBREAK_PRIORITY } from "../../../../apis/catalog/brc-analytics-catalog/common/schema-entities";
+import type { OUTBREAK_PRIORITY } from "../../../../apis/catalog/brc-analytics-catalog/common/schema-entities";
 import {
   getGenomeOrganismId,
   getOrganismId,

--- a/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
@@ -7,7 +7,7 @@ import { COLUMN_IDENTIFIER } from "@databiosphere/findable-ui/lib/components/Tab
 import { CHIP_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/chip";
 import { replaceParameters } from "@databiosphere/findable-ui/lib/utils/replaceParameters";
 import { ColumnDef, RowData } from "@tanstack/react-table";
-import { Organism } from "app/views/OrganismView/types";
+import type { Organism } from "app/views/OrganismView/types";
 import { LinkProps } from "next/link";
 import Router from "next/router";
 import { ComponentProps } from "react";

--- a/app/views/EntityView/assembly/components/Side/brc/side.styles.ts
+++ b/app/views/EntityView/assembly/components/Side/brc/side.styles.ts
@@ -1,0 +1,6 @@
+import styled from "@emotion/styled";
+import { Section } from "app/views/EntityView/ui/Section/section";
+
+export const StyledSection = styled(Section)`
+  align-items: flex-start;
+`;

--- a/app/views/EntityView/assembly/components/Side/brc/side.tsx
+++ b/app/views/EntityView/assembly/components/Side/brc/side.tsx
@@ -1,14 +1,16 @@
 import { BackPageContentSideColumn } from "@databiosphere/findable-ui/lib/components/Layout/components/BackPage/backPageView.styles";
-import { Box } from "@mui/material";
 import { JSX } from "react";
 import { AnalysisPortals } from "../../../../../../components/Entity/components/AnalysisPortals/analysisPortals";
 import { AssemblyFavoriteButton } from "../../../../../../components/Favorites/AssemblyFavoriteButton/assemblyFavoriteButton";
 import {
   buildAssemblyDetails,
   buildAssemblyResources,
+  buildOrganismDetails,
 } from "../../../../../../viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders";
+import { mapAssemblyToOrganism } from "../../../../../WorkflowInputsView/utils";
 import { KeyValueSection } from "../../../../components/KeyValueSection/keyValueSection";
 import { StyledFluidPaper } from "../side.styles";
+import { StyledSection } from "./side.styles";
 import { Props } from "./types";
 
 /**
@@ -21,9 +23,13 @@ export const Side = ({ assembly }: Props): JSX.Element => {
   return (
     <BackPageContentSideColumn>
       <StyledFluidPaper>
-        <Box sx={{ p: 2 }}>
+        <StyledSection>
           <AssemblyFavoriteButton accession={assembly.accession} />
-        </Box>
+        </StyledSection>
+        <KeyValueSection
+          {...buildOrganismDetails(mapAssemblyToOrganism(assembly))}
+          title="Organism Details"
+        />
         <KeyValueSection
           {...buildAssemblyDetails(assembly)}
           title="Assembly Details"

--- a/app/views/EntityView/assembly/components/Side/ga2/side.styles.ts
+++ b/app/views/EntityView/assembly/components/Side/ga2/side.styles.ts
@@ -1,0 +1,6 @@
+import styled from "@emotion/styled";
+import { Section } from "app/views/EntityView/ui/Section/section";
+
+export const StyledSection = styled(Section)`
+  align-items: flex-start;
+`;

--- a/app/views/EntityView/assembly/components/Side/ga2/side.tsx
+++ b/app/views/EntityView/assembly/components/Side/ga2/side.tsx
@@ -1,11 +1,16 @@
 import { BackPageContentSideColumn } from "@databiosphere/findable-ui/lib/components/Layout/components/BackPage/backPageView.styles";
-import { Box } from "@mui/material";
 import { JSX } from "react";
 import { AnalysisPortals } from "../../../../../../components/Entity/components/AnalysisPortals/analysisPortals";
 import { AssemblyFavoriteButton } from "../../../../../../components/Favorites/AssemblyFavoriteButton/assemblyFavoriteButton";
-import { buildAssemblyResources } from "../../../../../../viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders";
+import {
+  buildAssemblyResources,
+  buildOrganismDetails,
+} from "../../../../../../viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders";
+import { mapAssemblyToOrganism } from "../../../../../WorkflowInputsView/utils";
 import { AssemblyDetails } from "../../../../assembly/components/Side/ga2/components/AssemblyDetails/AssemblyDetails";
+import { KeyValueSection } from "../../../../components/KeyValueSection/keyValueSection";
 import { StyledFluidPaper } from "../side.styles";
+import { StyledSection } from "./side.styles";
 import { Props } from "./types";
 
 /**
@@ -18,9 +23,13 @@ export const Side = ({ assembly }: Props): JSX.Element => {
   return (
     <BackPageContentSideColumn>
       <StyledFluidPaper>
-        <Box sx={{ p: 2 }}>
+        <StyledSection>
           <AssemblyFavoriteButton accession={assembly.accession} />
-        </Box>
+        </StyledSection>
+        <KeyValueSection
+          {...buildOrganismDetails(mapAssemblyToOrganism(assembly))}
+          title="Organism Details"
+        />
         <AssemblyDetails assembly={assembly} />
         <AnalysisPortals
           {...buildAssemblyResources(assembly)}

--- a/app/views/OrganismView/components/Main/utils.ts
+++ b/app/views/OrganismView/components/Main/utils.ts
@@ -59,7 +59,7 @@ function workflowIsCompatibleWithOrganism(
   organism: Organism
 ): boolean {
   if (workflow.taxonomyId === null) return true;
-  return organism.genomes.some((genome) =>
+  return (organism.genomes ?? []).some((genome) =>
     genome.lineageTaxonomyIds.includes(workflow.taxonomyId as string)
   );
 }

--- a/app/views/OrganismView/types.ts
+++ b/app/views/OrganismView/types.ts
@@ -1,4 +1,4 @@
-import { OUTBREAK_PRIORITY } from "app/apis/catalog/brc-analytics-catalog/common/schema-entities";
+import type { OUTBREAK_PRIORITY } from "app/apis/catalog/brc-analytics-catalog/common/schema-entities";
 
 /**
  * Organism-scoped shape shared across BRC and GA2 and consumed by the workflow

--- a/app/views/OrganismView/types.ts
+++ b/app/views/OrganismView/types.ts
@@ -1,8 +1,21 @@
+import { OUTBREAK_PRIORITY } from "app/apis/catalog/brc-analytics-catalog/common/schema-entities";
+
+/**
+ * Organism-scoped shape shared across BRC and GA2 and consumed by the workflow
+ * side panel. Both BRCDataCatalogOrganism and GA2OrganismEntity satisfy it
+ * structurally, and an assembly can be mapped into it (see mapAssemblyToOrganism).
+ * Fields that GA2's organism (or the assembly-derived case) lacks are optional;
+ * consumers must omit them from display when undefined.
+ */
 export interface Organism {
-  assemblyCount: number;
-  genomes: OrganismGenome[];
+  genomes?: OrganismGenome[];
   ncbiTaxonomyId: string;
+  priority?: OUTBREAK_PRIORITY | null;
+  priorityPathogenName?: string | null;
+  taxonomicLevelIsolate?: string[];
+  taxonomicLevelSerotype?: string[];
   taxonomicLevelSpecies: string;
+  taxonomicLevelStrain?: string[];
 }
 
 interface OrganismGenome {

--- a/app/views/OrganismWorkflowInputsView/organismWorkflowInputsView.tsx
+++ b/app/views/OrganismWorkflowInputsView/organismWorkflowInputsView.tsx
@@ -5,6 +5,8 @@ import {
   BackPageView,
 } from "@databiosphere/findable-ui/lib/components/Layout/components/BackPage/backPageView.styles";
 import { JSX, useMemo } from "react";
+import { BRCDataCatalogOrganism } from "../../apis/catalog/brc-analytics-catalog/common/entities";
+import { GA2OrganismEntity } from "../../apis/catalog/ga2/entities";
 import { useStepper } from "../../components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/hooks/UseStepper/hook";
 import { SEQUENCING_STEPS } from "../../components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/steps/constants";
 import { useConfiguredSteps } from "../../components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/steps/hook";
@@ -15,11 +17,11 @@ import { WorkflowEntityContext } from "../../components/Entity/components/Config
 import { buildWorkflowEntityValue } from "../../components/Entity/components/ConfigureWorkflowInputs/providers/WorkflowEntity/utils";
 import { getWorkflow } from "../../services/workflows/entities";
 import { getEntity } from "../../services/workflows/query";
-import type { Organism } from "../OrganismView/types";
 import { useConfigureInputs } from "../WorkflowInputsView/hooks/UseConfigureInputs/useConfigureInputs";
 import { StyledBackPageContentMainColumn } from "../WorkflowInputsView/workflowInputsView.styles";
 import { Top } from "./components/Top/top";
 import type { Props } from "./types";
+import { mapOrganismEntityToOrganism } from "./utils";
 
 /**
  * OrganismWorkflowInputsView displays the workflow configure inputs stepper for organism-scoped workflows.
@@ -32,7 +34,10 @@ export const OrganismWorkflowInputsView = ({
   entityId,
   trsId,
 }: Props): JSX.Element => {
-  const organism = getEntity<Organism>("organisms", entityId);
+  const organism = getEntity<BRCDataCatalogOrganism | GA2OrganismEntity>(
+    "organisms",
+    entityId
+  );
   const workflow = getWorkflow(trsId);
 
   const { configuredInput, onConfigure } = useConfigureInputs();
@@ -42,6 +47,11 @@ export const OrganismWorkflowInputsView = ({
 
   const workflowEntityValue = useMemo(
     () => buildWorkflowEntityValue(organism),
+    [organism]
+  );
+
+  const organismDetails = useMemo(
+    () => mapOrganismEntityToOrganism(organism),
     [organism]
   );
 
@@ -72,6 +82,7 @@ export const OrganismWorkflowInputsView = ({
                   configuredInput,
                   SEQUENCING_STEPS
                 )}
+                organism={organismDetails}
                 workflow={workflow}
               />
             </BackPageContentSideColumn>

--- a/app/views/OrganismWorkflowInputsView/organismWorkflowInputsView.tsx
+++ b/app/views/OrganismWorkflowInputsView/organismWorkflowInputsView.tsx
@@ -5,8 +5,8 @@ import {
   BackPageView,
 } from "@databiosphere/findable-ui/lib/components/Layout/components/BackPage/backPageView.styles";
 import { JSX, useMemo } from "react";
-import { BRCDataCatalogOrganism } from "../../apis/catalog/brc-analytics-catalog/common/entities";
-import { GA2OrganismEntity } from "../../apis/catalog/ga2/entities";
+import type { BRCDataCatalogOrganism } from "../../apis/catalog/brc-analytics-catalog/common/entities";
+import type { GA2OrganismEntity } from "../../apis/catalog/ga2/entities";
 import { useStepper } from "../../components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/hooks/UseStepper/hook";
 import { SEQUENCING_STEPS } from "../../components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/steps/constants";
 import { useConfiguredSteps } from "../../components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/steps/hook";

--- a/app/views/OrganismWorkflowInputsView/utils.ts
+++ b/app/views/OrganismWorkflowInputsView/utils.ts
@@ -1,0 +1,37 @@
+import type { BRCDataCatalogOrganism } from "../../apis/catalog/brc-analytics-catalog/common/entities";
+import type { GA2OrganismEntity } from "../../apis/catalog/ga2/entities";
+import type { Organism } from "../OrganismView/types";
+
+/**
+ * Projects a BRC or GA2 organism entity onto the shared organism shape consumed by
+ * the side panel. Fields absent on GA2's organism (priority, priority pathogen,
+ * strain, serotype, isolate) resolve to undefined and are not displayed.
+ * @param organism - BRC or GA2 organism entity.
+ * @returns Organism shape for the side panel.
+ */
+export function mapOrganismEntityToOrganism(
+  organism: BRCDataCatalogOrganism | GA2OrganismEntity
+): Organism {
+  return {
+    genomes: organism.genomes,
+    ncbiTaxonomyId: organism.ncbiTaxonomyId,
+    priority: "priority" in organism ? organism.priority : undefined,
+    priorityPathogenName:
+      "priorityPathogenName" in organism
+        ? organism.priorityPathogenName
+        : undefined,
+    taxonomicLevelIsolate:
+      "taxonomicLevelIsolate" in organism
+        ? organism.taxonomicLevelIsolate
+        : undefined,
+    taxonomicLevelSerotype:
+      "taxonomicLevelSerotype" in organism
+        ? organism.taxonomicLevelSerotype
+        : undefined,
+    taxonomicLevelSpecies: organism.taxonomicLevelSpecies,
+    taxonomicLevelStrain:
+      "taxonomicLevelStrain" in organism
+        ? organism.taxonomicLevelStrain
+        : undefined,
+  };
+}

--- a/app/views/PriorityPathogensView/components/PriorityPathogens/utils.ts
+++ b/app/views/PriorityPathogensView/components/PriorityPathogens/utils.ts
@@ -9,7 +9,7 @@ import { CHIP_PROPS as APP_CHIP_PROPS } from "../../../../styles/common/mui/chip
  * @returns The color for the priority of the outbreak.
  */
 export function getPriorityColor(
-  priority: OUTBREAK_PRIORITY | null
+  priority?: OUTBREAK_PRIORITY | null
 ): ChipProps["color"] {
   switch (priority) {
     case OUTBREAK_PRIORITY.CRITICAL:

--- a/app/views/WorkflowInputsView/utils.ts
+++ b/app/views/WorkflowInputsView/utils.ts
@@ -1,0 +1,41 @@
+import {
+  getGenomeIsolateText,
+  getGenomeSerotypeText,
+  getGenomeStrainText,
+} from "app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders";
+import type { Organism } from "../OrganismView/types";
+import type { Assembly } from "./types";
+
+/**
+ * Maps an assembly to the shared organism shape consumed by the side panel, so the
+ * assembly-scoped flow can render Organism Details without an organism entity.
+ * Organism-only fields (e.g. genomes) are omitted; taxonomy values absent on the
+ * assembly resolve to empty arrays and are not displayed.
+ * @param assembly - Assembly to derive organism-level details from.
+ * @returns Organism shape for the side panel.
+ */
+export function mapAssemblyToOrganism(assembly: Assembly): Organism {
+  return {
+    // Organism-level link target: the species taxon, not the assembly's own
+    // (possibly strain-level) ncbiTaxonomyId.
+    ncbiTaxonomyId: assembly.speciesTaxonomyId,
+    priority: "priority" in assembly ? assembly.priority : undefined,
+    priorityPathogenName:
+      "priorityPathogenName" in assembly
+        ? assembly.priorityPathogenName
+        : undefined,
+    taxonomicLevelIsolate: toValues(getGenomeIsolateText(assembly)),
+    taxonomicLevelSerotype: toValues(getGenomeSerotypeText(assembly)),
+    taxonomicLevelSpecies: assembly.taxonomicLevelSpecies,
+    taxonomicLevelStrain: toValues(getGenomeStrainText(assembly)),
+  };
+}
+
+/**
+ * Wraps a taxonomy value in a single-element array, or an empty array when blank.
+ * @param value - Taxonomy text (empty string when absent).
+ * @returns The value as an array, or an empty array.
+ */
+function toValues(value: string): string[] {
+  return value ? [value] : [];
+}

--- a/app/views/WorkflowInputsView/workflowInputsView.tsx
+++ b/app/views/WorkflowInputsView/workflowInputsView.tsx
@@ -24,6 +24,7 @@ import { useConfigureInputs } from "./hooks/UseConfigureInputs/useConfigureInput
 import { useHandoffSync } from "./hooks/UseHandoffSync/useHandoffSync";
 import { SEQUENCING_STEP_KEYS } from "./sequencing/constants";
 import { Assembly, Props } from "./types";
+import { mapAssemblyToOrganism } from "./utils";
 import { StyledBackPageContentMainColumn } from "./workflowInputsView.styles";
 
 const DATA_STEP_KEYS = new Set([...SEQUENCING_STEP_KEYS, "sampleSheet"]);
@@ -67,6 +68,8 @@ export const WorkflowInputsView = ({ entityId, trsId }: Props): JSX.Element => {
     [genome]
   );
 
+  const organism = useMemo(() => mapAssemblyToOrganism(genome), [genome]);
+
   return (
     <WorkflowEntityContext.Provider value={workflowEntityValue}>
       <AssemblyContext.Provider value={genome}>
@@ -96,6 +99,7 @@ export const WorkflowInputsView = ({ entityId, trsId }: Props): JSX.Element => {
                       configuredInput,
                       SEQUENCING_STEPS
                     )}
+                    organism={organism}
                     workflow={workflow}
                   />
                 </BackPageContentSideColumn>

--- a/app/views/WorkflowView/workflowView.tsx
+++ b/app/views/WorkflowView/workflowView.tsx
@@ -15,6 +15,7 @@ import { buildWorkflowEntityValue } from "../../components/Entity/components/Con
 import { getAssembly, getWorkflow } from "../../services/workflows/entities";
 import { useConfigureInputs } from "../WorkflowInputsView/hooks/UseConfigureInputs/useConfigureInputs";
 import { Assembly } from "../WorkflowInputsView/types";
+import { mapAssemblyToOrganism } from "../WorkflowInputsView/utils";
 import { Top } from "./components/Top/top";
 import { useConfiguredSteps } from "./steps/hook";
 import { Props } from "./types";
@@ -47,6 +48,11 @@ export const WorkflowView = ({ trsId }: Props): JSX.Element => {
     [genome]
   );
 
+  const organism = useMemo(
+    () => (genome ? mapAssemblyToOrganism(genome) : undefined),
+    [genome]
+  );
+
   return (
     <WorkflowEntityContext.Provider value={workflowEntityValue}>
       <AssemblyContext.Provider value={genome ?? null}>
@@ -71,6 +77,7 @@ export const WorkflowView = ({ trsId }: Props): JSX.Element => {
                 <SideColumn
                   configuredInput={configuredInput}
                   configuredSteps={configuredSteps}
+                  organism={organism}
                   workflow={workflow}
                 />
               </BackPageContentSideColumn>

--- a/tests/views/organismView/buildOrganismWorkflows.test.ts
+++ b/tests/views/organismView/buildOrganismWorkflows.test.ts
@@ -8,7 +8,6 @@ import type { Organism } from "../../../app/views/OrganismView/types";
 
 describe("buildOrganismWorkflows", () => {
   const ORGANISM: Organism = {
-    assemblyCount: 2,
     genomes: [
       { lineageTaxonomyIds: ["1", "10239", "11320", "130760"] },
       { lineageTaxonomyIds: ["1", "10239", "11320", "93838"] },
@@ -240,7 +239,6 @@ describe("buildOrganismWorkflows", () => {
 
   test("returns empty array for organism with no genomes", () => {
     const emptyOrganism: Organism = {
-      assemblyCount: 0,
       genomes: [],
       ncbiTaxonomyId: "0",
       taxonomicLevelSpecies: "Empty Organism",


### PR DESCRIPTION
## Summary

Closes #1351.

Splits the workflow **Configure Inputs** side panel so organism-level and assembly-level fields live in separate sections — and unblocks the organism-scoped (no-assembly) flow where **Organism Details** renders while **Assembly Details** is hidden.

- **Organism Details** (new section, above Assembly Details): Species, Strain, Serotype, Isolate, Priority Pathogen. Priority Pathogen renders only when a value exists (no `-` placeholder).
- **Assembly Details**: now just Accession (with copy button).
- **Section gating**: Organism Details renders whenever organism-level info resolves; Assembly Details only when an assembly exists.

## Approach

- Introduced a shared `Organism` shape (`app/views/OrganismView/types.ts`) consumed by the side panel. Both `BRCDataCatalogOrganism` and `GA2OrganismEntity` satisfy it structurally; GA2-missing fields (priority, priority pathogen, strain/serotype/isolate) are optional and omitted from display when undefined.
- Two concrete→contract mappers feed the panel: `mapAssemblyToOrganism` (assembly-scoped flow) and `mapOrganismEntityToOrganism` (organism-scoped flow). The panel never sees a `BRC | GA2` union.
- `buildAssemblyDetails` trimmed to Accession; new `buildOrganismDetails` builds the organism section; `buildPriorityPathogen` now accepts a small `PriorityPathogenSource` contract instead of an entity union.
- Fixed `WorkflowView`'s side panel to map its (optional) reference assembly to organism details too — it would otherwise have lost Species/Strain/Serotype/Isolate/Priority after the split.

## Testing

- `npm run build:local` ✅ (static export, all pages prerendered)
- `npm test` ✅ 555/555
- `next lint` ✅, `prettier --check` ✅, `tsc --noEmit` ✅
- `npm run test:e2e` — running; will confirm on completion

## Notes

- Out-of-scope follow-up captured locally in `MONOREPO_PLAN.md` (Issue 1): the shared `Organism` contract should move from the `OrganismView` view directory to a site-neutral home, and the `"field" in organism` structural detection in `mapOrganismEntityToOrganism` should become explicit per-site composition (Issue 2c).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1604" height="1233" alt="image" src="https://github.com/user-attachments/assets/18f35f79-2b2d-4b06-9e65-63540c361734" />

<img width="1604" height="1231" alt="image" src="https://github.com/user-attachments/assets/aa08903d-3f7b-4ab7-92cc-0b5bddf6f1e5" />

<img width="1603" height="1235" alt="image" src="https://github.com/user-attachments/assets/60424951-50e4-4be0-8d06-d0e8e0fa6229" />

