### PR TITLE
feat: query ena /count live in the stepper instead of the precomputed read-count file (#1366)

### DIFF
--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/CollectionSelector/hooks/UseTable/hook.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/CollectionSelector/hooks/UseTable/hook.ts
@@ -6,7 +6,6 @@ import { ROW_POSITION } from "@databiosphere/findable-ui/lib/components/Table/fe
 import { ROW_PREVIEW } from "@databiosphere/findable-ui/lib/components/Table/features/RowPreview/constants";
 import { ROW_SELECTION_VALIDATION } from "@databiosphere/findable-ui/lib/components/Table/features/RowSelectionValidation/constants";
 import { TABLE_DOWNLOAD } from "@databiosphere/findable-ui/lib/components/Table/features/TableDownload/constants";
-import { UseQueryResult } from "@tanstack/react-query";
 import {
   functionalUpdate,
   getCoreRowModel,
@@ -19,7 +18,7 @@ import {
 } from "@tanstack/react-table";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { OnConfigure } from "../../../../../../../../../../../../../../../../../views/WorkflowInputsView/hooks/UseConfigureInputs/types";
-import { BaseReadRun, ReadRun } from "../../../../types";
+import { BaseReadRun, ENAReadRunsQuery, ReadRun } from "../../../../types";
 import { getSequencingData } from "../../../../utils";
 import { CATEGORY_GROUPS } from "./categoryGroups";
 import { columns } from "./columnDef";
@@ -34,7 +33,7 @@ import {
 } from "./utils";
 
 export const useTable = (
-  enaTaxonomyId: UseQueryResult<BaseReadRun[]>,
+  enaTaxonomyId: ENAReadRunsQuery,
   {
     columnFilters,
     rowSelection,

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/DataSelector/components/Alert/types.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/DataSelector/components/Alert/types.ts
@@ -1,7 +1,6 @@
-import { UseQueryResult } from "@tanstack/react-query";
-import { BaseReadRun } from "../../../../types";
+import { ENAReadRunsQuery } from "../../../../types";
 
 export interface Props {
-  enaTaxonomyId: UseQueryResult<BaseReadRun[]>;
+  enaTaxonomyId: ENAReadRunsQuery;
   taxonomyMatches: number;
 }

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/DataSelector/types.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/DataSelector/types.ts
@@ -1,8 +1,7 @@
-import { UseQueryResult } from "@tanstack/react-query";
-import { BaseReadRun } from "../../types";
+import { ENAReadRunsQuery } from "../../types";
 
 export interface Props {
-  enaTaxonomyId: UseQueryResult<BaseReadRun[]>;
+  enaTaxonomyId: ENAReadRunsQuery;
   onContinue: () => void;
   onOpen: () => void;
   selectedCount: number;

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/constants.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/constants.ts
@@ -1,6 +1,8 @@
 import { SEQUENCING_DATA_TYPE } from "../../types";
 import { ReadRun } from "./types";
 
+export const ENA_PORTAL_API_BASE_URL = `${process.env.NEXT_PUBLIC_ENA_PROXY_DOMAIN}/ena/portal/api`;
+
 export const LIBRARY_LAYOUT_TO_CONFIGURE_INPUT_KEY: Record<
   ReadRun["library_layout"],
   SEQUENCING_DATA_TYPE

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/hooks/UseENADataByAccession/request.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/hooks/UseENADataByAccession/request.ts
@@ -1,9 +1,10 @@
 import { replaceParameters } from "@databiosphere/findable-ui/lib/utils/replaceParameters";
+import { ENA_PORTAL_API_BASE_URL } from "../../constants";
 import { ENA_FIELDS } from "./constants";
 import { AccessionInfo } from "./entities";
 import { SubmitOptions } from "./types";
 
-export const ENA_API = `${process.env.NEXT_PUBLIC_ENA_PROXY_DOMAIN}/ena/portal/api/search?result=read_run&query={query}&fields=${ENA_FIELDS.join(",")}&format=json`;
+export const ENA_API = `${ENA_PORTAL_API_BASE_URL}/search?result=read_run&query={query}&fields=${ENA_FIELDS.join(",")}&format=json`;
 
 /**
  * Fetch ENA data for a given accession number.

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/query/hook.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/query/hook.ts
@@ -7,12 +7,17 @@ import {
 import { AppSiteConfig } from "../../../../../../../../../../../../../../../site-config/common/entities";
 import { useWorkflowEntity } from "../../../../../../../../../../providers/WorkflowEntity/hook";
 import { BaseReadRun } from "../types";
+import { countQueryFn } from "./options/countQueryFn";
 import { queryFn } from "./options/queryFn";
-import { QueryKey } from "./types";
+import { CountQueryKey, QueryKey } from "./types";
 import { isEligible } from "./utils";
 
 /**
- * Custom hook to fetch ENA sequencing data based on the workflow entity's taxonomy ID.
+ * Custom hook to fetch ENA sequencing data for the workflow entity's taxonomy ID.
+ *
+ * The read-run count is fetched live from ENA when the stepper loads; the read
+ * runs themselves are only pre-fetched when that count is under the browse-all
+ * cap. Otherwise the user enters accessions at the ENA picker step.
  *
  * @returns React Query result containing ENA sequencing data or an error.
  */
@@ -21,7 +26,22 @@ export const useQuery = (): UseQueryResult<BaseReadRun[]> => {
   const { ncbiTaxonomyId } = useWorkflowEntity() ?? {};
   const { maxReadRunsForBrowseAll } = config as AppSiteConfig;
 
-  const enabled = isEligible(ncbiTaxonomyId, maxReadRunsForBrowseAll);
+  // Live read-run count from ENA, replacing the precomputed
+  // taxonomy_read_counts.json lookup. On error we don't retry — the count is
+  // just a gate, so a failure falls back to the "Enter Accession(s)" path.
+  const countQuery = useReactQuery<number, DefaultError, number, CountQueryKey>(
+    {
+      enabled: Boolean(ncbiTaxonomyId),
+      queryFn: countQueryFn(),
+      queryKey: ["ReadRunCountByTaxonomyId", ncbiTaxonomyId],
+      retry: false,
+    }
+  );
+
+  // Only pre-fetch the read runs when the live count is known and under the
+  // browse-all cap. If the count errors, its data is undefined, so isEligible
+  // returns false and the picker shows only "Enter Accession(s)".
+  const enabled = isEligible(countQuery.data, maxReadRunsForBrowseAll);
 
   const query = useReactQuery<
     BaseReadRun[],
@@ -34,5 +54,10 @@ export const useQuery = (): UseQueryResult<BaseReadRun[]> => {
     queryKey: ["ReadRunsByTaxonomyId", ncbiTaxonomyId],
   });
 
-  return query;
+  // Treat the count fetch as part of loading, so the picker shows a spinner
+  // while the count resolves rather than briefly flashing the accession-only UI.
+  return {
+    ...query,
+    isLoading: countQuery.isLoading || query.isLoading,
+  } as UseQueryResult<BaseReadRun[]>;
 };

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/query/hook.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/query/hook.ts
@@ -1,12 +1,8 @@
 import { useConfig } from "@databiosphere/findable-ui/lib/hooks/useConfig";
-import {
-  DefaultError,
-  UseQueryResult,
-  useQuery as useReactQuery,
-} from "@tanstack/react-query";
+import { DefaultError, useQuery as useReactQuery } from "@tanstack/react-query";
 import { AppSiteConfig } from "../../../../../../../../../../../../../../../site-config/common/entities";
 import { useWorkflowEntity } from "../../../../../../../../../../providers/WorkflowEntity/hook";
-import { BaseReadRun } from "../types";
+import { BaseReadRun, ENAReadRunsQuery } from "../types";
 import { countQueryFn } from "./options/countQueryFn";
 import { queryFn } from "./options/queryFn";
 import { CountQueryKey, QueryKey } from "./types";
@@ -19,9 +15,10 @@ import { isEligible } from "./utils";
  * runs themselves are only pre-fetched when that count is under the browse-all
  * cap. Otherwise the user enters accessions at the ENA picker step.
  *
- * @returns React Query result containing ENA sequencing data or an error.
+ * @returns The fields of the read-run query the picker consumes; `isLoading`
+ * covers both the count fetch and the read-run download.
  */
-export const useQuery = (): UseQueryResult<BaseReadRun[]> => {
+export const useQuery = (): ENAReadRunsQuery => {
   const { config } = useConfig();
   const { ncbiTaxonomyId } = useWorkflowEntity() ?? {};
   const { maxReadRunsForBrowseAll } = config as AppSiteConfig;
@@ -54,10 +51,13 @@ export const useQuery = (): UseQueryResult<BaseReadRun[]> => {
     queryKey: ["ReadRunsByTaxonomyId", ncbiTaxonomyId],
   });
 
-  // Treat the count fetch as part of loading, so the picker shows a spinner
-  // while the count resolves rather than briefly flashing the accession-only UI.
+  // Return only the fields the picker reads. isLoading folds in the count fetch
+  // so the picker shows a spinner while the count resolves rather than briefly
+  // flashing the accession-only UI.
   return {
-    ...query,
+    data: query.data,
+    isEnabled: query.isEnabled,
     isLoading: countQuery.isLoading || query.isLoading,
-  } as UseQueryResult<BaseReadRun[]>;
+    isSuccess: query.isSuccess,
+  };
 };

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/query/options/countQueryFn.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/query/options/countQueryFn.ts
@@ -26,6 +26,14 @@ export function countQueryFn(): (
       signal,
     }).json<{ count: string }>();
 
-    return Number(count);
+    // Validate the response; throw on anything non-finite or negative so the
+    // query is treated as an error (which falls back to the accession path)
+    // rather than caching NaN/garbage.
+    const parsedCount = Number(count);
+    if (!Number.isFinite(parsedCount) || parsedCount < 0) {
+      throw new Error(`Unexpected ENA read-run count response: ${count}`);
+    }
+
+    return parsedCount;
   };
 }

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/query/options/countQueryFn.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/query/options/countQueryFn.ts
@@ -1,0 +1,31 @@
+import { QueryFunctionContext } from "@tanstack/react-query";
+import ky from "ky";
+import { ENA_PORTAL_API_BASE_URL } from "../../constants";
+import { CountQueryKey } from "../types";
+
+/**
+ * Fetches the ENA read-run count for the given taxonomy ID via ENA's dedicated
+ * /count endpoint, which returns the count as a server-side aggregate rather
+ * than downloading the read-run rows.
+ *
+ * @returns The read-run count for the taxon subtree.
+ */
+export function countQueryFn(): (
+  context: QueryFunctionContext<CountQueryKey>
+) => Promise<number> {
+  return async ({ queryKey, signal }: QueryFunctionContext<CountQueryKey>) => {
+    // The second element of the queryKey is the taxonomy ID.
+    const { 1: taxonomyId } = queryKey;
+
+    const { count } = await ky(`${ENA_PORTAL_API_BASE_URL}/count`, {
+      searchParams: {
+        format: "json",
+        query: `tax_tree(${taxonomyId})`,
+        result: "read_run",
+      },
+      signal,
+    }).json<{ count: string }>();
+
+    return Number(count);
+  };
+}

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/query/options/queryFn.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/query/options/queryFn.ts
@@ -1,5 +1,6 @@
 import { QueryFunctionContext } from "@tanstack/react-query";
 import ky from "ky";
