### PR TITLE
refactor: catalog build: count ena read runs via /count instead of downloading every run (#1366)

### DIFF
--- a/catalog/py_package/catalog_build/build.py
+++ b/catalog/py_package/catalog_build/build.py
@@ -1931,7 +1931,10 @@ def create_taxonomy_read_run_count(genomes_tsv_path: str, output_path: str):
 
 def generate_taxon_read_run_count(taxonomy_ids):
     taxon_counter = {}
-    url = "https://www.ebi.ac.uk/ena/portal/api/search"
+    # Use ENA's dedicated /count endpoint, which returns the read-run count as a
+    # server-side aggregate (~0.6s regardless of magnitude) instead of the
+    # /search endpoint, which would download every read_run row just to len() it.
+    url = "https://www.ebi.ac.uk/ena/portal/api/count"
     counter = 0
     num_taxids = len(taxonomy_ids)
     for tId in taxonomy_ids:
@@ -1942,7 +1945,6 @@ def generate_taxon_read_run_count(taxonomy_ids):
         params = {
             "result": "read_run",
             "query": f"tax_tree({tId})",
-            "fields": "experiment_accession,study_accession",
             "format": "json",
         }
         try:
@@ -1953,7 +1955,8 @@ def generate_taxon_read_run_count(taxonomy_ids):
             time.sleep(10)
             resp = requests.get(url, params=params)
             resp.raise_for_status()
-        taxon_counter[tId] = len(resp.json())
+        # /count?format=json returns {"count": "<n>"}.
+        taxon_counter[tId] = int(resp.json()["count"])
         counter += 1
     print(f"Processed {counter} taxonomy IDs", end="\n")
     return dict(sorted(taxon_counter.items(), key=lambda x: x[1], reverse=True))


### PR DESCRIPTION
## Summary

Closes #1366.

`generate_taxon_read_run_count` computed per-taxon read-run counts by hitting ENA's **`/search`** endpoint with `result=read_run` and **downloading every row** just to `len()` them — millions of rows across ~2,000 catalog taxids (e.g. *M. tuberculosis* subtree ≈ 349k), a major drag on the Phase-1 build (`npm run build-brc-from-ncbi`).

This switches the count to ENA's dedicated **`/count`** endpoint, which returns the integer as a server-side aggregate.

## Change

`catalog/py_package/catalog_build/build.py` — `generate_taxon_read_run_count`:
- `url`: `/ena/portal/api/search` → `/ena/portal/api/count`
- dropped the now-unneeded `fields` param
- `taxon_counter[tId] = len(resp.json())` → `int(resp.json()["count"])` (`/count?format=json` returns `{"count": "<n>"}`)
- `ConnectTimeout` retry handling preserved

Shared helper, so **both BRC and GA2** builds benefit (both call `create_taxonomy_read_run_count` → `generate_taxon_read_run_count`).

## Why it's safe & fast

- `/count` returns in ~0.6s regardless of magnitude (server-side aggregate, not a fetch).
- `tax_tree(...)` query shape is unchanged → counts stay subtree-inclusive and equivalent.
- `/count?result=read_run` counts the same result set `len(search(result=read_run))` did → equivalent values (modulo live drift).

## Verification

Ran the real function against live ENA:
- `2955291 → 67,705`, `10090 → 4,022,917`, `562 → 595,874` — all ints, sorted desc.
- `ruff format` clean; no new `ruff check` errors introduced.

## Scope / non-goals

- Only the read-count **generation** step; `taxIdReadCount.json` / `taxonomy_read_counts.json` schema unchanged (taxid → int).
- Runtime gate `isEligible()` untouched (still reads precomputed JSON).
- Temporary stopgap until #1192 (DB-backed catalog pipeline) makes this precompute step disappear entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
