### PR TITLE
feat: organism detail: assembly table column-category filter (step 3 of #1352) (#1389)

### DIFF
--- a/app/components/Table/components/TableCell/components/SpeciesCell/speciesCell.tsx
+++ b/app/components/Table/components/TableCell/components/SpeciesCell/speciesCell.tsx
@@ -6,14 +6,12 @@ import { TagList } from "./components/TagList/tagList";
 import { SpeciesCellProps } from "./types";
 
 /*
- * Renders the consolidated species cell: the species name as a link, an
- * optional accession beneath it, the populated minor taxonomy fields (strain,
- * isolate, serotype, taxonomic group) as chips, then the NCBI taxonomy id. The
- * accession and minor fields are provided by the view builder, so each renders
- * only when present.
+ * Renders the consolidated species cell: the primary label as a link, the
+ * populated minor taxonomy fields (strain, isolate, serotype, taxonomic group)
+ * as chips, then the NCBI taxonomy id. Minor fields are provided pre-filtered
+ * by the view builder, so a chip renders only when present.
  */
 export const SpeciesCell = ({
-  accession,
   ncbiTaxonomyId,
   species,
   tags,
@@ -21,14 +19,6 @@ export const SpeciesCell = ({
   return (
     <Stack spacing={2} useFlexGap>
       <Link {...species} />
-      {accession && (
-        <Typography
-          color={TYPOGRAPHY_PROPS.COLOR.INK_LIGHT}
-          variant={TYPOGRAPHY_PROPS.VARIANT.BODY_SMALL_400}
-        >
-          {accession}
-        </Typography>
-      )}
       <TagList tags={tags} />
       {ncbiTaxonomyId && (
         <Typography

--- a/app/components/Table/components/TableCell/components/SpeciesCell/speciesCell.tsx
+++ b/app/components/Table/components/TableCell/components/SpeciesCell/speciesCell.tsx
@@ -6,12 +6,14 @@ import { TagList } from "./components/TagList/tagList";
 import { SpeciesCellProps } from "./types";
 
 /*
- * Renders the consolidated species cell: the species name as a link, the
- * populated minor taxonomy fields (strain, isolate, serotype, taxonomic group)
- * as chips, then the NCBI taxonomy id. Minor fields are provided pre-filtered by
- * the view builder, so a chip renders only when present.
+ * Renders the consolidated species cell: the species name as a link, an
+ * optional accession beneath it, the populated minor taxonomy fields (strain,
+ * isolate, serotype, taxonomic group) as chips, then the NCBI taxonomy id. The
+ * accession and minor fields are provided by the view builder, so each renders
+ * only when present.
  */
 export const SpeciesCell = ({
+  accession,
   ncbiTaxonomyId,
   species,
   tags,
@@ -19,6 +21,14 @@ export const SpeciesCell = ({
   return (
     <Stack spacing={2} useFlexGap>
       <Link {...species} />
+      {accession && (
+        <Typography
+          color={TYPOGRAPHY_PROPS.COLOR.INK_LIGHT}
+          variant={TYPOGRAPHY_PROPS.VARIANT.BODY_SMALL_400}
+        >
+          {accession}
+        </Typography>
+      )}
       <TagList tags={tags} />
       {ncbiTaxonomyId && (
         <Typography

--- a/app/components/Table/components/TableCell/components/SpeciesCell/types.ts
+++ b/app/components/Table/components/TableCell/components/SpeciesCell/types.ts
@@ -2,6 +2,7 @@ import { LinkProps } from "@databiosphere/findable-ui/lib/components/Links/compo
 import { ChipProps } from "@mui/material";
 
 export interface SpeciesCellProps {
+  accession?: string;
   ncbiTaxonomyId?: string;
   species: LinkProps;
   tags?: SpeciesTag[];

--- a/app/components/Table/components/TableCell/components/SpeciesCell/types.ts
+++ b/app/components/Table/components/TableCell/components/SpeciesCell/types.ts
@@ -2,7 +2,6 @@ import { LinkProps } from "@databiosphere/findable-ui/lib/components/Links/compo
 import { ChipProps } from "@mui/material";
 
 export interface SpeciesCellProps {
-  accession?: string;
   ncbiTaxonomyId?: string;
   species: LinkProps;
   tags?: SpeciesTag[];

--- a/app/components/common/Tooltip/constants.ts
+++ b/app/components/common/Tooltip/constants.ts
@@ -1,0 +1,7 @@
+import { TooltipProps } from "@mui/material";
+
+export const SLOT_PROPS: TooltipProps["slotProps"] = {
+  popper: {
+    modifiers: [{ name: "preventOverflow", options: { padding: 8 } }],
+  },
+};

--- a/app/components/common/Tooltip/tooltip.styles.ts
+++ b/app/components/common/Tooltip/tooltip.styles.ts
@@ -1,0 +1,12 @@
+import styled from "@emotion/styled";
+
+/**
+ * Wrapper that gives MUI Tooltip a single ref-able child. `inline-flex` keeps
+ * the wrapper inline-level (like a bare span) while shrink-wrapping its content
+ * so the tooltip anchors to the content rather than the full cell width — e.g.
+ * in the collapsed (vertical) table row where the cell stretches to full width.
+ */
+export const StyledSpan = styled.span`
+  display: inline-flex;
+  min-width: 0;
+`;

--- a/app/components/common/Tooltip/tooltip.tsx
+++ b/app/components/common/Tooltip/tooltip.tsx
@@ -1,13 +1,15 @@
 import { Tooltip as MTooltip, TooltipProps } from "@mui/material";
 import { JSX } from "react";
+import { SLOT_PROPS } from "./constants";
+import { StyledSpan } from "./tooltip.styles";
 
 export const Tooltip = ({
   children,
   ...props /* Mui TooltipProps */
 }: TooltipProps): JSX.Element => {
   return (
-    <MTooltip {...props}>
-      <span>{children}</span>
+    <MTooltip slotProps={SLOT_PROPS} {...props}>
+      <StyledSpan>{children}</StyledSpan>
     </MTooltip>
   );
 };

--- a/app/components/index.ts
+++ b/app/components/index.ts
@@ -49,4 +49,5 @@ export { VersionInfoWithServerStatus } from "./Layout/components/Footer/componen
 export { AuthButton } from "./Layout/components/Header/components/AuthButton/authButton";
 export { AnalyzeGenome } from "./Table/components/TableCell/components/AnalyzeGenome/analyzeGenome";
 export { LevelCell } from "./Table/components/TableCell/components/LevelCell/levelCell";
+export { TagList } from "./Table/components/TableCell/components/SpeciesCell/components/TagList/tagList";
 export { SpeciesCell } from "./Table/components/TableCell/components/SpeciesCell/speciesCell";

--- a/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
@@ -6,7 +6,7 @@ import {
 import { COLUMN_IDENTIFIER } from "@databiosphere/findable-ui/lib/components/Table/common/columnIdentifier";
 import { CHIP_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/chip";
 import { replaceParameters } from "@databiosphere/findable-ui/lib/utils/replaceParameters";
-import { ColumnDef, RowData } from "@tanstack/react-table";
+import { ColumnDef, RowData, VisibilityState } from "@tanstack/react-table";
 import type { SpeciesTag } from "app/components/Table/components/TableCell/components/SpeciesCell/types";
 import type { Organism } from "app/views/OrganismView/types";
 import { parseISO } from "date-fns";
@@ -943,26 +943,30 @@ export const buildOrganismViewMain = (
 };
 
 /**
+ * Complete visibility state for the Default preset, also used as the table's
+ * initial state. Columns not listed here are shown; the internal row-position
+ * column is always hidden.
+ */
+const DEFAULT_COLUMN_VISIBILITY: VisibilityState = {
+  [COLUMN_IDENTIFIER.ROW_POSITION]: false,
+  [BRC_DATA_CATALOG_CATEGORY_KEY.CHROMOSOMES]: false,
+  [BRC_DATA_CATALOG_CATEGORY_KEY.COVERAGE]: false,
+  [BRC_DATA_CATALOG_CATEGORY_KEY.GC_PERCENT]: false,
+  [BRC_DATA_CATALOG_CATEGORY_KEY.SCAFFOLD_COUNT]: false,
+  [BRC_DATA_CATALOG_CATEGORY_KEY.SCAFFOLD_L50]: false,
+  [BRC_DATA_CATALOG_CATEGORY_KEY.SCAFFOLD_N50]: false,
+};
+
+/**
  * The column presets (Default, Quality) for the organism genomes table. Each
- * preset lists the columns hidden in that view; unlisted columns remain
- * visible.
+ * preset's complete visibility state is applied via table.setColumnVisibility
+ * on toggle; columns not listed are shown.
  */
 const ORGANISM_GENOMES_COLUMN_PRESETS: ComponentProps<
   typeof C.OrganismViewMain
 >["columnPresets"] = [
   {
-    // Complete visibility state applied via table.setColumnVisibility on toggle;
-    // columns not listed here are shown. The internal row-position column is
-    // always hidden.
-    columnVisibility: {
-      [COLUMN_IDENTIFIER.ROW_POSITION]: false,
-      [BRC_DATA_CATALOG_CATEGORY_KEY.CHROMOSOMES]: false,
-      [BRC_DATA_CATALOG_CATEGORY_KEY.COVERAGE]: false,
-      [BRC_DATA_CATALOG_CATEGORY_KEY.GC_PERCENT]: false,
-      [BRC_DATA_CATALOG_CATEGORY_KEY.SCAFFOLD_COUNT]: false,
-      [BRC_DATA_CATALOG_CATEGORY_KEY.SCAFFOLD_L50]: false,
-      [BRC_DATA_CATALOG_CATEGORY_KEY.SCAFFOLD_N50]: false,
-    },
+    columnVisibility: DEFAULT_COLUMN_VISIBILITY,
     key: COLUMN_PRESET_KEY.DEFAULT,
     label: COLUMN_PRESET_LABEL.DEFAULT,
   },
@@ -994,9 +998,7 @@ export function buildOrganismGenomesTable(
     data: organism.genomes,
     initialState: {
       // Mount on the Default preset so the table matches the toggle.
-      columnVisibility: ORGANISM_GENOMES_COLUMN_PRESETS.find(
-        ({ key }) => key === COLUMN_PRESET_KEY.DEFAULT
-      )?.columnVisibility,
+      columnVisibility: DEFAULT_COLUMN_VISIBILITY,
       sorting: [
         { desc: true, id: BRC_DATA_CATALOG_CATEGORY_KEY.IS_REF },
         { desc: false, id: BRC_DATA_CATALOG_CATEGORY_KEY.ACCESSION },

--- a/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
@@ -12,7 +12,7 @@ import type { Organism } from "app/views/OrganismView/types";
 import { parseISO } from "date-fns";
 import { LinkProps } from "next/link";
 import Router from "next/router";
-import { ComponentProps } from "react";
+import { ComponentProps, createElement } from "react";
 import {
   BRC_DATA_CATALOG_CATEGORY_KEY,
   BRC_DATA_CATALOG_CATEGORY_LABEL,
@@ -40,6 +40,10 @@ import * as C from "../../../../components";
 import { StepConfig } from "../../../../components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/types";
 import { KeyValueSection } from "../../../../components/Entity/components/Section/KeyValueSection/keyValueSection";
 import { formatDate } from "../../../../utils/date-fns";
+import {
+  COLUMN_PRESET_KEY,
+  COLUMN_PRESET_LABEL,
+} from "../../../../views/OrganismView/components/Main/constants";
 import {
   getPriorityColor,
   getPriorityLabel,
@@ -340,6 +344,14 @@ const LEVEL_FILLED_COUNT: Record<string, number> = {
 };
 
 /**
+ * Overrides the displayed label for specific NCBI assembly levels; levels not
+ * listed here display their raw value.
+ */
+const LEVEL_LABEL: Record<string, string> = {
+  "Complete Genome": "Genome",
+};
+
+/**
  * Build props for the level cell — a tiered bar indicator plus the level label.
  * @param entity - Entity with a level property.
  * @returns Props for the LevelCell component.
@@ -349,7 +361,7 @@ export const buildLevel = (
 ): ComponentProps<typeof C.LevelCell> => {
   return {
     filledCount: LEVEL_FILLED_COUNT[entity.level] ?? 0,
-    label: entity.level,
+    label: LEVEL_LABEL[entity.level] ?? entity.level,
   };
 };
 
@@ -923,11 +935,49 @@ export const buildOrganismViewMain = (
   organism: BRCDataCatalogOrganism
 ): ComponentProps<typeof C.OrganismViewMain> => {
   return {
+    columnPresets: ORGANISM_GENOMES_COLUMN_PRESETS,
     entityId: getOrganismId(organism),
     organism,
     tableOptions: buildOrganismGenomesTable(organism),
   };
 };
+
+/**
+ * The column presets (Default, Quality) for the organism genomes table. Each
+ * preset lists the columns hidden in that view; unlisted columns remain
+ * visible.
+ */
+const ORGANISM_GENOMES_COLUMN_PRESETS: ComponentProps<
+  typeof C.OrganismViewMain
+>["columnPresets"] = [
+  {
+    // Complete visibility state applied via table.setColumnVisibility on toggle;
+    // columns not listed here are shown. The internal row-position column is
+    // always hidden.
+    columnVisibility: {
+      [COLUMN_IDENTIFIER.ROW_POSITION]: false,
+      [BRC_DATA_CATALOG_CATEGORY_KEY.CHROMOSOMES]: false,
+      [BRC_DATA_CATALOG_CATEGORY_KEY.COVERAGE]: false,
+      [BRC_DATA_CATALOG_CATEGORY_KEY.GC_PERCENT]: false,
+      [BRC_DATA_CATALOG_CATEGORY_KEY.SCAFFOLD_COUNT]: false,
+      [BRC_DATA_CATALOG_CATEGORY_KEY.SCAFFOLD_L50]: false,
+      [BRC_DATA_CATALOG_CATEGORY_KEY.SCAFFOLD_N50]: false,
+    },
+    key: COLUMN_PRESET_KEY.DEFAULT,
+    label: COLUMN_PRESET_LABEL.DEFAULT,
+  },
+  {
+    columnVisibility: {
+      [COLUMN_IDENTIFIER.ROW_POSITION]: false,
+      [BRC_DATA_CATALOG_CATEGORY_KEY.ANNOTATION_STATUS]: false,
+      [BRC_DATA_CATALOG_CATEGORY_KEY.IS_REF]: false,
+      [BRC_DATA_CATALOG_CATEGORY_KEY.LENGTH]: false,
+      [BRC_DATA_CATALOG_CATEGORY_KEY.RELEASE_DATE]: false,
+    },
+    key: COLUMN_PRESET_KEY.QUALITY,
+    label: COLUMN_PRESET_LABEL.QUALITY,
+  },
+];
 
 /**
  * Build table options (columns, data, initial state) for the genomes table for the given organism.
@@ -943,7 +993,10 @@ export function buildOrganismGenomesTable(
     columns: buildOrganismGenomesTableColumns() as ColumnDef<RowData>[],
     data: organism.genomes,
     initialState: {
-      columnVisibility: { [COLUMN_IDENTIFIER.ROW_POSITION]: false },
+      // Mount on the Default preset so the table matches the toggle.
+      columnVisibility: ORGANISM_GENOMES_COLUMN_PRESETS.find(
+        ({ key }) => key === COLUMN_PRESET_KEY.DEFAULT
+      )?.columnVisibility,
       sorting: [
         { desc: true, id: BRC_DATA_CATALOG_CATEGORY_KEY.IS_REF },
         { desc: false, id: BRC_DATA_CATALOG_CATEGORY_KEY.ACCESSION },
@@ -963,80 +1016,133 @@ function buildOrganismGenomesTableColumns(): ColumnDef<BRCDataCatalogGenome>[] {
       cell: ({ row }) => C.AnalyzeGenome(buildAnalyzeGenome(row.original)),
       enableSorting: false,
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.ANALYZE_GENOME,
-      meta: { width: "auto" },
+      meta: {
+        header: BRC_DATA_CATALOG_CATEGORY_LABEL.ANALYZE_GENOME,
+        width: "auto",
+      },
     },
     {
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.TAXONOMIC_LEVEL_SPECIES,
       cell: ({ row }) =>
         C.SpeciesCell(buildOrganismGenomeSpecies(row.original)),
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.TAXONOMIC_LEVEL_SPECIES,
-      meta: { columnPinned: true, width: { max: "1.5fr", min: "340px" } },
+      meta: {
+        columnPinned: true,
+        header: BRC_DATA_CATALOG_CATEGORY_LABEL.TAXONOMIC_LEVEL_SPECIES,
+        width: { max: "1.5fr", min: "340px" },
+      },
     },
     {
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.ACCESSION,
       cell: ({ row }) => C.BasicCell(buildAccession(row.original)),
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.ACCESSION,
-      meta: { width: { max: "1fr", min: "164px" } },
+      meta: {
+        header: BRC_DATA_CATALOG_CATEGORY_LABEL.ACCESSION,
+        width: { max: "1fr", min: "164px" },
+      },
+    },
+    {
+      accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.RELEASE_DATE,
+      cell: ({ row }) =>
+        C.Tooltip({
+          ...buildReleaseDateTooltip(row.original),
+          children: createElement(C.BasicCell, buildReleaseDate(row.original)),
+        }),
+      header: BRC_DATA_CATALOG_CATEGORY_LABEL.RELEASE_DATE,
+      meta: {
+        header: BRC_DATA_CATALOG_CATEGORY_LABEL.RELEASE_DATE,
+        width: { max: "0.5fr", min: "120px" },
+      },
     },
     {
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.IS_REF,
       cell: ({ row }) => C.ChipCell(buildIsRef(row.original)),
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.IS_REF,
-      meta: { width: { max: "0.5fr", min: "100px" } },
+      meta: {
+        header: BRC_DATA_CATALOG_CATEGORY_LABEL.IS_REF,
+        width: { max: "0.5fr", min: "100px" },
+      },
     },
     {
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.LEVEL,
       cell: ({ row }) => C.LevelCell(buildLevel(row.original)),
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.LEVEL,
-      meta: { width: { max: "0.5fr", min: "142px" } },
+      meta: {
+        header: BRC_DATA_CATALOG_CATEGORY_LABEL.LEVEL,
+        width: { max: "0.5fr", min: "142px" },
+      },
     },
     {
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.CHROMOSOMES,
       cell: ({ row }) => C.BasicCell(buildChromosomes(row.original)),
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.CHROMOSOMES,
-      meta: { width: { max: "0.5fr", min: "142px" } },
+      meta: {
+        header: BRC_DATA_CATALOG_CATEGORY_LABEL.CHROMOSOMES,
+        width: { max: "0.5fr", min: "142px" },
+      },
     },
     {
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.LENGTH,
       cell: ({ row }) => C.BasicCell(buildLength(row.original)),
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.LENGTH,
-      meta: { width: { max: "0.5fr", min: "132px" } },
+      meta: {
+        header: BRC_DATA_CATALOG_CATEGORY_LABEL.LENGTH,
+        width: { max: "0.5fr", min: "132px" },
+      },
     },
     {
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.SCAFFOLD_COUNT,
       cell: ({ row }) => C.BasicCell(buildScaffoldCount(row.original)),
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.SCAFFOLD_COUNT,
-      meta: { width: { max: "0.5fr", min: "120px" } },
+      meta: {
+        header: BRC_DATA_CATALOG_CATEGORY_LABEL.SCAFFOLD_COUNT,
+        width: { max: "0.5fr", min: "120px" },
+      },
     },
     {
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.SCAFFOLD_N50,
       cell: ({ row }) => C.BasicCell(buildScaffoldN50(row.original)),
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.SCAFFOLD_N50,
-      meta: { width: { max: "0.5fr", min: "120px" } },
+      meta: {
+        header: BRC_DATA_CATALOG_CATEGORY_LABEL.SCAFFOLD_N50,
+        width: { max: "0.5fr", min: "120px" },
+      },
     },
     {
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.SCAFFOLD_L50,
       cell: ({ row }) => C.BasicCell(buildScaffoldL50(row.original)),
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.SCAFFOLD_L50,
-      meta: { width: { max: "0.5fr", min: "120px" } },
+      meta: {
+        header: BRC_DATA_CATALOG_CATEGORY_LABEL.SCAFFOLD_L50,
+        width: { max: "0.5fr", min: "120px" },
+      },
     },
     {
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.COVERAGE,
       cell: ({ row }) => C.BasicCell(buildCoverage(row.original)),
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.COVERAGE,
-      meta: { width: { max: "0.5fr", min: "120px" } },
+      meta: {
+        header: BRC_DATA_CATALOG_CATEGORY_LABEL.COVERAGE,
+        width: { max: "0.5fr", min: "120px" },
+      },
     },
     {
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.GC_PERCENT,
       cell: ({ row }) => C.BasicCell(buildGcPercent(row.original)),
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.GC_PERCENT,
-      meta: { width: { max: "0.5fr", min: "120px" } },
+      meta: {
+        header: BRC_DATA_CATALOG_CATEGORY_LABEL.GC_PERCENT,
+        width: { max: "0.5fr", min: "120px" },
+      },
     },
     {
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.ANNOTATION_STATUS,
       cell: ({ row }) => C.BasicCell(buildAnnotationStatus(row.original)),
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.ANNOTATION_STATUS,
-      meta: { width: { max: "0.5fr", min: "180px" } },
+      meta: {
+        header: BRC_DATA_CATALOG_CATEGORY_LABEL.ANNOTATION_STATUS,
+        width: { max: "0.5fr", min: "140px" },
+      },
     },
   ];
 }

--- a/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
@@ -258,7 +258,11 @@ export const buildOrganismGenomeSpecies = (
   genome: BRCDataCatalogGenome
 ): ComponentProps<typeof C.SpeciesCell> => {
   const props = buildGenomeSpecies(genome);
-  return { ...props, species: { ...props.species, url: "" } };
+  return {
+    ...props,
+    accession: genome.accession,
+    species: { ...props.species, url: "" },
+  };
 };
 
 /**
@@ -949,6 +953,9 @@ export const buildOrganismViewMain = (
  */
 const DEFAULT_COLUMN_VISIBILITY: VisibilityState = {
   [COLUMN_IDENTIFIER.ROW_POSITION]: false,
+  // Accession is shown within the species cell on the detail page; its column
+  // is hidden but retained so the table can still sort by accession.
+  [BRC_DATA_CATALOG_CATEGORY_KEY.ACCESSION]: false,
   [BRC_DATA_CATALOG_CATEGORY_KEY.CHROMOSOMES]: false,
   [BRC_DATA_CATALOG_CATEGORY_KEY.COVERAGE]: false,
   [BRC_DATA_CATALOG_CATEGORY_KEY.GC_PERCENT]: false,
@@ -973,6 +980,7 @@ const ORGANISM_GENOMES_COLUMN_PRESETS: ComponentProps<
   {
     columnVisibility: {
       [COLUMN_IDENTIFIER.ROW_POSITION]: false,
+      [BRC_DATA_CATALOG_CATEGORY_KEY.ACCESSION]: false,
       [BRC_DATA_CATALOG_CATEGORY_KEY.ANNOTATION_STATUS]: false,
       [BRC_DATA_CATALOG_CATEGORY_KEY.IS_REF]: false,
       [BRC_DATA_CATALOG_CATEGORY_KEY.LENGTH]: false,

--- a/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
@@ -1017,9 +1017,6 @@ export const buildOrganismViewMain = (
  */
 const DEFAULT_COLUMN_VISIBILITY: VisibilityState = {
   [COLUMN_IDENTIFIER.ROW_POSITION]: false,
-  // Accession is shown within the species cell on the detail page; its column
-  // is hidden but retained so the table can still sort by accession.
-  [BRC_DATA_CATALOG_CATEGORY_KEY.ACCESSION]: false,
   [BRC_DATA_CATALOG_CATEGORY_KEY.CHROMOSOMES]: false,
   [BRC_DATA_CATALOG_CATEGORY_KEY.COVERAGE]: false,
   [BRC_DATA_CATALOG_CATEGORY_KEY.GC_PERCENT]: false,
@@ -1044,7 +1041,6 @@ const ORGANISM_GENOMES_COLUMN_PRESETS: ComponentProps<
   {
     columnVisibility: {
       [COLUMN_IDENTIFIER.ROW_POSITION]: false,
-      [BRC_DATA_CATALOG_CATEGORY_KEY.ACCESSION]: false,
       [BRC_DATA_CATALOG_CATEGORY_KEY.ANNOTATION_STATUS]: false,
       [BRC_DATA_CATALOG_CATEGORY_KEY.IS_REF]: false,
       [BRC_DATA_CATALOG_CATEGORY_KEY.LENGTH]: false,
@@ -1102,7 +1098,10 @@ function buildOrganismGenomesTableColumns(): ColumnDef<BRCDataCatalogGenome>[] {
       },
     },
     {
-      accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.TAXONOMIC_LEVEL_SPECIES,
+      // Keyed on accession so the pinned "Assembly" column sorts by accession
+      // (its primary text); the SpeciesCell renders the accession + per-assembly
+      // tags.
+      accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.ACCESSION,
       cell: ({ row }) =>
         C.SpeciesCell(buildOrganismGenomeSpecies(row.original)),
       header: ASSEMBLY_COLUMN_HEADER,
@@ -1110,15 +1109,6 @@ function buildOrganismGenomesTableColumns(): ColumnDef<BRCDataCatalogGenome>[] {
         columnPinned: true,
         header: ASSEMBLY_COLUMN_HEADER,
         width: { max: "0.75fr", min: "176px" },
-      },
-    },
-    {
-      accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.ACCESSION,
-      cell: ({ row }) => C.BasicCell(buildAccession(row.original)),
-      header: BRC_DATA_CATALOG_CATEGORY_LABEL.ACCESSION,
-      meta: {
-        header: BRC_DATA_CATALOG_CATEGORY_LABEL.ACCESSION,
-        width: { max: "1fr", min: "164px" },
       },
     },
     {

--- a/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
@@ -220,23 +220,20 @@ export const buildGenomeSpecies = (
 ): ComponentProps<typeof C.SpeciesCell> => {
   const tags: SpeciesTag[] = [];
   const strain = getGenomeStrainText(genome);
-  if (strain) tags.push({ label: "strain", value: strain });
+  if (strain) tags.push({ label: "strain", tooltip: strain, value: strain });
   const serotype = getGenomeSerotypeText(genome);
-  if (serotype) tags.push({ label: "serotype", value: serotype });
+  if (serotype)
+    tags.push({ label: "serotype", tooltip: serotype, value: serotype });
   const isolate = getGenomeIsolateText(genome);
-  if (isolate) tags.push({ label: "isolate", value: isolate });
-  if (genome.taxonomicGroup.length > 0)
-    tags.push({
-      label: "group",
-      value: genome.taxonomicGroup.join(", "),
-    });
-  if (genome.priority)
-    tags.push({
-      color: getPriorityColor(genome.priority),
-      label: "priority",
-      tooltip: genome.priorityPathogenName ?? undefined,
-      value: genome.priority.toLowerCase().replace(/_/g, " "),
-    });
+  if (isolate)
+    tags.push({ label: "isolate", tooltip: isolate, value: isolate });
+  const groupTag = buildGroupTag(genome.taxonomicGroup);
+  if (groupTag) tags.push(groupTag);
+  const priorityTag = buildPriorityTag(
+    genome.priority,
+    genome.priorityPathogenName
+  );
+  if (priorityTag) tags.push(priorityTag);
   return {
     ncbiTaxonomyId: genome.ncbiTaxonomyId,
     species: {
@@ -248,9 +245,60 @@ export const buildGenomeSpecies = (
 };
 
 /**
+ * Species-cell tag labels. Single source of truth shared by the tag builders
+ * and the organism-scoped filter so they can't drift apart.
+ */
+const SPECIES_TAG_LABEL = {
+  GROUP: "group",
+  PRIORITY: "priority",
+} as const;
+
+/**
+ * Labels of the species/organism-scoped tags (constant across an organism's
+ * assemblies). On the organism detail page these move to the header, so the
+ * per-assembly species cell omits them.
+ */
+export const ORGANISM_SCOPED_TAG_LABELS: string[] = [
+  SPECIES_TAG_LABEL.GROUP,
+  SPECIES_TAG_LABEL.PRIORITY,
+];
+
+/**
+ * Build the taxonomic group tag, or null when there is no group.
+ * @param taxonomicGroup - Taxonomic group values.
+ * @returns Group tag, or null.
+ */
+export function buildGroupTag(taxonomicGroup: string[]): SpeciesTag | null {
+  if (taxonomicGroup.length === 0) return null;
+  const value = taxonomicGroup.join(", ");
+  return { label: SPECIES_TAG_LABEL.GROUP, tooltip: value, value };
+}
+
+/**
+ * Build the priority pathogen tag, or null when the entity has no priority.
+ * @param priority - Outbreak priority.
+ * @param priorityPathogenName - Priority pathogen name (tag tooltip).
+ * @returns Priority tag, or null.
+ */
+function buildPriorityTag(
+  priority: OUTBREAK_PRIORITY | null,
+  priorityPathogenName: string | null
+): SpeciesTag | null {
+  if (!priority) return null;
+  return {
+    color: getPriorityColor(priority),
+    label: SPECIES_TAG_LABEL.PRIORITY,
+    tooltip: priorityPathogenName ?? undefined,
+    value: priority.toLowerCase().replace(/_/g, " "),
+  };
+}
+
+/**
  * Build props for the species cell on the organism detail page assembly table.
- * Same as buildGenomeSpecies but with an empty species url — the species is the
- * page's own organism, so Link renders the name as plain text (no self-link).
+ * The accession is the cell's primary (unlinked) label — the species name is
+ * redundant on a single-organism page and moves to the hero title. The
+ * organism-scoped tags (group, priority) are dropped here as they move to the
+ * hero; only per-assembly tags (strain, serotype, isolate) remain.
  * @param genome - Genome entity.
  * @returns Props to be used for the SpeciesCell component.
  */
@@ -260,8 +308,12 @@ export const buildOrganismGenomeSpecies = (
   const props = buildGenomeSpecies(genome);
   return {
     ...props,
-    accession: genome.accession,
-    species: { ...props.species, url: "" },
+    // Accession replaces the species name as the cell's primary text (rendered
+    // as plain text — no link). Organism-scoped tags move to the page header.
+    species: { label: genome.accession, url: "" },
+    tags: props.tags?.filter(
+      ({ label }) => !ORGANISM_SCOPED_TAG_LABELS.includes(label)
+    ),
   };
 };
 
@@ -924,8 +976,20 @@ export const buildAssemblyResources = (
 export const buildOrganismHero = (
   organism: BRCDataCatalogOrganism
 ): ComponentProps<typeof C.BackPageHero> => {
+  // The species/group/priority are constant across the organism's assemblies,
+  // so surface group + priority as header chips rather than repeating them on
+  // every assembly row.
+  const tags: SpeciesTag[] = [];
+  const groupTag = buildGroupTag(organism.taxonomicGroup);
+  if (groupTag) tags.push(groupTag);
+  const priorityTag = buildPriorityTag(
+    organism.priority,
+    organism.priorityPathogenName
+  );
+  if (priorityTag) tags.push(priorityTag);
   return {
     breadcrumbs: getOrganismEntityBreadcrumbs(organism),
+    subTitle: tags.length > 0 ? createElement(C.TagList, { tags }) : undefined,
     title: organism.taxonomicLevelSpecies,
   };
 };
@@ -1016,6 +1080,12 @@ export function buildOrganismGenomesTable(
 }
 
 /**
+ * Header for the pinned species column on the organism detail table: relabelled
+ * "Assembly" since the cell's primary text is the assembly accession.
+ */
+const ASSEMBLY_COLUMN_HEADER = "Assembly";
+
+/**
  * Build the column definitions for the organism genomes table.
  * @returns column definitions.
  */
@@ -1035,11 +1105,11 @@ function buildOrganismGenomesTableColumns(): ColumnDef<BRCDataCatalogGenome>[] {
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.TAXONOMIC_LEVEL_SPECIES,
       cell: ({ row }) =>
         C.SpeciesCell(buildOrganismGenomeSpecies(row.original)),
-      header: BRC_DATA_CATALOG_CATEGORY_LABEL.TAXONOMIC_LEVEL_SPECIES,
+      header: ASSEMBLY_COLUMN_HEADER,
       meta: {
         columnPinned: true,
-        header: BRC_DATA_CATALOG_CATEGORY_LABEL.TAXONOMIC_LEVEL_SPECIES,
-        width: { max: "1.5fr", min: "340px" },
+        header: ASSEMBLY_COLUMN_HEADER,
+        width: { max: "0.75fr", min: "176px" },
       },
     },
     {
@@ -1106,7 +1176,7 @@ function buildOrganismGenomesTableColumns(): ColumnDef<BRCDataCatalogGenome>[] {
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.SCAFFOLD_COUNT,
       meta: {
         header: BRC_DATA_CATALOG_CATEGORY_LABEL.SCAFFOLD_COUNT,
-        width: { max: "0.5fr", min: "120px" },
+        width: { max: "0.5fr", min: "116px" },
       },
     },
     {
@@ -1115,7 +1185,7 @@ function buildOrganismGenomesTableColumns(): ColumnDef<BRCDataCatalogGenome>[] {
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.SCAFFOLD_N50,
       meta: {
         header: BRC_DATA_CATALOG_CATEGORY_LABEL.SCAFFOLD_N50,
-        width: { max: "0.5fr", min: "120px" },
+        width: { max: "0.5fr", min: "116px" },
       },
     },
     {
@@ -1124,7 +1194,7 @@ function buildOrganismGenomesTableColumns(): ColumnDef<BRCDataCatalogGenome>[] {
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.SCAFFOLD_L50,
       meta: {
         header: BRC_DATA_CATALOG_CATEGORY_LABEL.SCAFFOLD_L50,
-        width: { max: "0.5fr", min: "120px" },
+        width: { max: "0.5fr", min: "116px" },
       },
     },
     {
@@ -1133,7 +1203,7 @@ function buildOrganismGenomesTableColumns(): ColumnDef<BRCDataCatalogGenome>[] {
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.COVERAGE,
       meta: {
         header: BRC_DATA_CATALOG_CATEGORY_LABEL.COVERAGE,
-        width: { max: "0.5fr", min: "120px" },
+        width: { max: "0.5fr", min: "116px" },
       },
     },
     {
@@ -1142,7 +1212,7 @@ function buildOrganismGenomesTableColumns(): ColumnDef<BRCDataCatalogGenome>[] {
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.GC_PERCENT,
       meta: {
         header: BRC_DATA_CATALOG_CATEGORY_LABEL.GC_PERCENT,
-        width: { max: "0.5fr", min: "120px" },
+        width: { max: "0.5fr", min: "116px" },
       },
     },
     {

--- a/app/viewModelBuilders/catalog/ga2/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/ga2/viewModelBuilders.ts
@@ -67,6 +67,9 @@ export const buildOrganismViewMain = (
  */
 const DEFAULT_COLUMN_VISIBILITY: VisibilityState = {
   [COLUMN_IDENTIFIER.ROW_POSITION]: false,
+  // Accession is shown within the species cell on the detail page; its column
+  // is hidden but retained so the table can still sort by accession.
+  [GA2_CATEGORY_KEY.ACCESSION]: false,
   [GA2_CATEGORY_KEY.CHROMOSOMES]: false,
   [GA2_CATEGORY_KEY.COVERAGE]: false,
   [GA2_CATEGORY_KEY.GC_PERCENT]: false,
@@ -91,6 +94,7 @@ const ORGANISM_GENOMES_COLUMN_PRESETS: ComponentProps<
   {
     columnVisibility: {
       [COLUMN_IDENTIFIER.ROW_POSITION]: false,
+      [GA2_CATEGORY_KEY.ACCESSION]: false,
       [GA2_CATEGORY_KEY.ANNOTATION_STATUS]: false,
       [GA2_CATEGORY_KEY.IS_REF]: false,
       [GA2_CATEGORY_KEY.LENGTH]: false,
@@ -327,5 +331,9 @@ export const buildOrganismAssemblySpecies = (
   entity: GA2AssemblyEntity
 ): ComponentProps<typeof C.SpeciesCell> => {
   const props = buildAssemblySpecies(entity);
-  return { ...props, species: { ...props.species, url: "" } };
+  return {
+    ...props,
+    accession: entity.accession,
+    species: { ...props.species, url: "" },
+  };
 };

--- a/app/viewModelBuilders/catalog/ga2/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/ga2/viewModelBuilders.ts
@@ -1,6 +1,6 @@
 import { COLUMN_IDENTIFIER } from "@databiosphere/findable-ui/lib/components/Table/common/columnIdentifier";
 import { ColumnDef, RowData } from "@tanstack/react-table";
-import { ComponentProps } from "react";
+import { ComponentProps, createElement } from "react";
 import { ROUTES } from "../../../../routes/constants";
 import {
   GA2_CATEGORY_KEY,
@@ -14,9 +14,15 @@ import {
 import * as C from "../../../components";
 import type { SpeciesTag } from "../../../components/Table/components/TableCell/components/SpeciesCell/types";
 import {
+  COLUMN_PRESET_KEY,
+  COLUMN_PRESET_LABEL,
+} from "../../../views/OrganismView/components/Main/constants";
+import {
   buildAnalyzeGenome,
   buildIsRef,
   buildLevel,
+  buildReleaseDate,
+  buildReleaseDateTooltip,
   formatNumber,
   getGenomeStrainText,
 } from "../brc-analytics-catalog/common/viewModelBuilders";
@@ -47,11 +53,49 @@ export const buildOrganismViewMain = (
   entity: GA2OrganismEntity
 ): ComponentProps<typeof C.OrganismViewMain> => {
   return {
+    columnPresets: ORGANISM_GENOMES_COLUMN_PRESETS,
     entityId: sanitizeEntityId(entity.ncbiTaxonomyId),
     organism: entity,
     tableOptions: buildOrganismGenomesTable(entity),
   };
 };
+
+/**
+ * The column presets (Default, Quality) for the organism genomes table. Each
+ * preset lists the columns hidden in that view; unlisted columns remain
+ * visible.
+ */
+const ORGANISM_GENOMES_COLUMN_PRESETS: ComponentProps<
+  typeof C.OrganismViewMain
+>["columnPresets"] = [
+  {
+    // Complete visibility state applied via table.setColumnVisibility on toggle;
+    // columns not listed here are shown. The internal row-position column is
+    // always hidden.
+    columnVisibility: {
+      [COLUMN_IDENTIFIER.ROW_POSITION]: false,
+      [GA2_CATEGORY_KEY.CHROMOSOMES]: false,
+      [GA2_CATEGORY_KEY.COVERAGE]: false,
+      [GA2_CATEGORY_KEY.GC_PERCENT]: false,
+      [GA2_CATEGORY_KEY.SCAFFOLD_COUNT]: false,
+      [GA2_CATEGORY_KEY.SCAFFOLD_L50]: false,
+      [GA2_CATEGORY_KEY.SCAFFOLD_N50]: false,
+    },
+    key: COLUMN_PRESET_KEY.DEFAULT,
+    label: COLUMN_PRESET_LABEL.DEFAULT,
+  },
+  {
+    columnVisibility: {
+      [COLUMN_IDENTIFIER.ROW_POSITION]: false,
+      [GA2_CATEGORY_KEY.ANNOTATION_STATUS]: false,
+      [GA2_CATEGORY_KEY.IS_REF]: false,
+      [GA2_CATEGORY_KEY.LENGTH]: false,
+      [GA2_CATEGORY_KEY.RELEASE_DATE]: false,
+    },
+    key: COLUMN_PRESET_KEY.QUALITY,
+    label: COLUMN_PRESET_LABEL.QUALITY,
+  },
+];
 
 /**
  * Build props for the organism BackPageHero component.
@@ -81,7 +125,10 @@ export function buildOrganismGenomesTable(
     columns: buildOrganismGenomesTableColumns() as ColumnDef<RowData>[],
     data: entity.genomes,
     initialState: {
-      columnVisibility: { [COLUMN_IDENTIFIER.ROW_POSITION]: false },
+      // Mount on the Default preset so the table matches the toggle.
+      columnVisibility: ORGANISM_GENOMES_COLUMN_PRESETS.find(
+        ({ key }) => key === COLUMN_PRESET_KEY.DEFAULT
+      )?.columnVisibility,
       sorting: [
         { desc: true, id: GA2_CATEGORY_KEY.IS_REF },
         { desc: false, id: GA2_CATEGORY_KEY.ACCESSION },
@@ -101,75 +148,125 @@ function buildOrganismGenomesTableColumns(): ColumnDef<GA2AssemblyEntity>[] {
       cell: ({ row }) => C.AnalyzeGenome(buildAnalyzeGenome(row.original)),
       enableSorting: false,
       header: GA2_CATEGORY_LABEL.ANALYZE_GENOME,
-      meta: { width: "auto" },
+      meta: { header: GA2_CATEGORY_LABEL.ANALYZE_GENOME, width: "auto" },
     },
     {
       accessorKey: GA2_CATEGORY_KEY.TAXONOMIC_LEVEL_SPECIES,
       cell: ({ row }) =>
         C.SpeciesCell(buildOrganismAssemblySpecies(row.original)),
       header: GA2_CATEGORY_LABEL.TAXONOMIC_LEVEL_SPECIES,
-      meta: { columnPinned: true, width: { max: "1.5fr", min: "340px" } },
+      meta: {
+        columnPinned: true,
+        header: GA2_CATEGORY_LABEL.TAXONOMIC_LEVEL_SPECIES,
+        width: { max: "1.5fr", min: "340px" },
+      },
     },
     {
       accessorKey: GA2_CATEGORY_KEY.ACCESSION,
       header: GA2_CATEGORY_LABEL.ACCESSION,
-      meta: { width: { max: "1fr", min: "152px" } },
+      meta: {
+        header: GA2_CATEGORY_LABEL.ACCESSION,
+        width: { max: "1fr", min: "152px" },
+      },
+    },
+    {
+      accessorKey: GA2_CATEGORY_KEY.RELEASE_DATE,
+      cell: ({ row }) =>
+        C.Tooltip({
+          ...buildReleaseDateTooltip(row.original),
+          children: createElement(C.BasicCell, buildReleaseDate(row.original)),
+        }),
+      header: GA2_CATEGORY_LABEL.RELEASE_DATE,
+      meta: {
+        header: GA2_CATEGORY_LABEL.RELEASE_DATE,
+        width: { max: "1fr", min: "140px" },
+      },
     },
     {
       accessorKey: GA2_CATEGORY_KEY.IS_REF,
       cell: ({ row }) => C.ChipCell(buildIsRef(row.original)),
       header: GA2_CATEGORY_LABEL.IS_REF,
-      meta: { width: { max: "1fr", min: "152px" } },
+      meta: {
+        header: GA2_CATEGORY_LABEL.IS_REF,
+        width: { max: "1fr", min: "100px" },
+      },
     },
     {
       accessorKey: GA2_CATEGORY_KEY.LEVEL,
       cell: ({ row }) => C.LevelCell(buildLevel(row.original)),
       header: GA2_CATEGORY_LABEL.LEVEL,
-      meta: { width: { max: "1fr", min: "152px" } },
+      meta: {
+        header: GA2_CATEGORY_LABEL.LEVEL,
+        width: { max: "1fr", min: "152px" },
+      },
     },
     {
       accessorKey: GA2_CATEGORY_KEY.CHROMOSOMES,
       header: GA2_CATEGORY_LABEL.CHROMOSOMES,
-      meta: { width: { max: "1fr", min: "152px" } },
+      meta: {
+        header: GA2_CATEGORY_LABEL.CHROMOSOMES,
+        width: { max: "1fr", min: "152px" },
+      },
     },
     {
       accessorKey: GA2_CATEGORY_KEY.LENGTH,
       cell: ({ getValue }) => formatNumber(getValue()),
       header: GA2_CATEGORY_LABEL.LENGTH,
-      meta: { width: { max: "1fr", min: "152px" } },
+      meta: {
+        header: GA2_CATEGORY_LABEL.LENGTH,
+        width: { max: "1fr", min: "152px" },
+      },
     },
     {
       accessorKey: GA2_CATEGORY_KEY.SCAFFOLD_COUNT,
       cell: ({ getValue }) => formatNumber(getValue()),
       header: GA2_CATEGORY_LABEL.SCAFFOLD_COUNT,
-      meta: { width: { max: "1fr", min: "152px" } },
+      meta: {
+        header: GA2_CATEGORY_LABEL.SCAFFOLD_COUNT,
+        width: { max: "1fr", min: "152px" },
+      },
     },
     {
       accessorKey: GA2_CATEGORY_KEY.SCAFFOLD_N50,
       cell: ({ getValue }) => formatNumber(getValue()),
       header: GA2_CATEGORY_LABEL.SCAFFOLD_N50,
-      meta: { width: { max: "1fr", min: "152px" } },
+      meta: {
+        header: GA2_CATEGORY_LABEL.SCAFFOLD_N50,
+        width: { max: "1fr", min: "152px" },
+      },
     },
     {
       accessorKey: GA2_CATEGORY_KEY.SCAFFOLD_L50,
       cell: ({ getValue }) => formatNumber(getValue()),
       header: GA2_CATEGORY_LABEL.SCAFFOLD_L50,
-      meta: { width: { max: "1fr", min: "152px" } },
+      meta: {
+        header: GA2_CATEGORY_LABEL.SCAFFOLD_L50,
+        width: { max: "1fr", min: "152px" },
+      },
     },
     {
       accessorKey: GA2_CATEGORY_KEY.COVERAGE,
       header: GA2_CATEGORY_LABEL.COVERAGE,
-      meta: { width: { max: "1fr", min: "152px" } },
+      meta: {
+        header: GA2_CATEGORY_LABEL.COVERAGE,
+        width: { max: "1fr", min: "152px" },
+      },
     },
     {
       accessorKey: GA2_CATEGORY_KEY.GC_PERCENT,
       header: GA2_CATEGORY_LABEL.GC_PERCENT,
-      meta: { width: { max: "1fr", min: "152px" } },
+      meta: {
+        header: GA2_CATEGORY_LABEL.GC_PERCENT,
+        width: { max: "1fr", min: "152px" },
+      },
     },
     {
       accessorKey: GA2_CATEGORY_KEY.ANNOTATION_STATUS,
       header: GA2_CATEGORY_LABEL.ANNOTATION_STATUS,
-      meta: { width: { max: "1fr", min: "152px" } },
+      meta: {
+        header: GA2_CATEGORY_LABEL.ANNOTATION_STATUS,
+        width: { max: "1fr", min: "140px" },
+      },
     },
   ];
 }

--- a/app/viewModelBuilders/catalog/ga2/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/ga2/viewModelBuilders.ts
@@ -19,12 +19,14 @@ import {
 } from "../../../views/OrganismView/components/Main/constants";
 import {
   buildAnalyzeGenome,
+  buildGroupTag,
   buildIsRef,
   buildLevel,
   buildReleaseDate,
   buildReleaseDateTooltip,
   formatNumber,
   getGenomeStrainText,
+  ORGANISM_SCOPED_TAG_LABELS,
 } from "../brc-analytics-catalog/common/viewModelBuilders";
 
 /**
@@ -35,11 +37,17 @@ import {
 export const buildOrganismHero = (
   entity: GA2OrganismEntity
 ): ComponentProps<typeof C.BackPageHero> => {
+  // The species/group are constant across the organism's assemblies, so surface
+  // the group as a header chip rather than repeating it on every assembly row.
+  const groupTag = buildGroupTag(entity.taxonomicGroup);
   return {
     breadcrumbs: [
       { path: ROUTES.ORGANISMS, text: "Organisms" },
       { path: "", text: entity.taxonomicLevelSpecies },
     ],
+    subTitle: groupTag
+      ? createElement(C.TagList, { tags: [groupTag] })
+      : undefined,
     title: entity.taxonomicLevelSpecies,
   };
 };
@@ -144,6 +152,12 @@ export function buildOrganismGenomesTable(
 }
 
 /**
+ * Header for the pinned species column on the organism detail table: relabelled
+ * "Assembly" since the cell's primary text is the assembly accession.
+ */
+const ASSEMBLY_COLUMN_HEADER = "Assembly";
+
+/**
  * Build the column definitions for the organism genomes table.
  * @returns column definitions.
  */
@@ -160,11 +174,11 @@ function buildOrganismGenomesTableColumns(): ColumnDef<GA2AssemblyEntity>[] {
       accessorKey: GA2_CATEGORY_KEY.TAXONOMIC_LEVEL_SPECIES,
       cell: ({ row }) =>
         C.SpeciesCell(buildOrganismAssemblySpecies(row.original)),
-      header: GA2_CATEGORY_LABEL.TAXONOMIC_LEVEL_SPECIES,
+      header: ASSEMBLY_COLUMN_HEADER,
       meta: {
         columnPinned: true,
-        header: GA2_CATEGORY_LABEL.TAXONOMIC_LEVEL_SPECIES,
-        width: { max: "1.5fr", min: "340px" },
+        header: ASSEMBLY_COLUMN_HEADER,
+        width: { max: "0.75fr", min: "176px" },
       },
     },
     {
@@ -211,7 +225,7 @@ function buildOrganismGenomesTableColumns(): ColumnDef<GA2AssemblyEntity>[] {
       header: GA2_CATEGORY_LABEL.CHROMOSOMES,
       meta: {
         header: GA2_CATEGORY_LABEL.CHROMOSOMES,
-        width: { max: "1fr", min: "152px" },
+        width: { max: "1fr", min: "142px" },
       },
     },
     {
@@ -229,7 +243,7 @@ function buildOrganismGenomesTableColumns(): ColumnDef<GA2AssemblyEntity>[] {
       header: GA2_CATEGORY_LABEL.SCAFFOLD_COUNT,
       meta: {
         header: GA2_CATEGORY_LABEL.SCAFFOLD_COUNT,
-        width: { max: "1fr", min: "152px" },
+        width: { max: "1fr", min: "116px" },
       },
     },
     {
@@ -238,7 +252,7 @@ function buildOrganismGenomesTableColumns(): ColumnDef<GA2AssemblyEntity>[] {
       header: GA2_CATEGORY_LABEL.SCAFFOLD_N50,
       meta: {
         header: GA2_CATEGORY_LABEL.SCAFFOLD_N50,
-        width: { max: "1fr", min: "152px" },
+        width: { max: "1fr", min: "120px" },
       },
     },
     {
@@ -247,7 +261,7 @@ function buildOrganismGenomesTableColumns(): ColumnDef<GA2AssemblyEntity>[] {
       header: GA2_CATEGORY_LABEL.SCAFFOLD_L50,
       meta: {
         header: GA2_CATEGORY_LABEL.SCAFFOLD_L50,
-        width: { max: "1fr", min: "152px" },
+        width: { max: "1fr", min: "116px" },
       },
     },
     {
@@ -255,7 +269,7 @@ function buildOrganismGenomesTableColumns(): ColumnDef<GA2AssemblyEntity>[] {
       header: GA2_CATEGORY_LABEL.COVERAGE,
       meta: {
         header: GA2_CATEGORY_LABEL.COVERAGE,
-        width: { max: "1fr", min: "152px" },
+        width: { max: "1fr", min: "116px" },
       },
     },
     {
@@ -263,7 +277,7 @@ function buildOrganismGenomesTableColumns(): ColumnDef<GA2AssemblyEntity>[] {
       header: GA2_CATEGORY_LABEL.GC_PERCENT,
       meta: {
         header: GA2_CATEGORY_LABEL.GC_PERCENT,
-        width: { max: "1fr", min: "152px" },
+        width: { max: "1fr", min: "116px" },
       },
     },
     {
@@ -304,12 +318,9 @@ export const buildAssemblySpecies = (
 ): ComponentProps<typeof C.SpeciesCell> => {
   const tags: SpeciesTag[] = [];
   const strain = getGenomeStrainText(entity);
-  if (strain) tags.push({ label: "strain", value: strain });
-  if (entity.taxonomicGroup.length > 0)
-    tags.push({
-      label: "group",
-      value: entity.taxonomicGroup.join(", "),
-    });
+  if (strain) tags.push({ label: "strain", tooltip: strain, value: strain });
+  const groupTag = buildGroupTag(entity.taxonomicGroup);
+  if (groupTag) tags.push(groupTag);
   return {
     ncbiTaxonomyId: entity.ncbiTaxonomyId,
     species: {
@@ -322,8 +333,10 @@ export const buildAssemblySpecies = (
 
 /**
  * Build props for the species cell on the organism detail page assembly table.
- * Same as buildAssemblySpecies but with an empty species url — the species is the
- * page's own organism, so Link renders the name as plain text (no self-link).
+ * The accession is the cell's primary (unlinked) label — the species name is
+ * redundant on a single-organism page and moves to the hero title. The
+ * organism-scoped group tag is dropped here as it moves to the hero; only
+ * per-assembly tags (strain) remain.
  * @param entity - Assembly entity.
  * @returns Props to be used for the SpeciesCell component.
  */
@@ -333,7 +346,11 @@ export const buildOrganismAssemblySpecies = (
   const props = buildAssemblySpecies(entity);
   return {
     ...props,
-    accession: entity.accession,
-    species: { ...props.species, url: "" },
+    // Accession replaces the species name as the cell's primary text (rendered
+    // as plain text — no link). Organism-scoped tags move to the page header.
+    species: { label: entity.accession, url: "" },
+    tags: props.tags?.filter(
+      ({ label }) => !ORGANISM_SCOPED_TAG_LABELS.includes(label)
+    ),
   };
 };

--- a/app/viewModelBuilders/catalog/ga2/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/ga2/viewModelBuilders.ts
@@ -1,5 +1,5 @@
 import { COLUMN_IDENTIFIER } from "@databiosphere/findable-ui/lib/components/Table/common/columnIdentifier";
-import { ColumnDef, RowData } from "@tanstack/react-table";
+import { ColumnDef, RowData, VisibilityState } from "@tanstack/react-table";
 import { ComponentProps, createElement } from "react";
 import { ROUTES } from "../../../../routes/constants";
 import {
@@ -61,26 +61,30 @@ export const buildOrganismViewMain = (
 };
 
 /**
+ * Complete visibility state for the Default preset, also used as the table's
+ * initial state. Columns not listed here are shown; the internal row-position
+ * column is always hidden.
+ */
+const DEFAULT_COLUMN_VISIBILITY: VisibilityState = {
+  [COLUMN_IDENTIFIER.ROW_POSITION]: false,
+  [GA2_CATEGORY_KEY.CHROMOSOMES]: false,
+  [GA2_CATEGORY_KEY.COVERAGE]: false,
+  [GA2_CATEGORY_KEY.GC_PERCENT]: false,
+  [GA2_CATEGORY_KEY.SCAFFOLD_COUNT]: false,
+  [GA2_CATEGORY_KEY.SCAFFOLD_L50]: false,
+  [GA2_CATEGORY_KEY.SCAFFOLD_N50]: false,
+};
+
+/**
  * The column presets (Default, Quality) for the organism genomes table. Each
- * preset lists the columns hidden in that view; unlisted columns remain
- * visible.
+ * preset's complete visibility state is applied via table.setColumnVisibility
+ * on toggle; columns not listed are shown.
  */
 const ORGANISM_GENOMES_COLUMN_PRESETS: ComponentProps<
   typeof C.OrganismViewMain
 >["columnPresets"] = [
   {
-    // Complete visibility state applied via table.setColumnVisibility on toggle;
-    // columns not listed here are shown. The internal row-position column is
-    // always hidden.
-    columnVisibility: {
-      [COLUMN_IDENTIFIER.ROW_POSITION]: false,
-      [GA2_CATEGORY_KEY.CHROMOSOMES]: false,
-      [GA2_CATEGORY_KEY.COVERAGE]: false,
-      [GA2_CATEGORY_KEY.GC_PERCENT]: false,
-      [GA2_CATEGORY_KEY.SCAFFOLD_COUNT]: false,
-      [GA2_CATEGORY_KEY.SCAFFOLD_L50]: false,
-      [GA2_CATEGORY_KEY.SCAFFOLD_N50]: false,
-    },
+    columnVisibility: DEFAULT_COLUMN_VISIBILITY,
     key: COLUMN_PRESET_KEY.DEFAULT,
     label: COLUMN_PRESET_LABEL.DEFAULT,
   },
@@ -126,9 +130,7 @@ export function buildOrganismGenomesTable(
     data: entity.genomes,
     initialState: {
       // Mount on the Default preset so the table matches the toggle.
-      columnVisibility: ORGANISM_GENOMES_COLUMN_PRESETS.find(
-        ({ key }) => key === COLUMN_PRESET_KEY.DEFAULT
-      )?.columnVisibility,
+      columnVisibility: DEFAULT_COLUMN_VISIBILITY,
       sorting: [
         { desc: true, id: GA2_CATEGORY_KEY.IS_REF },
         { desc: false, id: GA2_CATEGORY_KEY.ACCESSION },

--- a/app/viewModelBuilders/catalog/ga2/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/ga2/viewModelBuilders.ts
@@ -75,9 +75,6 @@ export const buildOrganismViewMain = (
  */
 const DEFAULT_COLUMN_VISIBILITY: VisibilityState = {
   [COLUMN_IDENTIFIER.ROW_POSITION]: false,
-  // Accession is shown within the species cell on the detail page; its column
-  // is hidden but retained so the table can still sort by accession.
-  [GA2_CATEGORY_KEY.ACCESSION]: false,
   [GA2_CATEGORY_KEY.CHROMOSOMES]: false,
   [GA2_CATEGORY_KEY.COVERAGE]: false,
   [GA2_CATEGORY_KEY.GC_PERCENT]: false,
@@ -102,7 +99,6 @@ const ORGANISM_GENOMES_COLUMN_PRESETS: ComponentProps<
   {
     columnVisibility: {
       [COLUMN_IDENTIFIER.ROW_POSITION]: false,
-      [GA2_CATEGORY_KEY.ACCESSION]: false,
       [GA2_CATEGORY_KEY.ANNOTATION_STATUS]: false,
       [GA2_CATEGORY_KEY.IS_REF]: false,
       [GA2_CATEGORY_KEY.LENGTH]: false,
@@ -171,7 +167,10 @@ function buildOrganismGenomesTableColumns(): ColumnDef<GA2AssemblyEntity>[] {
       meta: { header: GA2_CATEGORY_LABEL.ANALYZE_GENOME, width: "auto" },
     },
     {
-      accessorKey: GA2_CATEGORY_KEY.TAXONOMIC_LEVEL_SPECIES,
+      // Keyed on accession so the pinned "Assembly" column sorts by accession
+      // (its primary text); the SpeciesCell renders the accession + per-assembly
+      // tags.
+      accessorKey: GA2_CATEGORY_KEY.ACCESSION,
       cell: ({ row }) =>
         C.SpeciesCell(buildOrganismAssemblySpecies(row.original)),
       header: ASSEMBLY_COLUMN_HEADER,
@@ -179,14 +178,6 @@ function buildOrganismGenomesTableColumns(): ColumnDef<GA2AssemblyEntity>[] {
         columnPinned: true,
         header: ASSEMBLY_COLUMN_HEADER,
         width: { max: "0.75fr", min: "176px" },
-      },
-    },
-    {
-      accessorKey: GA2_CATEGORY_KEY.ACCESSION,
-      header: GA2_CATEGORY_LABEL.ACCESSION,
-      meta: {
-        header: GA2_CATEGORY_LABEL.ACCESSION,
-        width: { max: "1fr", min: "152px" },
       },
     },
     {

--- a/app/views/OrganismView/components/Main/constants.ts
+++ b/app/views/OrganismView/components/Main/constants.ts
@@ -1,0 +1,9 @@
+export const COLUMN_PRESET_KEY = {
+  DEFAULT: "DEFAULT",
+  QUALITY: "QUALITY",
+} as const;
+
+export const COLUMN_PRESET_LABEL = {
+  DEFAULT: "Default",
+  QUALITY: "Quality",
+} as const;

--- a/app/views/OrganismView/components/Main/main.tsx
+++ b/app/views/OrganismView/components/Main/main.tsx
@@ -11,6 +11,7 @@ import { getWorkflows } from "../../../../services/workflows/entities";
 import { Accordion } from "../../../AnalyzeWorkflowsView/components/Main/components/Accordion/accordion";
 import { EmptyState } from "./components/EmptyState/emptyState";
 import { StyledSectionTitle } from "./main.styles";
+import { Toolbar } from "./table/components/Toolbar/toolbar";
 import { useTable } from "./table/hooks/UseTable/hook";
 import { StyledFluidPaper } from "./table/table.styles";
 import type { Props } from "./types";
@@ -20,12 +21,14 @@ import { buildOrganismWorkflows } from "./utils";
  * Main column for the organism detail page: organism-scoped workflows section
  * and the assemblies section (header, info alert, and assemblies table).
  * @param props - Component props.
+ * @param props.columnPresets - Column presets for the assemblies table.
  * @param props.entityId - Organism entity ID.
  * @param props.organism - Organism.
  * @param props.tableOptions - Options for the assemblies table.
  * @returns A JSX element with the organism detail main content.
  */
 export const Main = <T extends RowData>({
+  columnPresets,
   entityId,
   organism,
   tableOptions,
@@ -76,6 +79,7 @@ export const Main = <T extends RowData>({
         </EmptyState>
       ) : (
         <StyledFluidPaper elevation={0}>
+          <Toolbar columnPresets={columnPresets} table={table} />
           <Table table={table} />
         </StyledFluidPaper>
       )}

--- a/app/views/OrganismView/components/Main/table/components/Toolbar/components/ColumnPresetToggle/columnPresetToggle.styles.ts
+++ b/app/views/OrganismView/components/Main/table/components/Toolbar/components/ColumnPresetToggle/columnPresetToggle.styles.ts
@@ -1,0 +1,14 @@
+import { PALETTE } from "@databiosphere/findable-ui/lib/styles/common/constants/palette";
+import styled from "@emotion/styled";
+import { ToggleButtonGroup } from "@mui/material";
+
+export const StyledToggleButtonGroup = styled(ToggleButtonGroup)`
+  .MuiToggleButton-root {
+    padding: 8px 16px;
+    text-transform: none;
+
+    &:not(.Mui-selected) {
+      color: ${PALETTE.INK_LIGHT};
+    }
+  }
+`;

--- a/app/views/OrganismView/components/Main/table/components/Toolbar/components/ColumnPresetToggle/columnPresetToggle.styles.ts
+++ b/app/views/OrganismView/components/Main/table/components/Toolbar/components/ColumnPresetToggle/columnPresetToggle.styles.ts
@@ -4,7 +4,7 @@ import { ToggleButtonGroup } from "@mui/material";
 
 export const StyledToggleButtonGroup = styled(ToggleButtonGroup)`
   .MuiToggleButton-root {
-    padding: 8px 16px;
+    padding: 6px 16px;
     text-transform: none;
 
     &:not(.Mui-selected) {

--- a/app/views/OrganismView/components/Main/table/components/Toolbar/components/ColumnPresetToggle/columnPresetToggle.tsx
+++ b/app/views/OrganismView/components/Main/table/components/Toolbar/components/ColumnPresetToggle/columnPresetToggle.tsx
@@ -1,0 +1,34 @@
+import { ToggleButton } from "@mui/material";
+import { RowData } from "@tanstack/react-table";
+import { JSX } from "react";
+import { StyledToggleButtonGroup } from "./columnPresetToggle.styles";
+import { TOGGLE_BUTTON_GROUP_PROPS } from "./constants";
+import { useColumnPresets } from "./hooks/UseColumnPresets/hook";
+import type { Props } from "./types";
+
+/**
+ * Segmented control that switches the assemblies table between column presets.
+ * @param props - Component props.
+ * @param props.presets - Available column presets.
+ * @param props.table - Table instance whose column visibility the presets drive.
+ * @returns Column preset toggle.
+ */
+export const ColumnPresetToggle = <T extends RowData>({
+  presets,
+  table,
+}: Props<T>): JSX.Element => {
+  const { onChange, value } = useColumnPresets(presets, table);
+  return (
+    <StyledToggleButtonGroup
+      {...TOGGLE_BUTTON_GROUP_PROPS}
+      onChange={onChange}
+      value={value}
+    >
+      {presets.map((preset) => (
+        <ToggleButton key={preset.key} value={preset.key}>
+          {preset.label}
+        </ToggleButton>
+      ))}
+    </StyledToggleButtonGroup>
+  );
+};

--- a/app/views/OrganismView/components/Main/table/components/Toolbar/components/ColumnPresetToggle/constants.ts
+++ b/app/views/OrganismView/components/Main/table/components/Toolbar/components/ColumnPresetToggle/constants.ts
@@ -1,0 +1,6 @@
+import type { ToggleButtonGroupProps } from "@mui/material";
+
+export const TOGGLE_BUTTON_GROUP_PROPS: Partial<ToggleButtonGroupProps> = {
+  exclusive: true,
+  size: "small",
+};

--- a/app/views/OrganismView/components/Main/table/components/Toolbar/components/ColumnPresetToggle/hooks/UseColumnPresets/hook.ts
+++ b/app/views/OrganismView/components/Main/table/components/Toolbar/components/ColumnPresetToggle/hooks/UseColumnPresets/hook.ts
@@ -1,0 +1,34 @@
+import { useToggleButtonGroup } from "@databiosphere/findable-ui/lib/components/common/ToggleButtonGroup/hooks/UseToggleButtonGroup/hook";
+import type { RowData, Table } from "@tanstack/react-table";
+import { type MouseEvent, useCallback } from "react";
+import type { ColumnPreset } from "../../../../../../../types";
+import type { UseColumnPresets } from "./types";
+
+/**
+ * Tracks the active column preset and applies its visibility to the table. The
+ * first preset is active on mount (matching the table's initial state). An
+ * exclusive toggle emits `null` when the active button is re-clicked; that
+ * deselection is ignored so a preset is always applied.
+ * @param presets - Available column presets.
+ * @param table - Table instance whose column visibility the presets drive.
+ * @returns Active preset value and the toggle change handler.
+ */
+export const useColumnPresets = <T extends RowData>(
+  presets: ColumnPreset[],
+  table: Table<T>
+): UseColumnPresets => {
+  const { onChange: onValueChange, value } = useToggleButtonGroup<string>(
+    presets[0]?.key
+  );
+
+  const onChange = useCallback(
+    (event: MouseEvent<HTMLElement>, key: string | null): void => {
+      onValueChange?.(event, key);
+      const preset = presets.find((preset) => preset.key === key);
+      if (preset) table.setColumnVisibility(preset.columnVisibility);
+    },
+    [onValueChange, presets, table]
+  );
+
+  return { onChange, value };
+};

--- a/app/views/OrganismView/components/Main/table/components/Toolbar/components/ColumnPresetToggle/hooks/UseColumnPresets/types.ts
+++ b/app/views/OrganismView/components/Main/table/components/Toolbar/components/ColumnPresetToggle/hooks/UseColumnPresets/types.ts
@@ -1,0 +1,6 @@
+import type { ToggleButtonGroupProps } from "@mui/material";
+
+export type UseColumnPresets = Pick<
+  ToggleButtonGroupProps,
+  "onChange" | "value"
+>;

--- a/app/views/OrganismView/components/Main/table/components/Toolbar/components/ColumnPresetToggle/types.ts
+++ b/app/views/OrganismView/components/Main/table/components/Toolbar/components/ColumnPresetToggle/types.ts
@@ -1,0 +1,7 @@
+import type { RowData, Table } from "@tanstack/react-table";
+import type { ColumnPreset } from "../../../../../types";
+
+export interface Props<T extends RowData> {
+  presets: ColumnPreset[];
+  table: Table<T>;
+}

--- a/app/views/OrganismView/components/Main/table/components/Toolbar/toolbar.styles.ts
+++ b/app/views/OrganismView/components/Main/table/components/Toolbar/toolbar.styles.ts
@@ -1,0 +1,9 @@
+import { PALETTE } from "@databiosphere/findable-ui/lib/styles/common/constants/palette";
+import styled from "@emotion/styled";
+import { Toolbar } from "@mui/material";
+
+export const StyledToolbar = styled(Toolbar)`
+  border-bottom: 1px solid ${PALETTE.SMOKE_MAIN};
+  justify-content: flex-end;
+  padding: 16px;
+`;

--- a/app/views/OrganismView/components/Main/table/components/Toolbar/toolbar.tsx
+++ b/app/views/OrganismView/components/Main/table/components/Toolbar/toolbar.tsx
@@ -16,7 +16,8 @@ export const Toolbar = <T extends RowData>({
   columnPresets,
   table,
 }: Props<T>): JSX.Element | null => {
-  if (columnPresets.length === 0) return null;
+  // Nothing to switch between with fewer than two presets.
+  if (columnPresets.length < 2) return null;
   return (
     <StyledToolbar>
       <ColumnPresetToggle presets={columnPresets} table={table} />

--- a/app/views/OrganismView/components/Main/table/components/Toolbar/toolbar.tsx
+++ b/app/views/OrganismView/components/Main/table/components/Toolbar/toolbar.tsx
@@ -1,0 +1,25 @@
+import { RowData } from "@tanstack/react-table";
+import { JSX } from "react";
+import { ColumnPresetToggle } from "./components/ColumnPresetToggle/columnPresetToggle";
+import { StyledToolbar } from "./toolbar.styles";
+import type { Props } from "./types";
+
+/**
+ * Toolbar above the assemblies table; hosts the column preset toggle. Renders
+ * nothing when there are no presets to switch between.
+ * @param props - Component props.
+ * @param props.columnPresets - Column presets for the assemblies table.
+ * @param props.table - Table instance.
+ * @returns Assemblies table toolbar.
+ */
+export const Toolbar = <T extends RowData>({
+  columnPresets,
+  table,
+}: Props<T>): JSX.Element | null => {
+  if (columnPresets.length === 0) return null;
+  return (
+    <StyledToolbar>
+      <ColumnPresetToggle presets={columnPresets} table={table} />
+    </StyledToolbar>
+  );
+};

--- a/app/views/OrganismView/components/Main/table/components/Toolbar/types.ts
+++ b/app/views/OrganismView/components/Main/table/components/Toolbar/types.ts
@@ -1,0 +1,7 @@
+import type { RowData, Table } from "@tanstack/react-table";
+import type { ColumnPreset } from "../../../types";
+
+export interface Props<T extends RowData> {
+  columnPresets: ColumnPreset[];
+  table: Table<T>;
+}

--- a/app/views/OrganismView/components/Main/types.ts
+++ b/app/views/OrganismView/components/Main/types.ts
@@ -1,7 +1,18 @@
-import { RowData, TableOptions } from "@tanstack/react-table";
+import type {
+  RowData,
+  TableOptions,
+  VisibilityState,
+} from "@tanstack/react-table";
 import type { Organism } from "../../types";
 
+export interface ColumnPreset {
+  columnVisibility: VisibilityState;
+  key: string;
+  label: string;
+}
+
 export interface Props<T extends RowData> {
+  columnPresets: ColumnPreset[];
   entityId: string;
   organism: Organism;
   tableOptions: Pick<TableOptions<T>, "columns" | "data" | "initialState">;

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 /// <reference types="next/navigation-types/compat/navigation" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 /// <reference types="next/navigation-types/compat/navigation" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/tests/viewModelBuilders/level.test.ts
+++ b/tests/viewModelBuilders/level.test.ts
@@ -7,18 +7,18 @@ import { buildLevel } from "../../app/viewModelBuilders/catalog/brc-analytics-ca
 
 describe("buildLevel", () => {
   test.each([
-    ["Complete Genome", 4],
-    ["Chromosome", 3],
-    ["Scaffold", 2],
-    ["Contig", 1],
-  ])("maps %s to %i filled bars with the level as label", (level, filled) => {
+    ["Complete Genome", 4, "Genome"],
+    ["Chromosome", 3, "Chromosome"],
+    ["Scaffold", 2, "Scaffold"],
+    ["Contig", 1, "Contig"],
+  ])("maps %s to %i filled bars with label %s", (level, filled, label) => {
     expect(buildLevel({ level } as BRCDataCatalogGenome)).toEqual({
       filledCount: filled,
-      label: level,
+      label,
     });
   });
 
-  test("unknown level resolves to zero filled bars", () => {
+  test("unknown level resolves to zero filled bars and its raw label", () => {
     expect(
       buildLevel({ level: "Mystery" } as unknown as BRCDataCatalogGenome)
     ).toEqual({ filledCount: 0, label: "Mystery" });

--- a/tests/viewModelBuilders/species.test.ts
+++ b/tests/viewModelBuilders/species.test.ts
@@ -34,10 +34,14 @@ describe("buildGenomeSpecies", () => {
     expect(props.species.url).toBe("/data/organisms/287");
     expect(props.ncbiTaxonomyId).toBe("208964");
     expect(props.tags).toEqual([
-      { label: "strain", value: "PAO1" },
-      { label: "serotype", value: "O1" },
-      { label: "isolate", value: "ISO-1" },
-      { label: "group", value: "Bacteria, Proteobacteria" },
+      { label: "strain", tooltip: "PAO1", value: "PAO1" },
+      { label: "serotype", tooltip: "O1", value: "O1" },
+      { label: "isolate", tooltip: "ISO-1", value: "ISO-1" },
+      {
+        label: "group",
+        tooltip: "Bacteria, Proteobacteria",
+        value: "Bacteria, Proteobacteria",
+      },
       {
         color: "warning",
         label: "priority",
@@ -84,8 +88,8 @@ describe("buildAssemblySpecies", () => {
     expect(props.species.url).toBe("/data/organisms/9606");
     expect(props.ncbiTaxonomyId).toBe("9606");
     expect(props.tags).toEqual([
-      { label: "strain", value: "GRCh38" },
-      { label: "group", value: "Vertebrates" },
+      { label: "strain", tooltip: "GRCh38", value: "GRCh38" },
+      { label: "group", tooltip: "Vertebrates", value: "Vertebrates" },
     ]);
   });
 
@@ -105,9 +109,10 @@ describe("buildAssemblySpecies", () => {
   });
 });
 
-describe("organism detail species cell (no self-link)", () => {
-  test("buildOrganismGenomeSpecies blanks the species url, keeps tags", () => {
+describe("organism detail species cell (accession primary, no self-link)", () => {
+  test("buildOrganismGenomeSpecies uses the accession as an unlinked label, keeps per-assembly tags", () => {
     const genome = {
+      accession: "GCF_000002765.6",
       ncbiTaxonomyId: "5833",
       speciesTaxonomyId: "5833",
       strainName: "3D7",
@@ -120,13 +125,16 @@ describe("organism detail species cell (no self-link)", () => {
 
     const props = buildOrganismGenomeSpecies(genome);
 
-    expect(props.species.label).toBe("Plasmodium falciparum");
+    expect(props.species.label).toBe("GCF_000002765.6");
     expect(props.species.url).toBe("");
-    expect(props.tags).toEqual([{ label: "strain", value: "3D7" }]);
+    expect(props.tags).toEqual([
+      { label: "strain", tooltip: "3D7", value: "3D7" },
+    ]);
   });
 
-  test("buildOrganismAssemblySpecies blanks the species url, keeps tags", () => {
+  test("buildOrganismAssemblySpecies uses the accession as an unlinked label and drops the organism-scoped group tag", () => {
     const assembly = {
+      accession: "GCF_000001405.40",
       ncbiTaxonomyId: "9606",
       speciesTaxonomyId: "9606",
       strainName: "",
@@ -137,11 +145,10 @@ describe("organism detail species cell (no self-link)", () => {
 
     const props = buildOrganismAssemblySpecies(assembly);
 
-    expect(props.species.label).toBe("Homo sapiens");
+    expect(props.species.label).toBe("GCF_000001405.40");
     expect(props.species.url).toBe("");
     expect(props.tags).toEqual([
-      { label: "strain", value: "GRCh38" },
-      { label: "group", value: "Vertebrates" },
+      { label: "strain", tooltip: "GRCh38", value: "GRCh38" },
     ]);
   });
 });


### PR DESCRIPTION
## Summary

Adds a **column-category filter** to the assembly table on the **organism detail page** — a `Default | Quality` segmented toggle (top-right of the table) that switches which columns are shown, so users focus the view instead of horizontally scrolling a wide table. Covers **step 3 of #1352**; steps 1+2 shipped in #1388.

Closes #1389

### Presets (both BRC and GA2)

- **Default** — Assembly (accession), Release Date, Is Ref, Level, Length, Annotation Status
- **Quality** — Assembly (accession), Level, Chromosomes, Scaffolds, Scaffold N50, Scaffold L50, Coverage, GC%

The pinned **Assembly** column (accession as its primary text) + Analyze are always visible; Level is shared across both presets. No data is dropped — every column remains reachable via a preset. Sort / responsive / empty-state behavior preserved.

### How it works

- `Toolbar` → `ColumnPresetToggle` (under `OrganismView/.../table/components/Toolbar/`) drives visibility **imperatively** via `table.setColumnVisibility(preset.columnVisibility)`, reusing findable-ui's shared `useToggleButtonGroup`. No controlled state / `useMemo` churn.
- Presets are complete `VisibilityState` maps defined per-site (`ORGANISM_GENOMES_COLUMN_PRESETS`); the table mounts on the Default preset via `initialState.columnVisibility`.

### Also in this PR

- **Assembly column redesign** (organism detail only, per design feedback): the pinned "Species" column is renamed **Assembly** and shows the **accession as its primary (unlinked) text**. The species name and organism-scoped tags (group, priority) — identical on every row of a single-organism page — move to the **organism hero** as chips (reusing `TagList`). Rows keep only the per-assembly tags (strain, serotype, isolate). The standalone accession column is hidden but retained for sorting. `SpeciesCell` is unchanged for the catalog `/data/assemblies` table.
- **Chip tooltips**: the strain / serotype / isolate / group chips carry a tooltip of their full value, so a truncated chip reveals its text on hover.
- **Year column** added to the organism assembly table (reuses the catalog `buildReleaseDate` + tooltip; shown in Default, hidden in Quality).
- **"Complete Genome" → "Genome"** label shortening in the shared `buildLevel` (applies to all level cells, both sites; data value untouched so tier-bar count + sorting are unaffected).
- **`meta.header` added to every column** so the collapsed (mobile/vertical) rows render field labels — matching what the config-driven tables get automatically via `buildBaseColumnDef`.
- **Shared `Tooltip` fixes:** wrapper span uses `display: inline-flex; min-width: 0` so the tooltip anchors to its content (not the full cell width in collapsed rows), and an 8px Popper `preventOverflow` boundary offset so it never hugs the edge. Verified safe for all consumers (release-date cell, priority-pathogen chip, TagList chips).
- Annotation Status min-width reduced (BRC 180→140px, GA2 152→140px); GA2 Is Ref min aligned to BRC (100px).

### Tests / checks

- Unit suite green (568). `tsc`, ESLint, Prettier clean. Both site builds succeed. Manually verified on BRC + GA2 (toggle, year column, Genome label, collapsed-row labels, tooltip anchoring, "Assembly" column with accession-primary cell, group/priority header chips, chip tooltips).
- Updated `tests/viewModelBuilders/level.test.ts` and `species.test.ts` for the new label / accession-primary / tooltip behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1996" height="1130" alt="image" src="https://github.com/user-attachments/assets/dd126ab0-d153-41e9-93ec-f8fefa78e8a8" />

<img width="1998" height="1263" alt="image" src="https://github.com/user-attachments/assets/5728a269-96df-4653-8617-8e06a2c67b23" />

<img width="1996" height="1115" alt="image" src="https://github.com/user-attachments/assets/62861ca2-ab39-448b-bfcb-d22eafce393f" />

<img width="1998" height="1147" alt="image" src="https://github.com/user-attachments/assets/24ccf6d6-9fe1-4b80-ab1a-cf2b15bb79af" />



