### PR TITLE
feat: add tiered level cell to the assembly and organism detail tables (#1386)

### DIFF
--- a/app/components/Table/components/TableCell/components/LevelCell/constants.ts
+++ b/app/components/Table/components/TableCell/components/LevelCell/constants.ts
@@ -1,0 +1,3 @@
+// Number of bar segments in the level indicator (one per assembly level tier:
+// Complete Genome, Chromosome, Scaffold, Contig).
+export const BAR_COUNT = 4;

--- a/app/components/Table/components/TableCell/components/LevelCell/levelCell.styles.ts
+++ b/app/components/Table/components/TableCell/components/LevelCell/levelCell.styles.ts
@@ -1,0 +1,13 @@
+import { PALETTE } from "@databiosphere/findable-ui/lib/styles/common/constants/palette";
+import styled from "@emotion/styled";
+import { Box } from "@mui/material";
+
+export const StyledBox = styled(Box, {
+  shouldForwardProp: (prop) => prop !== "filled",
+})<{ filled: boolean }>`
+  background-color: ${({ filled }) =>
+    filled ? PALETTE.PRIMARY_MAIN : PALETTE.SMOKE_DARK};
+  border-radius: 1px;
+  height: 12px;
+  width: 5px;
+`;

--- a/app/components/Table/components/TableCell/components/LevelCell/levelCell.tsx
+++ b/app/components/Table/components/TableCell/components/LevelCell/levelCell.tsx
@@ -1,0 +1,32 @@
+import { STACK_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/stack";
+import { Stack } from "@mui/material";
+import { JSX } from "react";
+import { BAR_COUNT } from "./constants";
+import { StyledBox } from "./levelCell.styles";
+import { LevelCellProps } from "./types";
+
+/*
+ * Renders the assembly level as a tiered bar indicator (one filled bar per tier:
+ * Complete Genome = 4, Chromosome = 3, Scaffold = 2, Contig = 1) followed by the
+ * level label. The view builder maps the level value to its filled-bar count.
+ */
+export const LevelCell = ({
+  filledCount,
+  label,
+}: LevelCellProps): JSX.Element => {
+  return (
+    <Stack
+      alignItems={STACK_PROPS.ALIGN_ITEMS.CENTER}
+      direction={STACK_PROPS.DIRECTION.ROW}
+      gap={1}
+      useFlexGap
+    >
+      <Stack direction={STACK_PROPS.DIRECTION.ROW} gap={0.25} useFlexGap>
+        {Array.from({ length: BAR_COUNT }, (_, i) => (
+          <StyledBox filled={i < filledCount} key={i} />
+        ))}
+      </Stack>
+      <span>{label}</span>
+    </Stack>
+  );
+};

--- a/app/components/Table/components/TableCell/components/LevelCell/types.ts
+++ b/app/components/Table/components/TableCell/components/LevelCell/types.ts
@@ -1,0 +1,4 @@
+export interface LevelCellProps {
+  filledCount: number;
+  label: string;
+}

--- a/app/components/index.ts
+++ b/app/components/index.ts
@@ -48,4 +48,5 @@ export {
 export { VersionInfoWithServerStatus } from "./Layout/components/Footer/components/VersionInfoWithServerStatus/versionInfoWithServerStatus";
 export { AuthButton } from "./Layout/components/Header/components/AuthButton/authButton";
 export { AnalyzeGenome } from "./Table/components/TableCell/components/AnalyzeGenome/analyzeGenome";
+export { LevelCell } from "./Table/components/TableCell/components/LevelCell/levelCell";
 export { SpeciesCell } from "./Table/components/TableCell/components/SpeciesCell/speciesCell";

--- a/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
@@ -330,15 +330,26 @@ export const buildLength = (
 };
 
 /**
- * Build props for the level cell.
+ * Maps each NCBI assembly level to its filled-bar count (most → least complete).
+ */
+const LEVEL_FILLED_COUNT: Record<string, number> = {
+  Chromosome: 3,
+  "Complete Genome": 4,
+  Contig: 1,
+  Scaffold: 2,
+};
+
+/**
+ * Build props for the level cell — a tiered bar indicator plus the level label.
  * @param entity - Entity with a level property.
- * @returns Props for the BasicCell component.
+ * @returns Props for the LevelCell component.
  */
 export const buildLevel = (
   entity: BRCDataCatalogGenome | GA2AssemblyEntity
-): ComponentProps<typeof C.BasicCell> => {
+): ComponentProps<typeof C.LevelCell> => {
   return {
-    value: entity.level,
+    filledCount: LEVEL_FILLED_COUNT[entity.level] ?? 0,
+    label: entity.level,
   };
 };
 
@@ -975,7 +986,7 @@ function buildOrganismGenomesTableColumns(): ColumnDef<BRCDataCatalogGenome>[] {
     },
     {
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.LEVEL,
-      cell: ({ row }) => C.BasicCell(buildLevel(row.original)),
+      cell: ({ row }) => C.LevelCell(buildLevel(row.original)),
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.LEVEL,
       meta: { width: { max: "0.5fr", min: "142px" } },
     },

--- a/app/viewModelBuilders/catalog/ga2/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/ga2/viewModelBuilders.ts
@@ -16,6 +16,7 @@ import type { SpeciesTag } from "../../../components/Table/components/TableCell/
 import {
   buildAnalyzeGenome,
   buildIsRef,
+  buildLevel,
   formatNumber,
   getGenomeStrainText,
 } from "../brc-analytics-catalog/common/viewModelBuilders";
@@ -122,6 +123,7 @@ function buildOrganismGenomesTableColumns(): ColumnDef<GA2AssemblyEntity>[] {
     },
     {
       accessorKey: GA2_CATEGORY_KEY.LEVEL,
+      cell: ({ row }) => C.LevelCell(buildLevel(row.original)),
       header: GA2_CATEGORY_LABEL.LEVEL,
       meta: { width: { max: "1fr", min: "152px" } },
     },

--- a/site-config/brc-analytics/local/index/genomeEntityConfig.ts
+++ b/site-config/brc-analytics/local/index/genomeEntityConfig.ts
@@ -333,9 +333,9 @@ export const genomeEntityConfig: AppEntityConfig<BRCDataCatalogGenome> = {
       },
       {
         componentConfig: {
-          component: C.BasicCell,
+          component: C.LevelCell,
           viewBuilder: V.buildLevel,
-        } as ComponentConfig<typeof C.BasicCell, BRCDataCatalogGenome>,
+        } as ComponentConfig<typeof C.LevelCell, BRCDataCatalogGenome>,
         header: BRC_DATA_CATALOG_CATEGORY_LABEL.LEVEL,
         id: BRC_DATA_CATALOG_CATEGORY_KEY.LEVEL,
         width: { max: "0.5fr", min: "142px" },

--- a/site-config/ga2/local/index/genome/columnDefs.ts
+++ b/site-config/ga2/local/index/genome/columnDefs.ts
@@ -117,9 +117,9 @@ export const LENGTH: ColumnConfig<GA2AssemblyEntity> = {
 
 export const LEVEL: ColumnConfig<GA2AssemblyEntity> = {
   componentConfig: {
-    component: C.BasicCell,
+    component: C.LevelCell,
     viewBuilder: buildLevel,
-  } as ComponentConfig<typeof C.BasicCell, GA2AssemblyEntity>,
+  } as ComponentConfig<typeof C.LevelCell, GA2AssemblyEntity>,
   header: GA2_CATEGORY_LABEL.LEVEL,
   id: GA2_CATEGORY_KEY.LEVEL,
   width: { max: "0.5fr", min: "142px" },

--- a/tests/viewModelBuilders/level.test.ts
+++ b/tests/viewModelBuilders/level.test.ts
@@ -1,0 +1,26 @@
+// buildLevel references component types only (erased at runtime); mock the
+// component barrel so importing it doesn't pull untransformable MDX modules.
+jest.mock("app/components", () => ({}));
+
+import type { BRCDataCatalogGenome } from "../../app/apis/catalog/brc-analytics-catalog/common/entities";
+import { buildLevel } from "../../app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders";
+
+describe("buildLevel", () => {
+  test.each([
+    ["Complete Genome", 4],
+    ["Chromosome", 3],
+    ["Scaffold", 2],
+    ["Contig", 1],
+  ])("maps %s to %i filled bars with the level as label", (level, filled) => {
+    expect(buildLevel({ level } as BRCDataCatalogGenome)).toEqual({
+      filledCount: filled,
+      label: level,
+    });
+  });
+
+  test("unknown level resolves to zero filled bars", () => {
+    expect(
+      buildLevel({ level: "Mystery" } as unknown as BRCDataCatalogGenome)
+    ).toEqual({ filledCount: 0, label: "Mystery" });
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the plain-text **Level** column with a tiered **bar indicator + label**, per the Figma design, on both the catalog assembly list and the organism detail assembly table (BRC + GA2).

Closes #1386

### What changed
- **New cell** `C.LevelCell` (`app/components/Table/components/TableCell/components/LevelCell/`): 4 rounded bars (5×12px), first *N* filled `PALETTE.PRIMARY_MAIN`, rest `PALETTE.SMOKE_DARK`, followed by the level label — matching the Figma spec.
- **Builder** `buildLevel` repurposed to return `LevelCell` props via a tier map: **Complete Genome → 4, Chromosome → 3, Scaffold → 2, Contig → 1** (label = the actual NCBI level value; unknown → 0 bars).
- **Wired into all four Level columns:** BRC `genomeEntityConfig`, GA2 `columnDefs`, and the BRC + GA2 organism-detail tables (`buildOrganismGenomesTableColumns`).

### Design
- [Figma node](https://www.figma.com/design/wxBBIrZcZb6IhYSg4d8B7J/BRC-Analytics-Homepage?node-id=4602-5868&m=dev).
- Labels use the **actual NCBI values** (Complete Genome / Chromosome / Scaffold / Contig) — consistent with the Level filter and catalog data — rather than the Figma node's friendlier relabels (Genome / Foundation).

### Tests
- `tests/viewModelBuilders/level.test.ts` — pins the level → filled-bar mapping (incl. unknown → 0).
- Full unit suite: 566 passing. `tsc` + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1547" height="1147" alt="image" src="https://github.com/user-attachments/assets/99fa727e-20d6-4f2a-9c1a-ee01c8592996" />

<img width="1551" height="1041" alt="image" src="https://github.com/user-attachments/assets/64ab9b03-1c88-448f-bae1-1999d264d592" />

<img width="1551" height="1164" alt="image" src="https://github.com/user-attachments/assets/506b35fa-a25b-40f8-897b-e8f5c7f42a2a" />

<img width="1547" height="1126" alt="image" src="https://github.com/user-attachments/assets/872ad32a-280e-409a-b601-16ebea969b51" />

