### PR TITLE
feat: use the species cell on the organism detail assembly table (#1352)

### DIFF
--- a/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
@@ -244,6 +244,20 @@ export const buildGenomeSpecies = (
 };
 
 /**
+ * Build props for the species cell on the organism detail page assembly table.
+ * Same as buildGenomeSpecies but with an empty species url — the species is the
+ * page's own organism, so Link renders the name as plain text (no self-link).
+ * @param genome - Genome entity.
+ * @returns Props to be used for the SpeciesCell component.
+ */
+export const buildOrganismGenomeSpecies = (
+  genome: BRCDataCatalogGenome
+): ComponentProps<typeof C.SpeciesCell> => {
+  const props = buildGenomeSpecies(genome);
+  return { ...props, species: { ...props.species, url: "" } };
+};
+
+/**
  * Build props for the strain cell.
  * @param entity - Entity with a strainName and taxonomicLevelStrain property.
  * @returns Props to be used for the BasicCell component.
@@ -941,40 +955,17 @@ function buildOrganismGenomesTableColumns(): ColumnDef<BRCDataCatalogGenome>[] {
       meta: { width: "auto" },
     },
     {
+      accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.TAXONOMIC_LEVEL_SPECIES,
+      cell: ({ row }) =>
+        C.SpeciesCell(buildOrganismGenomeSpecies(row.original)),
+      header: BRC_DATA_CATALOG_CATEGORY_LABEL.TAXONOMIC_LEVEL_SPECIES,
+      meta: { columnPinned: true, width: { max: "1.5fr", min: "340px" } },
+    },
+    {
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.ACCESSION,
       cell: ({ row }) => C.BasicCell(buildAccession(row.original)),
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.ACCESSION,
-      meta: { columnPinned: true, width: { max: "1fr", min: "164px" } },
-    },
-    {
-      accessorFn: (row) => getGenomeStrainText(row),
-      cell: ({ row }) =>
-        C.BasicCell(buildGenomeTaxonomicLevelStrain(row.original)),
-      header: BRC_DATA_CATALOG_CATEGORY_LABEL.TAXONOMIC_LEVEL_STRAIN,
-      id: BRC_DATA_CATALOG_CATEGORY_KEY.TAXONOMIC_LEVEL_STRAIN,
-      meta: { width: { max: "0.5fr", min: "180px" } },
-    },
-    {
-      accessorFn: (row) => getGenomeSerotypeText(row),
-      cell: ({ row }) =>
-        C.BasicCell(buildGenomeTaxonomicLevelSerotype(row.original)),
-      header: BRC_DATA_CATALOG_CATEGORY_LABEL.TAXONOMIC_LEVEL_SEROTYPE,
-      id: BRC_DATA_CATALOG_CATEGORY_KEY.TAXONOMIC_LEVEL_SEROTYPE,
-      meta: { width: { max: "0.5fr", min: "180px" } },
-    },
-    {
-      accessorFn: (row) => getGenomeIsolateText(row),
-      cell: ({ row }) =>
-        C.BasicCell(buildGenomeTaxonomicLevelIsolate(row.original)),
-      header: BRC_DATA_CATALOG_CATEGORY_LABEL.TAXONOMIC_LEVEL_ISOLATE,
-      id: BRC_DATA_CATALOG_CATEGORY_KEY.TAXONOMIC_LEVEL_ISOLATE,
-      meta: { width: { max: "0.5fr", min: "180px" } },
-    },
-    {
-      accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.TAXONOMY_ID,
-      cell: ({ row }) => C.BasicCell(buildTaxonomyId(row.original)),
-      header: BRC_DATA_CATALOG_CATEGORY_LABEL.TAXONOMY_ID,
-      meta: { width: { max: "0.5fr", min: "144px" } },
+      meta: { width: { max: "1fr", min: "164px" } },
     },
     {
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.IS_REF,

--- a/app/viewModelBuilders/catalog/ga2/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/ga2/viewModelBuilders.ts
@@ -15,7 +15,6 @@ import * as C from "../../../components";
 import type { SpeciesTag } from "../../../components/Table/components/TableCell/components/SpeciesCell/types";
 import {
   buildAnalyzeGenome,
-  buildGenomeTaxonomicLevelStrain,
   buildIsRef,
   formatNumber,
   getGenomeStrainText,
@@ -104,21 +103,15 @@ function buildOrganismGenomesTableColumns(): ColumnDef<GA2AssemblyEntity>[] {
       meta: { width: "auto" },
     },
     {
+      accessorKey: GA2_CATEGORY_KEY.TAXONOMIC_LEVEL_SPECIES,
+      cell: ({ row }) =>
+        C.SpeciesCell(buildOrganismAssemblySpecies(row.original)),
+      header: GA2_CATEGORY_LABEL.TAXONOMIC_LEVEL_SPECIES,
+      meta: { columnPinned: true, width: { max: "1.5fr", min: "340px" } },
+    },
+    {
       accessorKey: GA2_CATEGORY_KEY.ACCESSION,
       header: GA2_CATEGORY_LABEL.ACCESSION,
-      meta: { columnPinned: true, width: { max: "1fr", min: "152px" } },
-    },
-    {
-      accessorFn: (row) => getGenomeStrainText(row),
-      cell: ({ row }) =>
-        C.BasicCell(buildGenomeTaxonomicLevelStrain(row.original)),
-      header: GA2_CATEGORY_LABEL.TAXONOMIC_LEVEL_STRAIN,
-      id: GA2_CATEGORY_KEY.TAXONOMIC_LEVEL_STRAIN,
-      meta: { width: { max: "1fr", min: "152px" } },
-    },
-    {
-      accessorKey: GA2_CATEGORY_KEY.TAXONOMY_ID,
-      header: GA2_CATEGORY_LABEL.TAXONOMY_ID,
       meta: { width: { max: "1fr", min: "152px" } },
     },
     {
@@ -220,4 +213,18 @@ export const buildAssemblySpecies = (
     },
     tags,
   };
+};
+
+/**
+ * Build props for the species cell on the organism detail page assembly table.
+ * Same as buildAssemblySpecies but with an empty species url — the species is the
+ * page's own organism, so Link renders the name as plain text (no self-link).
+ * @param entity - Assembly entity.
+ * @returns Props to be used for the SpeciesCell component.
+ */
+export const buildOrganismAssemblySpecies = (
+  entity: GA2AssemblyEntity
+): ComponentProps<typeof C.SpeciesCell> => {
+  const props = buildAssemblySpecies(entity);
+  return { ...props, species: { ...props.species, url: "" } };
 };

--- a/tests/viewModelBuilders/species.test.ts
+++ b/tests/viewModelBuilders/species.test.ts
@@ -4,8 +4,14 @@ jest.mock("app/components", () => ({}));
 
 import type { BRCDataCatalogGenome } from "../../app/apis/catalog/brc-analytics-catalog/common/entities";
 import type { GA2AssemblyEntity } from "../../app/apis/catalog/ga2/entities";
-import { buildGenomeSpecies } from "../../app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders";
-import { buildAssemblySpecies } from "../../app/viewModelBuilders/catalog/ga2/viewModelBuilders";
+import {
+  buildGenomeSpecies,
+  buildOrganismGenomeSpecies,
+} from "../../app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders";
+import {
+  buildAssemblySpecies,
+  buildOrganismAssemblySpecies,
+} from "../../app/viewModelBuilders/catalog/ga2/viewModelBuilders";
 
 describe("buildGenomeSpecies", () => {
   test("surfaces species, taxonomy id and all populated minor fields", () => {
@@ -96,5 +102,46 @@ describe("buildAssemblySpecies", () => {
     const props = buildAssemblySpecies(assembly);
 
     expect(props.tags).toEqual([]);
+  });
+});
+
+describe("organism detail species cell (no self-link)", () => {
+  test("buildOrganismGenomeSpecies blanks the species url, keeps tags", () => {
+    const genome = {
+      ncbiTaxonomyId: "5833",
+      speciesTaxonomyId: "5833",
+      strainName: "3D7",
+      taxonomicGroup: [],
+      taxonomicLevelIsolate: "None",
+      taxonomicLevelSerotype: "None",
+      taxonomicLevelSpecies: "Plasmodium falciparum",
+      taxonomicLevelStrain: "3D7",
+    } as unknown as BRCDataCatalogGenome;
+
+    const props = buildOrganismGenomeSpecies(genome);
+
+    expect(props.species.label).toBe("Plasmodium falciparum");
+    expect(props.species.url).toBe("");
+    expect(props.tags).toEqual([{ label: "strain", value: "3D7" }]);
+  });
+
+  test("buildOrganismAssemblySpecies blanks the species url, keeps tags", () => {
+    const assembly = {
+      ncbiTaxonomyId: "9606",
+      speciesTaxonomyId: "9606",
+      strainName: "",
+      taxonomicGroup: ["Vertebrates"],
+      taxonomicLevelSpecies: "Homo sapiens",
+      taxonomicLevelStrain: "GRCh38",
+    } as unknown as GA2AssemblyEntity;
+
+    const props = buildOrganismAssemblySpecies(assembly);
+
+    expect(props.species.label).toBe("Homo sapiens");
+    expect(props.species.url).toBe("");
+    expect(props.tags).toEqual([
+      { label: "strain", value: "GRCh38" },
+      { label: "group", value: "Vertebrates" },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

Redesigns the assembly table on the **organism detail page** to the compact, scannable layout — reusing the shared `SpeciesCell` from #1353. Covers **steps 1 + 2** of #1352 (consolidate identifiers into one column; tag minor IDs, only when populated).

Closes #1352 — steps 1 + 2 here; **step 3 (column-category filter) is split out to #1389.**

### What changed
- **BRC** `buildOrganismGenomesTableColumns`: replaced the separate **Strain / Serotype / Isolate / Taxonomy ID** columns with a single pinned **Species** column (`C.SpeciesCell`), with **Accession** unpinned right after it — mirroring the catalog `/data/assemblies` layout.
- **GA2** `buildOrganismGenomesTableColumns`: same, replacing **Strain / Taxonomy ID** (GA2 has no serotype/isolate/priority).
- **No self-link:** the species is the page's own organism, so new wrappers `buildOrganismGenomeSpecies` / `buildOrganismAssemblySpecies` reuse the existing species builders but set `species.url = ""` — findable-ui `Link` then renders the name as plain text. (Wrappers rather than a param, to avoid colliding with findable-ui passing `viewContext` as the 2nd arg to config viewBuilders.)
- Existing data (level, length, scaffold counts, N50, GC%, ref flag, annotation, etc.) is preserved.

### Follow-up
- **Step 3 — column-category filter** (toggle column groups): #1389.

### Tests
- `tests/viewModelBuilders/species.test.ts`: added regression tests for the two no-link wrappers (blank `species.url`, tags retained).
- Full unit suite: 563 passing. `tsc` + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