+import { ENA_PORTAL_API_BASE_URL } from "../../constants";
 import { ENA_FIELDS } from "../../hooks/UseENADataByAccession/constants";
 import { QueryKey } from "../types";
 
@@ -15,17 +16,14 @@ export function queryFn<T = unknown>(): (
     // The second element of the queryKey is the taxonomy ID.
     const { 1: taxonomyId } = queryKey;
 
-    return ky(
-      `${process.env.NEXT_PUBLIC_ENA_PROXY_DOMAIN}/ena/portal/api/search`,
-      {
-        searchParams: {
-          fields: ENA_FIELDS.join(","),
-          format: "json",
-          query: `tax_tree(${taxonomyId})`,
-          result: "read_run",
-        },
-        signal,
-      }
-    ).json<T>();
+    return ky(`${ENA_PORTAL_API_BASE_URL}/search`, {
+      searchParams: {
+        fields: ENA_FIELDS.join(","),
+        format: "json",
+        query: `tax_tree(${taxonomyId})`,
+        result: "read_run",
+      },
+      signal,
+    }).json<T>();
   };
 }

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/query/types.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/query/types.ts
@@ -1,1 +1,3 @@
+export type CountQueryKey = ["ReadRunCountByTaxonomyId", string | undefined];
+
 export type QueryKey = ["ReadRunsByTaxonomyId", string | undefined];

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/query/utils.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/query/utils.ts
@@ -11,8 +11,8 @@ export function isEligible(
   count: number | undefined,
   maxReadRuns: number
 ): boolean {
-  // A 0 (or still-loading) count is not browsable — there are no read runs to
-  // show, so fall through to the "Enter Accession(s)" path.
-  if (!count) return false;
-  return count < maxReadRuns;
+  // Eligible only when the count is known, positive, and under the cap. A 0,
+  // negative, NaN, or still-loading count falls through to the
+  // "Enter Accession(s)" path.
+  return count !== undefined && count > 0 && count < maxReadRuns;
 }

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/query/utils.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/query/utils.ts
@@ -1,23 +1,18 @@
-import taxonomyReadCounts from "./taxonomy_read_counts.json";
-
 /**
- * Determines whether ENA data should be pre-fetched by taxonomy ID.
- * Pre-fetching occurs when the read count is less than the maximum allowable count.
- * A 0 read count is not a valid value and should not be pre-fetched; the user will only be able to browse data by accession.
- * @param taxonomyId - Taxonomy ID.
- * @param maxReadRuns - Maximum allowable read runs for pre-fetching (default is 2000).
- * @returns True if ENA data by taxonomy ID should be pre-fetched.
+ * Determines whether ENA read runs should be pre-fetched for browsing, based on
+ * the live read-run count. Pre-fetching only happens when the count is known
+ * (not still loading), greater than zero, and under the browse-all cap;
+ * otherwise the user enters accessions manually at the ENA picker step.
+ * @param count - Live ENA read-run count, or undefined while it is loading.
+ * @param maxReadRuns - Maximum read runs eligible for browse-all pre-fetch.
+ * @returns True if read runs should be pre-fetched for browsing.
  */
 export function isEligible(
-  taxonomyId: string | undefined,
-  maxReadRuns: number = 2000
+  count: number | undefined,
+  maxReadRuns: number
 ): boolean {
-  if (!taxonomyId) return false;
-  const taxonomyIdReadCounts = new Map(Object.entries(taxonomyReadCounts));
-  const readCount = taxonomyIdReadCounts.get(taxonomyId);
-
-  // If the read count is not found -- or is 0, we should not pre-fetch ENA data by taxonomy ID.
-  if (!readCount) return false;
-
-  return readCount < maxReadRuns;
+  // A 0 (or still-loading) count is not browsable — there are no read runs to
+  // show, so fall through to the "Enter Accession(s)" path.
+  if (!count) return false;
+  return count < maxReadRuns;
 }

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/types.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/types.ts
@@ -24,6 +24,16 @@ export interface BaseReadRun {
   tax_lineage?: string;
 }
 
