### PR TITLE
fix: top-align the organism image on the assembly list (#1385)

### DIFF
--- a/app/components/Entity/components/OrganismAvatar/organismAvatar.styles.ts
+++ b/app/components/Entity/components/OrganismAvatar/organismAvatar.styles.ts
@@ -22,8 +22,9 @@ export const CardMedia = styled(MuiCardMedia)`
 `;
 
 export const Thumbnail = styled.img`
-  height: 40px;
-  width: 40px;
+  align-self: flex-start;
+  height: 36px;
+  width: 36px;
   border-radius: 20%;
   object-fit: cover;
 `;

--- a/site-config/ga2/local/index/genome/columnDefs.ts
+++ b/site-config/ga2/local/index/genome/columnDefs.ts
@@ -294,5 +294,5 @@ export const ORGANISM_IMAGE: ColumnConfig<GA2AssemblyEntity> = {
   enableSorting: false,
   header: GA2_CATEGORY_LABEL.ORGANISM_AVATAR,
   id: GA2_CATEGORY_KEY.ORGANISM_AVATAR,
-  width: { max: "100px", min: "100px" },
+  width: "auto",
 };

--- a/site-config/ga2/local/index/organism/columnDefs.ts
+++ b/site-config/ga2/local/index/organism/columnDefs.ts
@@ -139,5 +139,5 @@ export const ORGANISM_IMAGE: ColumnConfig<GA2OrganismEntity> = {
   enableSorting: false,
   header: GA2_CATEGORY_LABEL.ORGANISM_AVATAR,
   id: GA2_CATEGORY_KEY.ORGANISM_AVATAR,
-  width: { max: "100px", min: "100px" },
+  width: "auto",
 };


### PR DESCRIPTION
## Summary

Top-aligns the GA2 organism image (thumbnail) on the assembly list so it lines up with the row's other top-aligned content now that the Species cell is taller (#1353). Also tidies the image column width and thumbnail size.

Closes #1385

### What changed
- `OrganismAvatar` `Thumbnail` (`organismAvatar.styles.ts`): added `align-self: flex-start` so the image top-aligns in tall rows (no-op where rows ≈ image height, e.g. the organism list); sized **36×36px** (was 40×40) to match the Analyze button height.
- GA2 **assemblies** list image column (`genome/columnDefs.ts`): `width` → `"auto"` (was fixed `100px`).
- GA2 **organism** list image column (`organism/columnDefs.ts`): `width` → `"auto"` for consistency.

### Notes
- Shared `Thumbnail` is used by both GA2 tables (assemblies + organism list); changes apply consistently to both.
- BRC has no organism image column — unaffected.
- Pure styling/config; verified `tsc` + lint. No unit tests apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2549" height="1141" alt="image" src="https://github.com/user-attachments/assets/545d18bb-5b90-440f-9b66-7852bd31821d" />
