### PR TITLE
fix: harden shared tooltip slotProps merge (follow-up to #1398 review) (#1400)

### DIFF
--- a/app/components/common/Tooltip/tooltip.tsx
+++ b/app/components/common/Tooltip/tooltip.tsx
@@ -5,10 +5,13 @@ import { StyledSpan } from "./tooltip.styles";
 
 export const Tooltip = ({
   children,
+  slotProps,
   ...props /* Mui TooltipProps */
 }: TooltipProps): JSX.Element => {
   return (
-    <MTooltip slotProps={SLOT_PROPS} {...props}>
+    // Merge a caller's slotProps over the defaults (rather than letting the
+    // spread replace them) so the preventOverflow default is preserved.
+    <MTooltip slotProps={{ ...SLOT_PROPS, ...slotProps }} {...props}>
       <StyledSpan>{children}</StyledSpan>
     </MTooltip>
   );


### PR DESCRIPTION
## Summary

Addresses the non-blocking follow-ups from the #1398 review (#1400).

Closes #1400

### Item 2 — `slotProps` override footgun ✅ fixed
`app/components/common/Tooltip/tooltip.tsx` — `slotProps` is now destructured and merged (`{ ...SLOT_PROPS, ...slotProps }`) so a future caller passing its own `slotProps` no longer silently drops the `preventOverflow` boundary default. (The previous `slotProps={SLOT_PROPS} {...props}` order let the spread replace it — and note the review's suggested one-liner still had `{...props}` trailing, which would re-clobber it; destructuring is the correct form.)

### Item 1 — shared `Tooltip` `inline-flex` cross-cutting ✅ verified, no change
Confirmed chip behaviour in narrow / collapsed rows: a chip that exceeds the available width is capped and ellipsed (MUI `Chip` `max-width: 100%` + label `text-overflow: ellipsis`) while the other chips wrap (`TagList` `flexWrap`). The `inline-flex; min-width: 0` wrapper is what enables ellipsis-instead-of-overflow, and the tag tooltip surfaces the full value on hover. Nothing to change.

### Item 3 — dedupe presets across BRC/GA2 ⛔ won't do (per MONOREPO_PLAN)
`.claude/rules/MONOREPO_PLAN.md` lists **column definitions & category configs as site-specific**, with BRC and GA2 as **independent peers** meant to evolve independently (they already differ in column widths and tag sets). Its structural-contract-type guidance is for shared code consuming site *entities*, not for hoisting site *config* into shared code. Factoring a shared preset factory would reintroduce the cross-site config coupling the plan is removing, so the per-site duplication is intentional and kept. Drift risk is the accepted cost of independence (both tables are reviewed together).

### Checks
- `tsc`, ESLint, Prettier clean; 568 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)