+/**
+ * Result of the ENA read-run query hook — the subset of the react-query result
+ * the picker consumes. `isLoading` covers both the live count fetch and the
+ * read-run download.
+ */
+export type ENAReadRunsQuery = Pick<
+  UseQueryResult<BaseReadRun[]>,
+  "data" | "isEnabled" | "isLoading" | "isSuccess"
+>;
+
 export interface ReadRun extends BaseReadRun {
   validation: Validation;
 }
@@ -36,7 +46,7 @@ export interface Validation {
 export interface Props {
   enaAccessionActions: Actions<BaseReadRun>;
   enaAccessionStatus: Status;
-  enaTaxonomyId: UseQueryResult<BaseReadRun[]>;
+  enaTaxonomyId: ENAReadRunsQuery;
   onConfigure: OnConfigure;
   requirementsMatches: string[];
   selectedCount: number;

--- a/tests/configureWorkflow/sequencingStep/useENADataByTaxonomyId.utils.test.ts
+++ b/tests/configureWorkflow/sequencingStep/useENADataByTaxonomyId.utils.test.ts
@@ -9,6 +9,14 @@ describe("isEligible", () => {
     expect(isEligible(0, 60000)).toBe(false);
   });
 
+  test("returns false for a negative count", () => {
+    expect(isEligible(-1, 60000)).toBe(false);
+  });
+
+  test("returns false for a NaN count", () => {
+    expect(isEligible(NaN, 60000)).toBe(false);
+  });
+
   test("returns true when count is between 1 and the cap", () => {
     expect(isEligible(123, 60000)).toBe(true);
   });

--- a/tests/configureWorkflow/sequencingStep/useENADataByTaxonomyId.utils.test.ts
+++ b/tests/configureWorkflow/sequencingStep/useENADataByTaxonomyId.utils.test.ts
@@ -1,24 +1,23 @@
 import { isEligible } from "../../../app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/query/utils";
 
 describe("isEligible", () => {
-  test("returns false when taxonomyId is empty", () => {
-    expect(isEligible("")).toBe(false);
+  test("returns false when count is undefined (still loading)", () => {
+    expect(isEligible(undefined, 60000)).toBe(false);
   });
 
-  test("returns false when taxonomyId is not found in counts", () => {
-    expect(isEligible("__missing__")).toBe(false);
+  test("returns false when count is 0 (no read runs to browse)", () => {
+    expect(isEligible(0, 60000)).toBe(false);
   });
 
-  test("returns false when read count is 0 (not browsable)", () => {
-    expect(isEligible("2767082")).toBe(false); // Known zero-count example from the dataset.
+  test("returns true when count is between 1 and the cap", () => {
+    expect(isEligible(123, 60000)).toBe(true);
   });
 
-  test("returns true when read count is below default maxReadRuns (2000)", () => {
-    expect(isEligible("299321")).toBe(true); // Known small count (e.g., 21).
+  test("returns false when count equals the cap (strictly less than)", () => {
+    expect(isEligible(60000, 60000)).toBe(false);
   });
 
-  test("returns false when read count >= provided maxReadRuns (strictly less)", () => {
-    expect(isEligible("299321", 21)).toBe(false);
-    expect(isEligible("5833", 3000)).toBe(false);
+  test("returns false when count exceeds the cap", () => {
+    expect(isEligible(67705, 60000)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Closes #1366.

Implements the redesign discussed with the team: instead of gating the ENA read-run picker on a **precomputed** `taxonomy_read_counts.json` (built during the slow Phase-1 catalog build), the stepper now queries ENA's `/count` endpoint **live** when it loads, then decides whether to pre-fetch read runs.

> Note: the GitHub ticket text still describes the old "swap `search`→`count` in the Python build" approach — this PR follows the newer live-frontend-count design from the team discussion. Removing the count precompute from the catalog build is a tracked **follow-on** ("once the real-time count query lands").

## What changed

- **`query/options/countQueryFn.ts`** (new) — fetches the live count: `…/ena/portal/api/count?result=read_run&format=json&query=tax_tree(<taxid>)` → `{count}` → number.
- **`query/hook.ts`** — fetches the count when the stepper loads (`retry: false`), then gates the read-run download on `isEligible(count, maxReadRunsForBrowseAll)`. Count loading is folded into the result's `isLoading` so the picker shows a spinner while the count resolves.
- **`query/utils.ts`** — `isEligible(count, maxReadRuns)`: eligible only when the count is known, `> 0`, and `< cap`.
- **`query/constants.ts`** removed; shared `ENA_PORTAL_API_BASE_URL` lives in `ENASequencingData/constants.ts`, used by `queryFn`, `countQueryFn`, and the accession `request.ts`.
- **`query/types.ts`** — `CountQueryKey`.
- Replaced the obsolete `isEligible` (JSON-lookup) test with one for the count-based helper.

## Behavior

- `0 < count < 60k` → "Browse N Sequences" (downloads read runs as before).
- `count ≥ 60k` → "Enter Accession(s)" only (e.g. influenza `2955291` ≈ 67,705).
- `count === 0` → "Enter Accession(s)" only — no "No Sequences" button, no taxonomy alert.
- **count errors** → not eligible → falls back to "Enter Accession(s)" (no retry/spinner hang).

## Testing

- `tsc --noEmit` ✅ · `next lint` ✅ · `prettier --check` ✅
- `npm test` ✅ 555/555 (incl. new `isEligible` cases: undefined/0 → false, mid → true, ≥cap → false)

## Notes

- `taxonomy_read_counts.json` is now **unread by the app**; removing the catalog-build step that generates it is the **follow-on**.
- This unblocks the organism-scoped flu ticket (#1349), which needs the live count for taxid `2955291`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1726" height="1235" alt="image" src="https://github.com/user-attachments/assets/5969ccf9-609b-4a57-959d-8cdf95729f09" />

<img width="834" height="813" alt="image" src="https://github.com/user-attachments/assets/798bf351-4606-46c5-9cd4-34a51e32bfc6" />

<img width="832" height="864" alt="image" src="https://github.com/user-attachments/assets/560bbca9-c43c-4601-b0c4-06306b60d973" />

<img width="1725" height="1232" alt="image" src="https://github.com/user-attachments/assets/989547b6-f9d8-4973-a67a-eb58d534764b" />
