### PR TITLE
feat(assistant): fill the analysis tracker from the catalog and harden output parsing

### DIFF
--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -64,6 +64,11 @@ logger = logging.getLogger(__name__)
 # fence-break attempts in user text.
 _USER_INPUT_CLOSE_TAG = re.compile(r"</\s*user_input\s*>", re.IGNORECASE)
 
+# Either structured-output trailer keyword. Used to bound a malformed marker's
+# excision so it can't reach past the next trailer -- the prompt places
+# SUGGESTIONS after SCHEMA_UPDATE, so a broken SCHEMA_UPDATE must not swallow it.
+_TRAILER_MARKER = re.compile(r"\*{0,2}\b(?:schema_update|suggestions)\b", re.IGNORECASE)
+
 # ~20 turn-pairs; tool-heavy turns produce 3-5 messages each, so this
 # bounds total context while preserving good conversational continuity.
 MAX_HISTORY_MESSAGES = 40
@@ -898,11 +903,26 @@ class AssistantAgent:
                     except json.JSONDecodeError:
                         # The model mangled the JSON (smaller models sometimes
                         # emit broken brackets). Excise from the marker through
-                        # the last bracket so raw JSON never reaches the user.
+                        # the last bracket so raw JSON never reaches the user --
+                        # but bound the reach to this marker's own payload: stop
+                        # at the next real trailer (line start or uppercase) so a
+                        # broken SCHEMA_UPDATE can't swallow the SUGGESTIONS the
+                        # prompt places after it.
                         if not marker_is_real:
                             continue
-                        last = max(text.rfind("]"), text.rfind("}"))
-                        cut = last + 1 if last > json_at else len(text)
+                        region_end = len(text)
+                        for bm in _TRAILER_MARKER.finditer(text, m.end()):
+                            bls = text.rfind("\n", 0, bm.start()) + 1
+                            if text[bls : bm.start()].strip() == "" or any(
+                                c.isupper() for c in bm.group(0)
+                            ):
+                                region_end = bm.start()
+                                break
+                        last = max(
+                            text.rfind("]", json_at, region_end),
+                            text.rfind("}", json_at, region_end),
+                        )
+                        cut = last + 1 if last >= json_at else region_end
                         text = (text[: m.start()] + text[cut:]).strip()
                         break
                     if not marker_is_real:

--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -865,10 +865,12 @@ class AssistantAgent:
         text = raw_reply
 
         def _extract(text: str, keyword: str, validate) -> tuple[str, Any]:
-            # Optional **bold**/italic and colon on either side, anywhere in the
-            # text (not anchored to line start). \b stops it matching mid-word.
+            # Optional **bold** and a colon (with optional surrounding spaces)
+            # on either side, anywhere in the text (not anchored to line start).
+            # \b stops it matching mid-word.
             marker = re.compile(
-                r"\*{0,2}\b" + keyword + r"\b:?\*{0,2}:?[ \t]*", re.IGNORECASE
+                r"\*{0,2}\b" + keyword + r"\b[ \t]*:?[ \t]*\*{0,2}[ \t]*:?[ \t]*",
+                re.IGNORECASE,
             )
             result: Any = None
             # Loop so *every* real trailer of this type is handled: a model that
@@ -905,7 +907,7 @@ class AssistantAgent:
                         # emit broken brackets). Excise from the marker through
                         # the last bracket so raw JSON never reaches the user --
                         # but bound the reach to this marker's own payload: stop
-                        # at the next real trailer (line start or uppercase) so a
+                        # at the next real trailer (on its own line) so a
                         # broken SCHEMA_UPDATE can't swallow the SUGGESTIONS the
                         # prompt places after it.
                         if not marker_is_real:
@@ -913,9 +915,11 @@ class AssistantAgent:
                         region_end = len(text)
                         for bm in _TRAILER_MARKER.finditer(text, m.end()):
                             bls = text.rfind("\n", 0, bm.start()) + 1
-                            if text[bls : bm.start()].strip() == "" or any(
-                                c.isupper() for c in bm.group(0)
-                            ):
+                            # Only a trailer on its own line bounds the reach; a
+                            # marker word mid-line (e.g. inside a JSON string) is
+                            # not a real boundary, so we over-strip past it rather
+                            # than stop inside it and leak the tail.
+                            if text[bls : bm.start()].strip() == "":
                                 region_end = bm.start()
                                 break
                         last = max(
@@ -937,7 +941,14 @@ class AssistantAgent:
                         result = {**result, **value}
                     else:
                         result = value
-                    text = text[: m.start()] + text[end:]
+                    # raw_decode stops at the end of the first JSON value; drop
+                    # any trailing junk on the trailer's own line (e.g. a stray
+                    # second array) rather than leave it visible.
+                    line_end = text.find("\n", end)
+                    if line_end == -1:
+                        line_end = len(text)
+                    tail = end if text[end:line_end].strip() == "" else line_end
+                    text = text[: m.start()] + text[tail:]
                     break
                 else:
                     break  # no marker spliced this pass -- done

--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -865,45 +865,63 @@ class AssistantAgent:
             marker = re.compile(
                 r"\*{0,2}\b" + keyword + r"\b:?\*{0,2}:?[ \t]*", re.IGNORECASE
             )
-            for m in marker.finditer(text):
-                rest = text[m.end() :]
-                json_at = None
-                for i, ch in enumerate(rest):
-                    if ch in "[{":
-                        json_at = m.end() + i
-                        break
-                    if not ch.isspace():
-                        break  # prose follows, not a JSON payload -- leave it
-                if json_at is None:
-                    continue
-                # A real trailer is either at line start (the model's own line)
-                # or written with some uppercase -- the markers are emitted in
-                # caps per the prompt. An all-lowercase marker mid-prose (e.g.
-                # "...a few suggestions: [...]") is prose and is left untouched,
-                # even when the brackets happen to be valid JSON.
-                line_start = text.rfind("\n", 0, m.start()) + 1
-                at_line_start = text[line_start : m.start()].strip() == ""
-                marker_is_real = at_line_start or any(c.isupper() for c in m.group(0))
-                try:
-                    # raw_decode reads one JSON value and reports where it ends,
-                    # so a multi-line array/object is handled in one shot.
-                    value, end = json.JSONDecoder().raw_decode(text, json_at)
-                except json.JSONDecodeError:
-                    # The model mangled the JSON (smaller models sometimes emit
-                    # broken brackets). Excise from the marker through the last
-                    # bracket so raw JSON never reaches the user.
-                    if not marker_is_real:
+            result: Any = None
+            # Loop so *every* real trailer of this type is handled: a model that
+            # emits the marker twice must not leave the second block (and its raw
+            # JSON) visible. Re-search after each splice since positions shift.
+            while True:
+                for m in marker.finditer(text):
+                    rest = text[m.end() :]
+                    json_at = None
+                    for i, ch in enumerate(rest):
+                        if ch in "[{":
+                            json_at = m.end() + i
+                            break
+                        if not ch.isspace():
+                            break  # prose follows, not a JSON payload -- leave it
+                    if json_at is None:
                         continue
-                    last = max(text.rfind("]"), text.rfind("}"))
-                    cut = last + 1 if last > json_at else len(text)
-                    return (text[: m.start()] + text[cut:]).strip(), None
-                if not marker_is_real:
-                    continue  # prose that merely looks JSON-ish -- leave it
-                if not validate(value):
-                    # Parsed but the wrong shape -- still strip a real trailer.
-                    return (text[: m.start()] + text[end:]).strip(), None
-                return text[: m.start()] + text[end:], value
-            return text, None
+                    # A real trailer is either at line start (the model's own
+                    # line) or written with some uppercase -- the markers are
+                    # emitted in caps per the prompt. An all-lowercase marker
+                    # mid-prose (e.g. "...a few suggestions: [...]") is prose and
+                    # is left untouched, even when the brackets are valid JSON.
+                    line_start = text.rfind("\n", 0, m.start()) + 1
+                    at_line_start = text[line_start : m.start()].strip() == ""
+                    marker_is_real = at_line_start or any(
+                        c.isupper() for c in m.group(0)
+                    )
+                    try:
+                        # raw_decode reads one JSON value and reports where it
+                        # ends, so a multi-line array/object is read in one shot.
+                        value, end = json.JSONDecoder().raw_decode(text, json_at)
+                    except json.JSONDecodeError:
+                        # The model mangled the JSON (smaller models sometimes
+                        # emit broken brackets). Excise from the marker through
+                        # the last bracket so raw JSON never reaches the user.
+                        if not marker_is_real:
+                            continue
+                        last = max(text.rfind("]"), text.rfind("}"))
+                        cut = last + 1 if last > json_at else len(text)
+                        text = (text[: m.start()] + text[cut:]).strip()
+                        break
+                    if not marker_is_real:
+                        continue  # prose that merely looks JSON-ish -- leave it
+                    if not validate(value):
+                        # Parsed but the wrong shape -- still strip a real trailer.
+                        text = (text[: m.start()] + text[end:]).strip()
+                        break
+                    # Merge repeated SCHEMA_UPDATE dicts (later keys win); for a
+                    # repeated list marker the last one wins.
+                    if isinstance(result, dict) and isinstance(value, dict):
+                        result = {**result, **value}
+                    else:
+                        result = value
+                    text = text[: m.start()] + text[end:]
+                    break
+                else:
+                    break  # no marker spliced this pass -- done
+            return text, result
 
         def _valid_schema(v: Any) -> bool:
             return isinstance(v, dict) and all(

--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -843,8 +843,10 @@ class AssistantAgent:
         it on its own line, and when they don't, a line-by-line scan leaves the
         raw JSON visible to the user. So we search the whole reply for each
         marker and decode the JSON value that follows it, wherever it is.
-        Markdown bold/italic around the marker and mixed case are tolerated; a
-        marker not followed by valid JSON is left untouched in the text.
+        Markdown bold/italic and mixed case are tolerated. An uppercase marker
+        (the real trailer) has its payload removed even when it will not parse,
+        so raw JSON never reaches the user; a lowercase or payload-less
+        "suggestions: ..." is treated as prose and left in place.
         """
         suggestions: List[SuggestionChip] = []
         schema_updates: Dict[str, Optional[str]] = {}
@@ -1068,9 +1070,8 @@ class AssistantAgent:
         The required read layout (paired/single) and library strategy are a
         property of the workflow, not a user choice -- so derive them from the
         catalog rather than relying on the model to emit a SCHEMA_UPDATE for a
-        field it (correctly) doesn't treat as user input. Always recompute when
-        a workflow is set so a workflow change refreshes the value; clear it
-        when no workflow is selected.
+        field it (correctly) doesn't treat as user input. Recompute whenever a
+        workflow is set so a workflow change refreshes the value.
         """
         if schema.workflow.status != FieldStatus.FILLED:
             return
@@ -1086,54 +1087,37 @@ class AssistantAgent:
         self, workflow_ref: Optional[str]
     ) -> Optional[tuple[str, str]]:
         """Return (display label, detail) for the data a workflow expects from
-        the user, read from its input parameters. Sequencing-read workflows
-        report the layout (PAIRED/SINGLE, encoded in the variable name) plus any
-        library strategy from a data_requirements block. Workflows that instead
-        consume an assembled genome (no reads, an ASSEMBLY_FASTA_URL input --
-        e.g. genome annotation) report that. Returns None when neither applies."""
-        if not workflow_ref:
+        the user, or None. Read workflows report the layout plus any library
+        strategy; workflows that consume an assembled genome report that."""
+        wf = self._workflow_by_ref(workflow_ref)
+        if wf is None:
             return None
-        for cat in self.catalog.workflows_by_category:
-            for wf in cat.get("workflows", []):
-                if workflow_ref not in (wf.get("trsId"), wf.get("iwcId")):
-                    continue
-                for p in wf.get("parameters", []):
-                    variable = p.get("variable")
-                    if variable not in (
-                        "SANGER_READ_RUN_PAIRED",
-                        "SANGER_READ_RUN_SINGLE",
-                    ):
-                        continue
-                    req = p.get("data_requirements") or {}
-                    layout = req.get("library_layout") or (
-                        "PAIRED" if variable == "SANGER_READ_RUN_PAIRED" else "SINGLE"
-                    )
-                    layout_label = {
-                        "PAIRED": "Paired-end",
-                        "SINGLE": "Single-end",
-                    }.get(layout, layout)
-                    strategy = req.get("library_strategy") or req.get("library_source")
-                    if isinstance(strategy, list):
-                        strategy_label = "/".join(str(s) for s in strategy)
-                    else:
-                        strategy_label = strategy
-                    if strategy_label:
-                        value = f"{layout_label} {strategy_label} reads"
-                    else:
-                        value = f"{layout_label} sequencing reads"
-                    return value, "Required by the selected workflow"
-                # No sequencing-read input: workflows that consume an assembled
-                # genome directly (e.g. genome annotation) characterise their
-                # input as a FASTA assembly.
-                if any(
-                    p.get("variable") == "ASSEMBLY_FASTA_URL"
-                    for p in wf.get("parameters", [])
-                ):
-                    return (
-                        "Assembled genome (FASTA)",
-                        "Required by the selected workflow",
-                    )
-                return None
+        params = wf.get("parameters", [])
+        for p in params:
+            variable = p.get("variable")
+            if variable not in ("SANGER_READ_RUN_PAIRED", "SANGER_READ_RUN_SINGLE"):
+                continue
+            req = p.get("data_requirements") or {}
+            layout = req.get("library_layout") or (
+                "PAIRED" if variable == "SANGER_READ_RUN_PAIRED" else "SINGLE"
+            )
+            layout_label = {"PAIRED": "Paired-end", "SINGLE": "Single-end"}.get(
+                layout, layout
+            )
+            strategy = req.get("library_strategy") or req.get("library_source")
+            if isinstance(strategy, list):
+                strategy_label = "/".join(str(s) for s in strategy)
+            else:
+                strategy_label = strategy
+            if strategy_label:
+                value = f"{layout_label} {strategy_label} reads"
+            else:
+                value = f"{layout_label} sequencing reads"
+            return value, "Required by the selected workflow"
+        # No sequencing-read input: workflows that consume an assembled genome
+        # directly (e.g. genome annotation) characterise their input as a FASTA.
+        if any(p.get("variable") == "ASSEMBLY_FASTA_URL" for p in params):
+            return "Assembled genome (FASTA)", "Required by the selected workflow"
         return None
 
     def _reflect_gene_annotation_requirement(self, schema: AnalysisSchema) -> None:
@@ -1179,19 +1163,23 @@ class AssistantAgent:
             return url
         return None
 
-    def _workflow_requires_gene_model(self, workflow_ref: Optional[str]) -> bool:
-        """True when the workflow (matched by trsId or iwcId) takes a
-        GENE_MODEL_URL parameter."""
+    def _workflow_by_ref(self, workflow_ref: Optional[str]) -> Optional[Dict[str, Any]]:
+        """Return the catalog workflow dict matched by trsId or iwcId, or None."""
         if not workflow_ref:
-            return False
+            return None
         for cat in self.catalog.workflows_by_category:
             for wf in cat.get("workflows", []):
                 if workflow_ref in (wf.get("trsId"), wf.get("iwcId")):
-                    return any(
-                        p.get("variable") == "GENE_MODEL_URL"
-                        for p in wf.get("parameters", [])
-                    )
-        return False
+                    return wf
+        return None
+
+    def _workflow_requires_gene_model(self, workflow_ref: Optional[str]) -> bool:
+        """True when the workflow (matched by trsId or iwcId) takes a
+        GENE_MODEL_URL parameter."""
+        wf = self._workflow_by_ref(workflow_ref)
+        return wf is not None and any(
+            p.get("variable") == "GENE_MODEL_URL" for p in wf.get("parameters", [])
+        )
 
     def _find_assembly_accession(
         self, value: str, schema: AnalysisSchema

--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -914,10 +914,14 @@ class AssistantAgent:
                         region_end = len(text)
                         for bm in _TRAILER_MARKER.finditer(text, m.end()):
                             bls = text.rfind("\n", 0, bm.start()) + 1
-                            # Only a trailer on its own line bounds the reach; a
-                            # marker word mid-line (e.g. inside a JSON string) is
-                            # not a real boundary.
-                            if text[bls : bm.start()].strip() == "":
+                            if text[bls : bm.start()].strip() != "":
+                                continue  # not on its own line
+                            # A real boundary also needs trailer syntax: after
+                            # the keyword (optional colon/bold/space) a JSON
+                            # opener. A marker word that only starts a line inside
+                            # a malformed string is not a boundary.
+                            after = text[bm.end() :].lstrip(" \t:*")
+                            if after[:1] in ("[", "{"):
                                 region_end = bm.start()
                                 break
                         text = (text[: m.start()] + text[region_end:]).strip()
@@ -925,8 +929,13 @@ class AssistantAgent:
                     if not marker_is_real:
                         continue  # prose that merely looks JSON-ish -- leave it
                     if not validate(value):
-                        # Parsed but the wrong shape -- still strip a real trailer.
-                        text = (text[: m.start()] + text[end:]).strip()
+                        # Parsed but the wrong shape -- strip the marker through
+                        # its own line so trailing junk (a second object, extra
+                        # tokens) after the parsed value can't leak.
+                        line_end = text.find("\n", end)
+                        if line_end == -1:
+                            line_end = len(text)
+                        text = (text[: m.start()] + text[line_end:]).strip()
                         break
                     # Merge repeated SCHEMA_UPDATE dicts (later keys win); for a
                     # repeated list marker the last one wins.
@@ -1113,9 +1122,11 @@ class AssistantAgent:
                     field.detail = self._find_workflow_trs_id(workflow_value)
                 if not field.detail:
                     # Named a workflow we can't map to a visible (assembly-scope)
-                    # catalog entry -- don't commit it FILLED with no detail, so
-                    # the tracker stays honest and no handoff fires on a phantom
-                    # workflow (Codex #10).
+                    # catalog entry. Clear the field rather than commit a phantom
+                    # or silently keep a stale prior workflow the user was trying
+                    # to change -- either would let a handoff fire on the wrong
+                    # workflow (Codex).
+                    setattr(schema, key, SchemaField())
                     continue
 
             setattr(schema, key, field)

--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -1050,11 +1050,10 @@ class AssistantAgent:
         """Apply LLM-emitted schema updates to the current schema.
 
         Values of None clear the field back to EMPTY (supports mid-conversation
-        corrections when the user changes their mind).
+        corrections when the user changes their mind). The catalog-derived fields
+        are reconciled on every call -- even with no updates -- so a restored
+        session carrying stale derived state is corrected on the next turn.
         """
-        if not updates:
-            return current
-
         schema = current.model_copy(deep=True)
         valid_fields = {
             "organism",
@@ -1108,6 +1107,12 @@ class AssistantAgent:
                         break
                 if not field.detail:
                     field.detail = self._find_workflow_trs_id(workflow_value)
+                if not field.detail:
+                    # Named a workflow we can't map to a visible (assembly-scope)
+                    # catalog entry -- don't commit it FILLED with no detail, so
+                    # the tracker stays honest and no handoff fires on a phantom
+                    # workflow (Codex #10).
+                    continue
 
             setattr(schema, key, field)
 
@@ -1226,11 +1231,18 @@ class AssistantAgent:
         return None
 
     def _workflow_by_ref(self, workflow_ref: Optional[str]) -> Optional[Dict[str, Any]]:
-        """Return the catalog workflow dict matched by trsId or iwcId, or None."""
+        """Return the catalog workflow dict matched by trsId or iwcId, or None.
+
+        Only ASSEMBLY-scope workflows are visible to the assistant, so an
+        organism/comparative-scope ref -- e.g. one carried in a restored session
+        -- resolves to None and never drives derivation or handoff (Codex #5).
+        """
         if not workflow_ref:
             return None
         for cat in self.catalog.workflows_by_category:
             for wf in cat.get("workflows", []):
+                if not _is_assembly_scope(wf):
+                    continue
                 if workflow_ref in (wf.get("trsId"), wf.get("iwcId")):
                     return wf
         return None

--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -78,6 +78,7 @@ ASSISTANT_RUN_TIMEOUT_SECONDS = 105.0
 # recompute or clear it on a workflow/assembly change without stomping a value
 # set elsewhere.
 _DATA_CHARACTERISTICS_DERIVED_DETAIL = "Required by the selected workflow"
+_GENE_ANNOTATION_AUTO_DETAIL = "Auto-selected from the assembly"
 
 
 class AssistantTimeoutError(RuntimeError):
@@ -1138,29 +1139,41 @@ class AssistantAgent:
         """Reconcile gene annotation against the workflow and assembly (#1324/#1331).
 
         When the workflow requires a GTF: if the selected assembly ships a gene
-        model, fill it (the setup step resolves that URL automatically, and the
-        user can still override); otherwise surface it as needing attention so
-        the panel doesn't render a required annotation as "Optional". Workflows
-        that take no GTF leave it empty/optional. A filled annotation set
-        elsewhere (e.g. an explicit user choice) is left untouched.
+        model, auto-fill it (setup resolves the URL automatically, and the user
+        can still override); otherwise surface it as needing attention so the
+        panel doesn't render a required annotation as "Optional". A workflow that
+        takes no GTF, or no workflow at all, clears the derived state.
+
+        Only this field's own derived output (auto-selected or needs-attention)
+        is recomputed -- so switching to an assembly with no gene model demotes a
+        previously auto-selected GTF, and clearing the workflow drops it. An
+        explicit user/model choice (FILLED without the auto-selected marker) is
+        left untouched.
         """
-        if (
-            schema.workflow.status != FieldStatus.FILLED
-            or schema.gene_annotation.status == FieldStatus.FILLED
-        ):
+        gene_annotation = schema.gene_annotation
+        auto_selected = gene_annotation.detail == _GENE_ANNOTATION_AUTO_DETAIL
+        if gene_annotation.status == FieldStatus.FILLED and not auto_selected:
+            return
+        derived_state = (
+            auto_selected or gene_annotation.status == FieldStatus.NEEDS_ATTENTION
+        )
+
+        if schema.workflow.status != FieldStatus.FILLED:
+            if derived_state:
+                schema.gene_annotation = SchemaField()
             return
         if self._workflow_requires_gene_model(schema.workflow.detail):
             if self._assembly_gene_model_url(schema):
                 schema.gene_annotation = SchemaField(
                     value="Reference GTF",
                     status=FieldStatus.FILLED,
-                    detail="Auto-selected from the assembly",
+                    detail=_GENE_ANNOTATION_AUTO_DETAIL,
                 )
             else:
-                schema.gene_annotation.status = FieldStatus.NEEDS_ATTENTION
-        elif schema.gene_annotation.status == FieldStatus.NEEDS_ATTENTION:
-            # Workflow changed to one that no longer needs a GTF.
-            schema.gene_annotation.status = FieldStatus.EMPTY
+                schema.gene_annotation = SchemaField(status=FieldStatus.NEEDS_ATTENTION)
+        elif derived_state:
+            # Workflow no longer needs a GTF -- drop the derived state.
+            schema.gene_annotation = SchemaField()
 
     def _assembly_gene_model_url(self, schema: AnalysisSchema) -> Optional[str]:
         """Return the selected assembly's gene model URL, or None when the

--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -962,10 +962,10 @@ class AssistantAgent:
                 for k, val in v.items()
             )
 
-        # Extract SCHEMA_UPDATE before SUGGESTIONS. A malformed SUGGESTIONS
-        # trailer is excised through the last bracket in the reply, which would
-        # swallow a SCHEMA_UPDATE that follows it. Schema state matters more
-        # than cosmetic chips, so pull it out first.
+        # Extract SCHEMA_UPDATE before SUGGESTIONS: schema state matters more
+        # than cosmetic chips, so if the two ever interfere the schema wins. (A
+        # malformed SUGGESTIONS is excised only up to the next real trailer, so
+        # pulling SCHEMA_UPDATE out first keeps it safe regardless of ordering.)
         text, parsed = _extract(text, "schema_update", _valid_schema)
         if parsed is not None:
             schema_updates = parsed
@@ -1131,10 +1131,22 @@ class AssistantAgent:
 
             setattr(schema, key, field)
 
+        self._reflect_workflow(schema)
         self._reflect_data_characteristics(schema)
         self._reflect_gene_annotation_requirement(schema)
 
         return schema
+
+    def _reflect_workflow(self, schema: AnalysisSchema) -> None:
+        """Drop a FILLED workflow whose detail no longer maps to a visible
+        catalog entry -- e.g. a restored session carrying a stale or
+        organism-scope workflow detail. Runs before the derived reflectors so
+        the tracker can't complete or hand off on a phantom workflow (Copilot)."""
+        if (
+            schema.workflow.status == FieldStatus.FILLED
+            and self._workflow_by_ref(schema.workflow.detail) is None
+        ):
+            schema.workflow = SchemaField()
 
     def _reflect_data_characteristics(self, schema: AnalysisSchema) -> None:
         """Derive data characteristics from the selected workflow's inputs.

--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -239,10 +239,14 @@ for catalog data.
 
 ## Schema updates
 
-When the user **makes a decision** (selects an organism, picks an assembly, \
-chooses an analysis type, etc.), emit a SCHEMA_UPDATE line at the end of your \
-response with the fields that changed. Only include fields where the user has \
-committed to a choice — do NOT set fields just because you listed options.
+On every turn where the user has committed to one or more choices so far in \
+this conversation, emit a SCHEMA_UPDATE line at the end of your response. \
+Include **all** fields the user has committed to up to now — re-emit the fields \
+you set on earlier turns, not only the one that changed this turn. Re-emitting \
+the already-known fields every turn is required: it keeps the analysis tracker \
+in sync even when an earlier turn left one out. Only include a field once the \
+user has actually committed to a choice — do NOT set fields just because you \
+listed options.
 
 Format: a JSON object on its own line prefixed with "SCHEMA_UPDATE:". \
 Valid keys: organism, assembly, analysis_type, workflow, data_source, \
@@ -264,9 +268,9 @@ Example — user switches from RNA-seq to variant calling:
 SCHEMA_UPDATE: {"analysis_type": "Variant Calling", "workflow": null, \
 "data_characteristics": null, "gene_annotation": null}
 
-Only emit this when the user has actually chosen or changed something. If the \
-conversation is purely exploratory (listing options, answering questions), do \
-NOT emit it.
+Emit this line on every turn once at least one field is committed, re-stating \
+all committed fields. Only when the user has committed to nothing at all yet \
+(purely browsing or asking questions) should you omit it entirely.
 
 ## Suggestion chips
 

--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -895,19 +895,23 @@ class AssistantAgent:
                 return text[: m.start()] + text[end:], value
             return text, None
 
-        text, parsed = _extract(text, "suggestions", lambda v: isinstance(v, list))
-        if parsed is not None:
-            suggestions = self._build_suggestion_chips(parsed)
-
         def _valid_schema(v: Any) -> bool:
             return isinstance(v, dict) and all(
                 isinstance(k, str) and (isinstance(val, str) or val is None)
                 for k, val in v.items()
             )
 
+        # Extract SCHEMA_UPDATE before SUGGESTIONS. A malformed SUGGESTIONS
+        # trailer is excised through the last bracket in the reply, which would
+        # swallow a SCHEMA_UPDATE that follows it. Schema state matters more
+        # than cosmetic chips, so pull it out first.
         text, parsed = _extract(text, "schema_update", _valid_schema)
         if parsed is not None:
             schema_updates = parsed
+
+        text, parsed = _extract(text, "suggestions", lambda v: isinstance(v, list))
+        if parsed is not None:
+            suggestions = self._build_suggestion_chips(parsed)
 
         # Tidy whitespace left where an inline marker was spliced out.
         text = re.sub(r"[ \t]+\n", "\n", text)

--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -836,53 +836,81 @@ class AssistantAgent:
     def _parse_structured_output(
         self, raw_reply: str
     ) -> tuple[str, List[SuggestionChip], Dict[str, Optional[str]]]:
-        """Extract SCHEMA_UPDATE and SUGGESTIONS lines from the reply.
+        """Extract SCHEMA_UPDATE and SUGGESTIONS from the reply.
 
-        Handles common LLM formatting variations: bold markdown wrapping,
-        mixed case, extra whitespace around the prefix.
+        The marker may sit at the start of a line, inline after prose, or with
+        its JSON value spanning several lines -- smaller models don't always put
+        it on its own line, and when they don't, a line-by-line scan leaves the
+        raw JSON visible to the user. So we search the whole reply for each
+        marker and decode the JSON value that follows it, wherever it is.
+        Markdown bold/italic around the marker and mixed case are tolerated; a
+        marker not followed by valid JSON is left untouched in the text.
         """
         suggestions: List[SuggestionChip] = []
         schema_updates: Dict[str, Optional[str]] = {}
-        reply_lines = []
+        text = raw_reply
 
-        # Match SUGGESTIONS or SCHEMA_UPDATE with optional markdown bold/italic.
-        # The colon may be inside or outside the bold markers:
-        #   SUGGESTIONS: ...  |  **SUGGESTIONS:** ...  |  **SUGGESTIONS**: ...
-        suggestions_re = re.compile(
-            r"^\s*\*{0,2}suggestions:?\*{0,2}:?\s*", re.IGNORECASE
-        )
-        schema_re = re.compile(r"^\s*\*{0,2}schema_update:?\*{0,2}:?\s*", re.IGNORECASE)
-
-        for line in raw_reply.rstrip().split("\n"):
-            s_match = suggestions_re.match(line)
-            u_match = schema_re.match(line)
-            if s_match:
+        def _extract(text: str, keyword: str, validate) -> tuple[str, Any]:
+            # Optional **bold**/italic and colon on either side, anywhere in the
+            # text (not anchored to line start). \b stops it matching mid-word.
+            marker = re.compile(
+                r"\*{0,2}\b" + keyword + r"\b:?\*{0,2}:?[ \t]*", re.IGNORECASE
+            )
+            for m in marker.finditer(text):
+                rest = text[m.end() :]
+                json_at = None
+                for i, ch in enumerate(rest):
+                    if ch in "[{":
+                        json_at = m.end() + i
+                        break
+                    if not ch.isspace():
+                        break  # prose follows, not a JSON payload -- leave it
+                if json_at is None:
+                    continue
+                # The real markers are emitted in uppercase per the prompt, so
+                # only an uppercase marker is excised when its payload won't
+                # parse -- a mid-prose lowercase "suggestions: [...]" that just
+                # looks JSON-ish is left untouched rather than stripped as prose.
+                marker_is_real = keyword.upper() in m.group(0)
                 try:
-                    json_str = line[s_match.end() :].strip()
-                    items = json.loads(json_str)
-                    if isinstance(items, list):
-                        suggestions = self._build_suggestion_chips(items)
-                    else:
-                        reply_lines.append(line)
-                except (json.JSONDecodeError, TypeError):
-                    reply_lines.append(line)
-            elif u_match:
-                try:
-                    json_str = line[u_match.end() :].strip()
-                    data = json.loads(json_str)
-                    if isinstance(data, dict) and all(
-                        isinstance(k, str) and (isinstance(v, str) or v is None)
-                        for k, v in data.items()
-                    ):
-                        schema_updates = data
-                    else:
-                        reply_lines.append(line)
-                except (json.JSONDecodeError, TypeError):
-                    reply_lines.append(line)
-            else:
-                reply_lines.append(line)
+                    # raw_decode reads one JSON value and reports where it ends,
+                    # so a multi-line array/object is handled in one shot.
+                    value, end = json.JSONDecoder().raw_decode(text, json_at)
+                except json.JSONDecodeError:
+                    # The model mangled the JSON (smaller models sometimes emit
+                    # broken brackets). Excise from the marker through the last
+                    # bracket so raw JSON never reaches the user.
+                    if not marker_is_real:
+                        continue
+                    last = max(text.rfind("]"), text.rfind("}"))
+                    cut = last + 1 if last > json_at else len(text)
+                    return (text[: m.start()] + text[cut:]).strip(), None
+                if not validate(value):
+                    # Parsed but the wrong shape -- still strip a real trailer.
+                    if not marker_is_real:
+                        continue
+                    return (text[: m.start()] + text[end:]).strip(), None
+                return text[: m.start()] + text[end:], value
+            return text, None
 
-        return "\n".join(reply_lines).rstrip(), suggestions, schema_updates
+        text, parsed = _extract(text, "suggestions", lambda v: isinstance(v, list))
+        if parsed is not None:
+            suggestions = self._build_suggestion_chips(parsed)
+
+        def _valid_schema(v: Any) -> bool:
+            return isinstance(v, dict) and all(
+                isinstance(k, str) and (isinstance(val, str) or val is None)
+                for k, val in v.items()
+            )
+
+        text, parsed = _extract(text, "schema_update", _valid_schema)
+        if parsed is not None:
+            schema_updates = parsed
+
+        # Tidy whitespace left where an inline marker was spliced out.
+        text = re.sub(r"[ \t]+\n", "\n", text)
+        text = re.sub(r"\n{3,}", "\n\n", text)
+        return text.strip(), suggestions, schema_updates
 
     def _build_suggestion_chips(self, items: List[Any]) -> List[SuggestionChip]:
         """Build suggestion chips, dropping any that reference data we don't have.

--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -73,6 +73,12 @@ MAX_HISTORY_MESSAGES = 40
 MAX_USER_FACING_MESSAGES = 100
 ASSISTANT_RUN_TIMEOUT_SECONDS = 105.0
 
+# Detail marker stamped on tracker fields the catalog derives (vs. an explicit
+# user/model value). Lets the reconcilers recognise their own prior output and
+# recompute or clear it on a workflow/assembly change without stomping a value
+# set elsewhere.
+_DATA_CHARACTERISTICS_DERIVED_DETAIL = "Required by the selected workflow"
+
 
 class AssistantTimeoutError(RuntimeError):
     """Raised when the assistant run exceeds the server-side timeout."""
@@ -1075,17 +1081,21 @@ class AssistantAgent:
         property of the workflow, not a user choice -- so derive them from the
         catalog rather than relying on the model to emit a SCHEMA_UPDATE for a
         field it (correctly) doesn't treat as user input. Recompute whenever a
-        workflow is set so a workflow change refreshes the value.
+        workflow is set, and clear a previously derived value when the workflow
+        is cleared or swapped for one that supplies no characteristics, so a
+        stale layout can't linger or falsely complete the schema. A value set
+        elsewhere (its detail marker won't match) is left alone.
         """
-        if schema.workflow.status != FieldStatus.FILLED:
-            return
-        derived = self._data_characteristics_for_workflow(schema.workflow.detail)
-        if derived is None:
-            return
-        value, detail = derived
-        schema.data_characteristics = SchemaField(
-            value=value, status=FieldStatus.FILLED, detail=detail
-        )
+        derived = None
+        if schema.workflow.status == FieldStatus.FILLED:
+            derived = self._data_characteristics_for_workflow(schema.workflow.detail)
+        if derived is not None:
+            value, detail = derived
+            schema.data_characteristics = SchemaField(
+                value=value, status=FieldStatus.FILLED, detail=detail
+            )
+        elif schema.data_characteristics.detail == _DATA_CHARACTERISTICS_DERIVED_DETAIL:
+            schema.data_characteristics = SchemaField()
 
     def _data_characteristics_for_workflow(
         self, workflow_ref: Optional[str]
@@ -1117,11 +1127,11 @@ class AssistantAgent:
                 value = f"{layout_label} {strategy_label} reads"
             else:
                 value = f"{layout_label} sequencing reads"
-            return value, "Required by the selected workflow"
+            return value, _DATA_CHARACTERISTICS_DERIVED_DETAIL
         # No sequencing-read input: workflows that consume an assembled genome
         # directly (e.g. genome annotation) characterise their input as a FASTA.
         if any(p.get("variable") == "ASSEMBLY_FASTA_URL" for p in params):
-            return "Assembled genome (FASTA)", "Required by the selected workflow"
+            return "Assembled genome (FASTA)", _DATA_CHARACTERISTICS_DERIVED_DETAIL
         return None
 
     def _reflect_gene_annotation_requirement(self, schema: AnalysisSchema) -> None:

--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -1105,10 +1105,14 @@ class AssistantAgent:
         return None
 
     def _reflect_gene_annotation_requirement(self, schema: AnalysisSchema) -> None:
-        """Mark gene annotation as needing attention when the selected workflow
-        actually requires a GTF, so the panel doesn't render a required
-        annotation as "Optional" (#1324/#1331). Workflows that take no GTF leave
-        it empty/optional; a filled annotation is left untouched.
+        """Reconcile gene annotation against the workflow and assembly (#1324/#1331).
+
+        When the workflow requires a GTF: if the selected assembly ships a gene
+        model, fill it (the setup step resolves that URL automatically, and the
+        user can still override); otherwise surface it as needing attention so
+        the panel doesn't render a required annotation as "Optional". Workflows
+        that take no GTF leave it empty/optional. A filled annotation set
+        elsewhere (e.g. an explicit user choice) is left untouched.
         """
         if (
             schema.workflow.status != FieldStatus.FILLED
@@ -1116,10 +1120,32 @@ class AssistantAgent:
         ):
             return
         if self._workflow_requires_gene_model(schema.workflow.detail):
-            schema.gene_annotation.status = FieldStatus.NEEDS_ATTENTION
+            if self._assembly_gene_model_url(schema):
+                schema.gene_annotation = SchemaField(
+                    value="Reference GTF",
+                    status=FieldStatus.FILLED,
+                    detail="Auto-selected from the assembly",
+                )
+            else:
+                schema.gene_annotation.status = FieldStatus.NEEDS_ATTENTION
         elif schema.gene_annotation.status == FieldStatus.NEEDS_ATTENTION:
             # Workflow changed to one that no longer needs a GTF.
             schema.gene_annotation.status = FieldStatus.EMPTY
+
+    def _assembly_gene_model_url(self, schema: AnalysisSchema) -> Optional[str]:
+        """Return the selected assembly's gene model URL, or None when the
+        assembly is unknown or has no gene model (catalog uses the string
+        "None" for the latter)."""
+        accession = schema.assembly.detail
+        if not accession:
+            return None
+        details = self.catalog.get_assembly_details(accession)
+        if not details:
+            return None
+        url = details.get("gene_model_url")
+        if url and url != "None":
+            return url
+        return None
 
     def _workflow_requires_gene_model(self, workflow_ref: Optional[str]) -> bool:
         """True when the workflow (matched by trsId or iwcId) takes a

--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -73,10 +73,9 @@ MAX_HISTORY_MESSAGES = 40
 MAX_USER_FACING_MESSAGES = 100
 ASSISTANT_RUN_TIMEOUT_SECONDS = 105.0
 
-# Detail marker stamped on tracker fields the catalog derives (vs. an explicit
-# user/model value). Lets the reconcilers recognise their own prior output and
-# recompute or clear it on a workflow/assembly change without stomping a value
-# set elsewhere.
+# Human-readable "detail" labels for the tracker fields the catalog derives
+# (data characteristics, gene annotation). These fields are always recomputed
+# from the workflow/assembly, so the labels are informational only.
 _DATA_CHARACTERISTICS_DERIVED_DETAIL = "Required by the selected workflow"
 _GENE_ANNOTATION_AUTO_DETAIL = "Auto-selected from the assembly"
 
@@ -1076,16 +1075,14 @@ class AssistantAgent:
         return schema
 
     def _reflect_data_characteristics(self, schema: AnalysisSchema) -> None:
-        """Fill data characteristics from the selected workflow's read inputs.
+        """Derive data characteristics from the selected workflow's inputs.
 
-        The required read layout (paired/single) and library strategy are a
-        property of the workflow, not a user choice -- so derive them from the
-        catalog rather than relying on the model to emit a SCHEMA_UPDATE for a
-        field it (correctly) doesn't treat as user input. Recompute whenever a
-        workflow is set, and clear a previously derived value when the workflow
-        is cleared or swapped for one that supplies no characteristics, so a
-        stale layout can't linger or falsely complete the schema. A value set
-        elsewhere (its detail marker won't match) is left alone.
+        Read layout (paired/single) and library strategy are a property of the
+        workflow, not a user choice, so the catalog is authoritative here: the
+        model may re-emit this field, but its value is always recomputed from
+        the workflow, never trusted. Recomputing from scratch every apply means
+        a workflow change (or clear) can't leave a stale value -- and a
+        re-emitted value can't block reconciliation.
         """
         derived = None
         if schema.workflow.status == FieldStatus.FILLED:
@@ -1095,7 +1092,7 @@ class AssistantAgent:
             schema.data_characteristics = SchemaField(
                 value=value, status=FieldStatus.FILLED, detail=detail
             )
-        elif schema.data_characteristics.detail == _DATA_CHARACTERISTICS_DERIVED_DETAIL:
+        else:
             schema.data_characteristics = SchemaField()
 
     def _data_characteristics_for_workflow(
@@ -1138,29 +1135,20 @@ class AssistantAgent:
     def _reflect_gene_annotation_requirement(self, schema: AnalysisSchema) -> None:
         """Reconcile gene annotation against the workflow and assembly (#1324/#1331).
 
-        When the workflow requires a GTF: if the selected assembly ships a gene
-        model, auto-fill it (setup resolves the URL automatically, and the user
-        can still override); otherwise surface it as needing attention so the
-        panel doesn't render a required annotation as "Optional". A workflow that
-        takes no GTF, or no workflow at all, clears the derived state.
+        Whether an annotation is needed, and whether the assembly can supply it,
+        is a property of the workflow+assembly, not a user choice (the annotation
+        source is picked later at workflow setup). The catalog is authoritative:
+        the model may re-emit this field, but it's always recomputed, never
+        trusted. Recompute every apply:
 
-        Only this field's own derived output (auto-selected or needs-attention)
-        is recomputed -- so switching to an assembly with no gene model demotes a
-        previously auto-selected GTF, and clearing the workflow drops it. An
-        explicit user/model choice (FILLED without the auto-selected marker) is
-        left untouched.
+        - workflow needs a GTF and the assembly ships a gene model -> auto-fill
+          (setup resolves the URL automatically);
+        - workflow needs a GTF but the assembly has none -> needs attention, so
+          the panel doesn't render a required annotation as "Optional";
+        - no GTF required, or no workflow -> empty.
         """
-        gene_annotation = schema.gene_annotation
-        auto_selected = gene_annotation.detail == _GENE_ANNOTATION_AUTO_DETAIL
-        if gene_annotation.status == FieldStatus.FILLED and not auto_selected:
-            return
-        derived_state = (
-            auto_selected or gene_annotation.status == FieldStatus.NEEDS_ATTENTION
-        )
-
         if schema.workflow.status != FieldStatus.FILLED:
-            if derived_state:
-                schema.gene_annotation = SchemaField()
+            schema.gene_annotation = SchemaField()
             return
         if self._workflow_requires_gene_model(schema.workflow.detail):
             if self._assembly_gene_model_url(schema):
@@ -1171,8 +1159,7 @@ class AssistantAgent:
                 )
             else:
                 schema.gene_annotation = SchemaField(status=FieldStatus.NEEDS_ATTENTION)
-        elif derived_state:
-            # Workflow no longer needs a GTF -- drop the derived state.
+        else:
             schema.gene_annotation = SchemaField()
 
     def _assembly_gene_model_url(self, schema: AnalysisSchema) -> Optional[str]:

--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -904,12 +904,11 @@ class AssistantAgent:
                         value, end = json.JSONDecoder().raw_decode(text, json_at)
                     except json.JSONDecodeError:
                         # The model mangled the JSON (smaller models sometimes
-                        # emit broken brackets). Excise from the marker through
-                        # the last bracket so raw JSON never reaches the user --
-                        # but bound the reach to this marker's own payload: stop
-                        # at the next real trailer (on its own line) so a
-                        # broken SCHEMA_UPDATE can't swallow the SUGGESTIONS the
-                        # prompt places after it.
+                        # emit broken brackets). Excise the whole bounded region
+                        # -- from the marker to the next real trailer (on its own
+                        # line), else end of reply -- so raw JSON never reaches
+                        # the user. Cutting at the "last bracket" instead could
+                        # stop at a ]/} inside a string literal and leak the tail.
                         if not marker_is_real:
                             continue
                         region_end = len(text)
@@ -917,17 +916,11 @@ class AssistantAgent:
                             bls = text.rfind("\n", 0, bm.start()) + 1
                             # Only a trailer on its own line bounds the reach; a
                             # marker word mid-line (e.g. inside a JSON string) is
-                            # not a real boundary, so we over-strip past it rather
-                            # than stop inside it and leak the tail.
+                            # not a real boundary.
                             if text[bls : bm.start()].strip() == "":
                                 region_end = bm.start()
                                 break
-                        last = max(
-                            text.rfind("]", json_at, region_end),
-                            text.rfind("}", json_at, region_end),
-                        )
-                        cut = last + 1 if last >= json_at else region_end
-                        text = (text[: m.start()] + text[cut:]).strip()
+                        text = (text[: m.start()] + text[region_end:]).strip()
                         break
                     if not marker_is_real:
                         continue  # prose that merely looks JSON-ish -- leave it

--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -1148,12 +1148,17 @@ class AssistantAgent:
             return None
         params = wf.get("parameters", [])
         for p in params:
-            variable = p.get("variable")
-            if variable not in ("SANGER_READ_RUN_PAIRED", "SANGER_READ_RUN_SINGLE"):
+            variable = p.get("variable") or ""
+            # Read inputs are SANGER_READ_RUN_* params: PAIRED/SINGLE plus the
+            # _FILE, FORWARD_FILE and REVERSE_FILE variants some workflows use
+            # (e.g. Flye, Shovill). Match the family, not the two exact names.
+            if not variable.startswith("SANGER_READ_RUN"):
                 continue
             req = p.get("data_requirements") or {}
+            # Prefer the declared layout; else infer from the name -- only the
+            # SINGLE variants are single-end, forward/reverse imply paired.
             layout = req.get("library_layout") or (
-                "PAIRED" if variable == "SANGER_READ_RUN_PAIRED" else "SINGLE"
+                "SINGLE" if "SINGLE" in variable else "PAIRED"
             )
             layout_label = {"PAIRED": "Paired-end", "SINGLE": "Single-end"}.get(
                 layout, layout

--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -1222,8 +1222,10 @@ class AssistantAgent:
 
         - workflow needs a GTF and the assembly ships a gene model -> auto-fill
           (setup resolves the URL automatically);
-        - workflow needs a GTF but the assembly has none -> needs attention, so
-          the panel doesn't render a required annotation as "Optional";
+        - workflow needs a GTF, an assembly is chosen but has none -> needs
+          attention, so the panel doesn't render a required annotation as
+          "Optional";
+        - workflow needs a GTF but no assembly chosen yet -> pending;
         - no GTF required, or no workflow -> empty.
         """
         if schema.workflow.status != FieldStatus.FILLED:
@@ -1236,8 +1238,19 @@ class AssistantAgent:
                     status=FieldStatus.FILLED,
                     detail=_GENE_ANNOTATION_AUTO_DETAIL,
                 )
+            elif schema.assembly.status == FieldStatus.FILLED:
+                # Assembly chosen but ships no gene model -- flag it (with a
+                # stable display value) so the panel doesn't render a required
+                # annotation as "Optional".
+                schema.gene_annotation = SchemaField(
+                    value="Reference GTF",
+                    status=FieldStatus.NEEDS_ATTENTION,
+                    detail="No gene model for the selected assembly",
+                )
             else:
-                schema.gene_annotation = SchemaField(status=FieldStatus.NEEDS_ATTENTION)
+                # Needs a GTF but no assembly chosen yet -- can't judge
+                # availability, so stay pending rather than flag attention early.
+                schema.gene_annotation = SchemaField()
         else:
             schema.gene_annotation = SchemaField()
 

--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -849,10 +849,11 @@ class AssistantAgent:
         it on its own line, and when they don't, a line-by-line scan leaves the
         raw JSON visible to the user. So we search the whole reply for each
         marker and decode the JSON value that follows it, wherever it is.
-        Markdown bold/italic and mixed case are tolerated. An uppercase marker
-        (the real trailer) has its payload removed even when it will not parse,
-        so raw JSON never reaches the user; a lowercase or payload-less
-        "suggestions: ..." is treated as prose and left in place.
+        Markdown bold/italic and mixed case are tolerated. A marker at line
+        start, or written with any uppercase, is a real trailer: its payload is
+        removed even when it will not parse, so raw JSON never reaches the user.
+        An all-lowercase marker mid-prose (e.g. "...a few suggestions: [...]") is
+        left in place as prose, even when its brackets are valid JSON.
         """
         suggestions: List[SuggestionChip] = []
         schema_updates: Dict[str, Optional[str]] = {}
@@ -875,11 +876,14 @@ class AssistantAgent:
                         break  # prose follows, not a JSON payload -- leave it
                 if json_at is None:
                     continue
-                # The real markers are emitted in uppercase per the prompt, so
-                # only an uppercase marker is excised when its payload won't
-                # parse -- a mid-prose lowercase "suggestions: [...]" that just
-                # looks JSON-ish is left untouched rather than stripped as prose.
-                marker_is_real = keyword.upper() in m.group(0)
+                # A real trailer is either at line start (the model's own line)
+                # or written with some uppercase -- the markers are emitted in
+                # caps per the prompt. An all-lowercase marker mid-prose (e.g.
+                # "...a few suggestions: [...]") is prose and is left untouched,
+                # even when the brackets happen to be valid JSON.
+                line_start = text.rfind("\n", 0, m.start()) + 1
+                at_line_start = text[line_start : m.start()].strip() == ""
+                marker_is_real = at_line_start or any(c.isupper() for c in m.group(0))
                 try:
                     # raw_decode reads one JSON value and reports where it ends,
                     # so a multi-line array/object is handled in one shot.
@@ -893,10 +897,10 @@ class AssistantAgent:
                     last = max(text.rfind("]"), text.rfind("}"))
                     cut = last + 1 if last > json_at else len(text)
                     return (text[: m.start()] + text[cut:]).strip(), None
+                if not marker_is_real:
+                    continue  # prose that merely looks JSON-ish -- leave it
                 if not validate(value):
                     # Parsed but the wrong shape -- still strip a real trailer.
-                    if not marker_is_real:
-                        continue
                     return (text[: m.start()] + text[end:]).strip(), None
                 return text[: m.start()] + text[end:], value
             return text, None

--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -1186,8 +1186,9 @@ class AssistantAgent:
 
     def _assembly_gene_model_url(self, schema: AnalysisSchema) -> Optional[str]:
         """Return the selected assembly's gene model URL, or None when the
-        assembly is unknown or has no gene model (catalog uses the string
-        "None" for the latter)."""
+        assembly is unknown or has no gene model. The catalog stores a missing
+        model as null (surfaced as Python None); a literal "None" string is also
+        treated as absent, defensively against a stringified null upstream."""
         accession = schema.assembly.detail
         if not accession:
             return None

--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -1025,9 +1025,84 @@ class AssistantAgent:
 
             setattr(schema, key, field)
 
+        self._reflect_data_characteristics(schema)
         self._reflect_gene_annotation_requirement(schema)
 
         return schema
+
+    def _reflect_data_characteristics(self, schema: AnalysisSchema) -> None:
+        """Fill data characteristics from the selected workflow's read inputs.
+
+        The required read layout (paired/single) and library strategy are a
+        property of the workflow, not a user choice -- so derive them from the
+        catalog rather than relying on the model to emit a SCHEMA_UPDATE for a
+        field it (correctly) doesn't treat as user input. Always recompute when
+        a workflow is set so a workflow change refreshes the value; clear it
+        when no workflow is selected.
+        """
+        if schema.workflow.status != FieldStatus.FILLED:
+            return
+        derived = self._data_characteristics_for_workflow(schema.workflow.detail)
+        if derived is None:
+            return
+        value, detail = derived
+        schema.data_characteristics = SchemaField(
+            value=value, status=FieldStatus.FILLED, detail=detail
+        )
+
+    def _data_characteristics_for_workflow(
+        self, workflow_ref: Optional[str]
+    ) -> Optional[tuple[str, str]]:
+        """Return (display label, detail) for the data a workflow expects from
+        the user, read from its input parameters. Sequencing-read workflows
+        report the layout (PAIRED/SINGLE, encoded in the variable name) plus any
+        library strategy from a data_requirements block. Workflows that instead
+        consume an assembled genome (no reads, an ASSEMBLY_FASTA_URL input --
+        e.g. genome annotation) report that. Returns None when neither applies."""
+        if not workflow_ref:
+            return None
+        for cat in self.catalog.workflows_by_category:
+            for wf in cat.get("workflows", []):
+                if workflow_ref not in (wf.get("trsId"), wf.get("iwcId")):
+                    continue
+                for p in wf.get("parameters", []):
+                    variable = p.get("variable")
+                    if variable not in (
+                        "SANGER_READ_RUN_PAIRED",
+                        "SANGER_READ_RUN_SINGLE",
+                    ):
+                        continue
+                    req = p.get("data_requirements") or {}
+                    layout = req.get("library_layout") or (
+                        "PAIRED" if variable == "SANGER_READ_RUN_PAIRED" else "SINGLE"
+                    )
+                    layout_label = {
+                        "PAIRED": "Paired-end",
+                        "SINGLE": "Single-end",
+                    }.get(layout, layout)
+                    strategy = req.get("library_strategy") or req.get("library_source")
+                    if isinstance(strategy, list):
+                        strategy_label = "/".join(str(s) for s in strategy)
+                    else:
+                        strategy_label = strategy
+                    if strategy_label:
+                        value = f"{layout_label} {strategy_label} reads"
+                    else:
+                        value = f"{layout_label} sequencing reads"
+                    return value, "Required by the selected workflow"
+                # No sequencing-read input: workflows that consume an assembled
+                # genome directly (e.g. genome annotation) characterise their
+                # input as a FASTA assembly.
+                if any(
+                    p.get("variable") == "ASSEMBLY_FASTA_URL"
+                    for p in wf.get("parameters", [])
+                ):
+                    return (
+                        "Assembled genome (FASTA)",
+                        "Required by the selected workflow",
+                    )
+                return None
+        return None
 
     def _reflect_gene_annotation_requirement(self, schema: AnalysisSchema) -> None:
         """Mark gene annotation as needing attention when the selected workflow

--- a/backend/api/pyproject.toml
+++ b/backend/api/pyproject.toml
@@ -33,6 +33,7 @@ dev = [
     "ruff>=0.13.0",
     "pydantic-evals>=1.0.0",
     "pyyaml>=6.0",
+    "hypothesis>=6.0",
 ]
 
 [build-system]

--- a/backend/api/tests/test_assistant_agent.py
+++ b/backend/api/tests/test_assistant_agent.py
@@ -193,6 +193,28 @@ class TestParseStructuredOutput:
         assert text == raw
         assert suggestions == []
 
+    def test_lowercase_prose_valid_json_left_as_prose(self, agent):
+        # A lowercase "suggestions:" mid-prose is prose, not a trailer -- even
+        # when the brackets are valid JSON it is left untouched and yields no
+        # chips (only a line-start or uppercase marker is a trailer).
+        raw = (
+            'I have a few suggestions: ["check the docs", "ask the forum"] '
+            "before you decide."
+        )
+        text, suggestions, _ = agent._parse_structured_output(raw)
+        assert text == raw
+        assert suggestions == []
+
+    def test_mixed_case_marker_wrong_shape_stripped(self, agent):
+        # A mixed-case "Schema_Update" is still a real (if mangled) trailer -- its
+        # wrong-shape payload must be excised, never left visible as raw JSON.
+        raw = 'Recorded it. Schema_Update: {"organism": 5833}'
+        text, _, updates = agent._parse_structured_output(raw)
+        assert updates == {}
+        assert "Schema_Update" not in text
+        assert "5833" not in text
+        assert text == "Recorded it."
+
     def test_schema_update_inline_after_prose(self, agent):
         # Same for SCHEMA_UPDATE emitted inline after prose.
         raw = 'Recorded it. SCHEMA_UPDATE: {"organism": "Plasmodium falciparum"}'

--- a/backend/api/tests/test_assistant_agent.py
+++ b/backend/api/tests/test_assistant_agent.py
@@ -596,9 +596,12 @@ class TestApplySchemaUpdates:
         )
         assert result.workflow.detail == "#workflow/github.com/iwc/rnaseq-pe/main"
 
-    def test_gene_annotation_needs_attention_when_workflow_requires_gtf(self, agent):
-        # A GTF-requiring workflow must not leave gene annotation looking optional
-        # (#1324/#1331) -- it should surface as needing attention.
+    def test_gene_annotation_pending_when_workflow_needs_gtf_but_no_assembly(
+        self, agent
+    ):
+        # A GTF-requiring workflow with no assembly chosen yet must stay pending,
+        # not prematurely flag attention -- availability can't be judged without
+        # an assembly (Copilot).
         agent.catalog.workflows_by_category = [
             {
                 "category": "TRANSCRIPTOMICS",
@@ -615,7 +618,7 @@ class TestApplySchemaUpdates:
             AnalysisSchema(), {"workflow": "RNA-Seq (rnaseq-pe)"}
         )
         assert result.workflow.status == FieldStatus.FILLED
-        assert result.gene_annotation.status == FieldStatus.NEEDS_ATTENTION
+        assert result.gene_annotation.status == FieldStatus.EMPTY
 
     def test_gene_annotation_stays_optional_when_workflow_has_no_gtf(self, agent):
         # A workflow with no GENE_MODEL_URL param leaves gene annotation empty so
@@ -986,6 +989,7 @@ class TestApplySchemaUpdates:
             schema, {"workflow": "Variant calling (var-pe)"}
         )
         assert result.gene_annotation.status == FieldStatus.NEEDS_ATTENTION
+        assert result.gene_annotation.value == "Reference GTF"
 
     def test_assembly_gene_model_url_treats_none_string_defensively(self, agent):
         # The catalog stores a missing gene model as null (-> Python None); the

--- a/backend/api/tests/test_assistant_agent.py
+++ b/backend/api/tests/test_assistant_agent.py
@@ -801,7 +801,7 @@ class TestApplySchemaUpdates:
                 ],
             }
         ]
-        agent.catalog.get_assembly_details.return_value = {"gene_model_url": "None"}
+        agent.catalog.get_assembly_details.return_value = {"gene_model_url": None}
         schema = AnalysisSchema(
             assembly=SchemaField(
                 value="Some assembly GCF_999999999.1",
@@ -813,6 +813,20 @@ class TestApplySchemaUpdates:
             schema, {"workflow": "Variant calling (var-pe)"}
         )
         assert result.gene_annotation.status == FieldStatus.NEEDS_ATTENTION
+
+    def test_assembly_gene_model_url_treats_none_string_defensively(self, agent):
+        # The catalog stores a missing gene model as null (-> Python None); the
+        # lookup also treats a literal "None" string as absent, guarding against
+        # a stringified null upstream.
+        agent.catalog.get_assembly_details.return_value = {"gene_model_url": "None"}
+        schema = AnalysisSchema(
+            assembly=SchemaField(
+                value="A GCF_000000001.1",
+                detail="GCF_000000001.1",
+                status=FieldStatus.FILLED,
+            )
+        )
+        assert agent._assembly_gene_model_url(schema) is None
 
     def test_gene_annotation_reevaluated_when_assembly_loses_gene_model(self, agent):
         # An auto-selected GTF must be re-evaluated when the user switches to an
@@ -832,7 +846,7 @@ class TestApplySchemaUpdates:
         agent.catalog.get_assembly_details.side_effect = lambda acc: (
             {"gene_model_url": "https://example.org/genes.gtf.gz"}
             if acc == "GCF_000002765.6"
-            else {"gene_model_url": "None"}
+            else {"gene_model_url": None}
         )
         schema = AnalysisSchema(
             assembly=SchemaField(
@@ -902,7 +916,7 @@ class TestApplySchemaUpdates:
         agent.catalog.get_assembly_details.side_effect = lambda acc: (
             {"gene_model_url": "https://example.org/genes.gtf.gz"}
             if acc == "GCF_000002765.6"
-            else {"gene_model_url": "None"}
+            else {"gene_model_url": None}
         )
         schema = AnalysisSchema(
             assembly=SchemaField(

--- a/backend/api/tests/test_assistant_agent.py
+++ b/backend/api/tests/test_assistant_agent.py
@@ -457,6 +457,99 @@ class TestApplySchemaUpdates:
         assert result.workflow.status == FieldStatus.FILLED
         assert result.gene_annotation.status == FieldStatus.EMPTY
 
+    def test_data_characteristics_filled_from_paired_workflow(self, agent):
+        # Read layout is a workflow constraint -- derive it from the workflow's
+        # SANGER_READ_RUN_PAIRED param instead of waiting on the model to emit it.
+        agent.catalog.workflows_by_category = [
+            {
+                "category": "VARIANT_CALLING",
+                "workflows": [
+                    {
+                        "iwcId": "ploidy-main",
+                        "trsId": "trs-ploidy",
+                        "parameters": [
+                            {"variable": "SANGER_READ_RUN_PAIRED"},
+                            {"variable": "ASSEMBLY_FASTA_URL"},
+                        ],
+                    }
+                ],
+            }
+        ]
+        result = agent._apply_schema_updates(
+            AnalysisSchema(), {"workflow": "Ploidy-aware calling (ploidy-main)"}
+        )
+        assert result.data_characteristics.status == FieldStatus.FILLED
+        assert result.data_characteristics.value == "Paired-end sequencing reads"
+
+    def test_data_characteristics_includes_library_strategy(self, agent):
+        # When the catalog declares a library strategy, fold it into the label.
+        agent.catalog.workflows_by_category = [
+            {
+                "category": "VARIANT_CALLING",
+                "workflows": [
+                    {
+                        "iwcId": "wgs-pe",
+                        "trsId": "trs-wgs",
+                        "parameters": [
+                            {
+                                "variable": "SANGER_READ_RUN_PAIRED",
+                                "data_requirements": {
+                                    "library_layout": "PAIRED",
+                                    "library_strategy": ["WGS"],
+                                },
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+        result = agent._apply_schema_updates(
+            AnalysisSchema(), {"workflow": "WGS PE (wgs-pe)"}
+        )
+        assert result.data_characteristics.status == FieldStatus.FILLED
+        assert result.data_characteristics.value == "Paired-end WGS reads"
+
+    def test_data_characteristics_empty_when_workflow_takes_no_reads(self, agent):
+        # A workflow with no SANGER_READ_RUN param leaves data characteristics empty.
+        agent.catalog.workflows_by_category = [
+            {
+                "category": "ASSEMBLY",
+                "workflows": [
+                    {
+                        "iwcId": "asm-only",
+                        "trsId": "trs-asm",
+                        "parameters": [{"variable": "ASSEMBLY_ID"}],
+                    }
+                ],
+            }
+        ]
+        result = agent._apply_schema_updates(
+            AnalysisSchema(), {"workflow": "Assembly (asm-only)"}
+        )
+        assert result.data_characteristics.status == FieldStatus.EMPTY
+
+    def test_data_characteristics_genome_fasta_workflow(self, agent):
+        # A workflow that takes an assembled genome instead of reads -- e.g.
+        # Braker3 annotation -- characterises its input as a FASTA assembly so
+        # the field fills and the analysis can complete.
+        agent.catalog.workflows_by_category = [
+            {
+                "category": "ANNOTATION",
+                "workflows": [
+                    {
+                        "iwcId": "braker3",
+                        "trsId": "trs-braker3",
+                        "parameters": [{"variable": "ASSEMBLY_FASTA_URL"}],
+                    }
+                ],
+            }
+        ]
+        result = agent._apply_schema_updates(
+            AnalysisSchema(), {"workflow": "Braker3 annotation (braker3)"}
+        )
+        assert result.data_characteristics.status == FieldStatus.FILLED
+        assert result.data_characteristics.value == "Assembled genome (FASTA)"
+
 
 # ---------- compute_handoff ----------
 

--- a/backend/api/tests/test_assistant_agent.py
+++ b/backend/api/tests/test_assistant_agent.py
@@ -550,6 +550,69 @@ class TestApplySchemaUpdates:
         assert result.data_characteristics.status == FieldStatus.FILLED
         assert result.data_characteristics.value == "Assembled genome (FASTA)"
 
+    def test_gene_annotation_filled_when_assembly_has_gene_model(self, agent):
+        # A GTF-requiring workflow whose assembly ships a gene model fills the
+        # annotation (setup resolves the URL automatically).
+        agent.catalog.workflows_by_category = [
+            {
+                "category": "VARIANT_CALLING",
+                "workflows": [
+                    {
+                        "iwcId": "var-pe",
+                        "trsId": "trs-var",
+                        "parameters": [
+                            {"variable": "SANGER_READ_RUN_PAIRED"},
+                            {"variable": "GENE_MODEL_URL"},
+                        ],
+                    }
+                ],
+            }
+        ]
+        agent.catalog.get_assembly_details.return_value = {
+            "gene_model_url": "https://example.org/genes.gtf.gz"
+        }
+        schema = AnalysisSchema(
+            assembly=SchemaField(
+                value="P. falciparum GCF_000002765.6",
+                detail="GCF_000002765.6",
+                status=FieldStatus.FILLED,
+            )
+        )
+        result = agent._apply_schema_updates(
+            schema, {"workflow": "Variant calling (var-pe)"}
+        )
+        assert result.gene_annotation.status == FieldStatus.FILLED
+        assert result.gene_annotation.value == "Reference GTF"
+
+    def test_gene_annotation_needs_attention_when_assembly_lacks_gene_model(
+        self, agent
+    ):
+        # Same workflow, but the assembly has no gene model -> needs attention.
+        agent.catalog.workflows_by_category = [
+            {
+                "category": "VARIANT_CALLING",
+                "workflows": [
+                    {
+                        "iwcId": "var-pe",
+                        "trsId": "trs-var",
+                        "parameters": [{"variable": "GENE_MODEL_URL"}],
+                    }
+                ],
+            }
+        ]
+        agent.catalog.get_assembly_details.return_value = {"gene_model_url": "None"}
+        schema = AnalysisSchema(
+            assembly=SchemaField(
+                value="Some assembly GCF_999999999.1",
+                detail="GCF_999999999.1",
+                status=FieldStatus.FILLED,
+            )
+        )
+        result = agent._apply_schema_updates(
+            schema, {"workflow": "Variant calling (var-pe)"}
+        )
+        assert result.gene_annotation.status == FieldStatus.NEEDS_ATTENTION
+
 
 # ---------- compute_handoff ----------
 

--- a/backend/api/tests/test_assistant_agent.py
+++ b/backend/api/tests/test_assistant_agent.py
@@ -392,10 +392,14 @@ class TestParseStructuredOutput:
 
 
 class TestApplySchemaUpdates:
-    def test_empty_updates_returns_same(self, agent):
+    def test_empty_updates_reconciles_copy(self, agent):
+        # Empty updates no longer short-circuits: it returns a reconciled copy so
+        # a restored session's derived fields are always recomputed (Codex #9).
         schema = AnalysisSchema()
         result = agent._apply_schema_updates(schema, {})
-        assert result is schema  # same object, not a copy
+        assert result is not schema
+        assert result.organism.status == FieldStatus.EMPTY
+        assert result.data_characteristics.status == FieldStatus.EMPTY
 
     def test_sets_organism(self, agent):
         schema = AnalysisSchema()
@@ -492,8 +496,9 @@ class TestApplySchemaUpdates:
         result = agent._apply_schema_updates(
             schema, {"workflow": "some-other-workflow"}
         )
-        assert result.workflow.status == FieldStatus.FILLED
-        assert result.workflow.detail is None
+        # No visible catalog match -> not committed: stays EMPTY rather than
+        # FILLED with a null detail (Codex #10).
+        assert result.workflow.status == FieldStatus.EMPTY
 
     def test_preserves_existing_fields(self, agent):
         schema = AnalysisSchema(
@@ -733,6 +738,61 @@ class TestApplySchemaUpdates:
         result = agent._data_characteristics_for_workflow("trs-shovill")
         assert result is not None
         assert result[0] == "Paired-end sequencing reads"
+
+    def test_workflow_by_ref_ignores_organism_scope(self, agent):
+        # A ref to a hidden ORGANISM-scope workflow (e.g. carried in a restored
+        # session) must not resolve, so its inputs can't drive derivation or a
+        # handoff (Codex #5).
+        agent.catalog.workflows_by_category = [
+            {
+                "category": "ASSEMBLY",
+                "workflows": [
+                    {
+                        "iwcId": "flye",
+                        "trsId": "trs-flye",
+                        "scope": "ORGANISM",
+                        "parameters": [
+                            {
+                                "variable": "SANGER_READ_RUN_SINGLE_FILE",
+                                "data_requirements": {"library_layout": "SINGLE"},
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+        assert agent._workflow_by_ref("trs-flye") is None
+        assert agent._data_characteristics_for_workflow("trs-flye") is None
+
+    def test_empty_updates_still_reconciles_stale_derived(self, agent):
+        # A restored session can carry stale derived state with no new updates;
+        # the reflectors must still run so it is corrected (Codex #9).
+        agent.catalog.workflows_by_category = [
+            {
+                "category": "ASSEMBLY",
+                "workflows": [
+                    {
+                        "iwcId": "asm-only",
+                        "trsId": "trs-asm",
+                        "parameters": [{"variable": "ASSEMBLY_ID"}],
+                    }
+                ],
+            }
+        ]
+        stale = AnalysisSchema(
+            workflow=SchemaField(
+                value="Assembly (asm-only)",
+                detail="trs-asm",
+                status=FieldStatus.FILLED,
+            ),
+            data_characteristics=SchemaField(
+                value="Paired-end sequencing reads",
+                detail="Required by the selected workflow",
+                status=FieldStatus.FILLED,
+            ),
+        )
+        result = agent._apply_schema_updates(stale, {})
+        assert result.data_characteristics.status == FieldStatus.EMPTY
 
     def test_data_characteristics_cleared_when_workflow_unset(self, agent):
         # Clearing the workflow (a mid-conversation correction) must drop a value

--- a/backend/api/tests/test_assistant_agent.py
+++ b/backend/api/tests/test_assistant_agent.py
@@ -135,6 +135,21 @@ class TestParseStructuredOutput:
         assert suggestions == []
         assert text == "Which Plasmodium species is your data from?"
 
+    def test_malformed_suggestions_before_schema_update_preserved(self, agent):
+        # A malformed SUGGESTIONS trailer is excised through the last bracket in
+        # the reply. If a valid SCHEMA_UPDATE follows it, pulling SCHEMA_UPDATE
+        # out first keeps the update from being swallowed with the bad chips.
+        raw = (
+            "Recorded it.\n"
+            'SUGGESTIONS: [{"label": "broken"\n'
+            'SCHEMA_UPDATE: {"organism": "Plasmodium falciparum"}'
+        )
+        text, suggestions, updates = agent._parse_structured_output(raw)
+        assert updates == {"organism": "Plasmodium falciparum"}
+        assert "SCHEMA_UPDATE" not in text
+        assert "SUGGESTIONS" not in text
+        assert suggestions == []
+
     def test_multiline_body_preserved(self, agent):
         raw = 'Line 1\nLine 2\nLine 3\nSUGGESTIONS: ["Next"]'
         text, suggestions, _ = agent._parse_structured_output(raw)

--- a/backend/api/tests/test_assistant_agent.py
+++ b/backend/api/tests/test_assistant_agent.py
@@ -108,11 +108,32 @@ class TestParseStructuredOutput:
         assert suggestions == []
         assert "not valid json" in text
 
-    def test_malformed_schema_kept_as_text(self, agent):
-        raw = "SCHEMA_UPDATE: {broken"
+    def test_malformed_schema_payload_stripped(self, agent):
+        # A marker followed by a broken JSON payload is excised, not shown --
+        # raw JSON must never leak into the visible reply.
+        raw = "Recorded it. SCHEMA_UPDATE: {broken"
         text, _, updates = agent._parse_structured_output(raw)
         assert updates == {}
-        assert "{broken" in text
+        assert "SCHEMA_UPDATE" not in text
+        assert "broken" not in text
+        assert text == "Recorded it."
+
+    def test_malformed_suggestions_json_stripped_not_leaked(self, agent):
+        # Real-world MiniMax failure: a SUGGESTIONS array with broken brackets
+        # (a string where an object belongs, then a second stray array). It
+        # can't be parsed, but it must still be stripped so the user never sees
+        # raw JSON -- we just produce no chips that turn.
+        raw = (
+            "Which Plasmodium species is your data from?\n\n"
+            'SUGGESTIONS: [{"label": "Use P. falciparum", "organism": "5833"}, '
+            '{"label": "Tell me about variant calling for malaria"], '
+            '[{"label": "Tell me about transcriptomics for malaria"]'
+        )
+        text, suggestions, _ = agent._parse_structured_output(raw)
+        assert "SUGGESTIONS" not in text
+        assert "[" not in text and "{" not in text
+        assert suggestions == []
+        assert text == "Which Plasmodium species is your data from?"
 
     def test_multiline_body_preserved(self, agent):
         raw = 'Line 1\nLine 2\nLine 3\nSUGGESTIONS: ["Next"]'
@@ -130,6 +151,40 @@ class TestParseStructuredOutput:
         raw = '**SCHEMA_UPDATE:** {"organism": "E. coli"}'
         _, _, updates = agent._parse_structured_output(raw)
         assert updates == {"organism": "E. coli"}
+
+    def test_suggestions_inline_after_prose(self, agent):
+        # The marker can land inline at the end of a prose line (smaller models
+        # don't always put it on its own line). It must still be stripped, not
+        # leaked into the visible reply.
+        raw = 'Which species is your data from? SUGGESTIONS: ["P. falciparum", "P. knowlesi"]'
+        text, suggestions, _ = agent._parse_structured_output(raw)
+        assert text == "Which species is your data from?"
+        assert "SUGGESTIONS" not in text
+        assert len(suggestions) == 2
+
+    def test_suggestions_multiline_json(self, agent):
+        # A JSON value spanning multiple lines must be decoded and removed whole.
+        raw = 'Pick one.\nSUGGESTIONS: [\n  "Variant calling",\n  "Transcriptomics"\n]'
+        text, suggestions, _ = agent._parse_structured_output(raw)
+        assert text == "Pick one."
+        assert "SUGGESTIONS" not in text
+        assert len(suggestions) == 2
+
+    def test_inline_suggestions_invalid_json_left_as_prose(self, agent):
+        # A mid-prose "suggestions:" with JSON-ish but invalid text must be left
+        # alone -- only a line-start trailer is excised when it cannot parse.
+        raw = "I have a few suggestions: [check the docs, ask the forum]"
+        text, suggestions, _ = agent._parse_structured_output(raw)
+        assert text == raw
+        assert suggestions == []
+
+    def test_schema_update_inline_after_prose(self, agent):
+        # Same for SCHEMA_UPDATE emitted inline after prose.
+        raw = 'Recorded it. SCHEMA_UPDATE: {"organism": "Plasmodium falciparum"}'
+        text, _, updates = agent._parse_structured_output(raw)
+        assert "SCHEMA_UPDATE" not in text
+        assert updates == {"organism": "Plasmodium falciparum"}
+        assert text == "Recorded it."
 
     # ---- catalog-grounded suggestion chips (#1297) ----
 

--- a/backend/api/tests/test_assistant_agent.py
+++ b/backend/api/tests/test_assistant_agent.py
@@ -760,6 +760,109 @@ class TestApplySchemaUpdates:
         )
         assert result.gene_annotation.status == FieldStatus.NEEDS_ATTENTION
 
+    def test_gene_annotation_reevaluated_when_assembly_loses_gene_model(self, agent):
+        # An auto-selected GTF must be re-evaluated when the user switches to an
+        # assembly with no gene model -- it can't stay FILLED as "Reference GTF".
+        agent.catalog.workflows_by_category = [
+            {
+                "category": "VARIANT_CALLING",
+                "workflows": [
+                    {
+                        "iwcId": "var-pe",
+                        "trsId": "trs-var",
+                        "parameters": [{"variable": "GENE_MODEL_URL"}],
+                    }
+                ],
+            }
+        ]
+        agent.catalog.get_assembly_details.side_effect = lambda acc: (
+            {"gene_model_url": "https://example.org/genes.gtf.gz"}
+            if acc == "GCF_000002765.6"
+            else {"gene_model_url": "None"}
+        )
+        schema = AnalysisSchema(
+            assembly=SchemaField(
+                value="Has model GCF_000002765.6",
+                detail="GCF_000002765.6",
+                status=FieldStatus.FILLED,
+            )
+        )
+        filled = agent._apply_schema_updates(
+            schema, {"workflow": "Variant calling (var-pe)"}
+        )
+        assert filled.gene_annotation.status == FieldStatus.FILLED
+        assert filled.gene_annotation.value == "Reference GTF"
+        switched = agent._apply_schema_updates(
+            filled, {"assembly": "No model GCF_999999999.1"}
+        )
+        assert switched.gene_annotation.status == FieldStatus.NEEDS_ATTENTION
+
+    def test_gene_annotation_cleared_when_workflow_unset(self, agent):
+        # Clearing the workflow drops an auto-selected GTF rather than leaving it
+        # stale with no workflow selected.
+        agent.catalog.workflows_by_category = [
+            {
+                "category": "VARIANT_CALLING",
+                "workflows": [
+                    {
+                        "iwcId": "var-pe",
+                        "trsId": "trs-var",
+                        "parameters": [{"variable": "GENE_MODEL_URL"}],
+                    }
+                ],
+            }
+        ]
+        agent.catalog.get_assembly_details.return_value = {
+            "gene_model_url": "https://example.org/genes.gtf.gz"
+        }
+        schema = AnalysisSchema(
+            assembly=SchemaField(
+                value="Has model GCF_000002765.6",
+                detail="GCF_000002765.6",
+                status=FieldStatus.FILLED,
+            )
+        )
+        filled = agent._apply_schema_updates(
+            schema, {"workflow": "Variant calling (var-pe)"}
+        )
+        assert filled.gene_annotation.status == FieldStatus.FILLED
+        cleared = agent._apply_schema_updates(filled, {"workflow": None})
+        assert cleared.gene_annotation.status == FieldStatus.EMPTY
+
+    def test_gene_annotation_user_choice_preserved(self, agent):
+        # A gene annotation the user set explicitly (no auto-selected marker) is
+        # left untouched even under a GTF-requiring workflow.
+        agent.catalog.workflows_by_category = [
+            {
+                "category": "VARIANT_CALLING",
+                "workflows": [
+                    {
+                        "iwcId": "var-pe",
+                        "trsId": "trs-var",
+                        "parameters": [{"variable": "GENE_MODEL_URL"}],
+                    }
+                ],
+            }
+        ]
+        agent.catalog.get_assembly_details.return_value = {
+            "gene_model_url": "https://example.org/genes.gtf.gz"
+        }
+        schema = AnalysisSchema(
+            assembly=SchemaField(
+                value="Has model GCF_000002765.6",
+                detail="GCF_000002765.6",
+                status=FieldStatus.FILLED,
+            ),
+            gene_annotation=SchemaField(
+                value="My custom annotation", status=FieldStatus.FILLED
+            ),
+        )
+        result = agent._apply_schema_updates(
+            schema, {"workflow": "Variant calling (var-pe)"}
+        )
+        assert result.gene_annotation.status == FieldStatus.FILLED
+        assert result.gene_annotation.value == "My custom annotation"
+
 
 # ---------- compute_handoff ----------
 

--- a/backend/api/tests/test_assistant_agent.py
+++ b/backend/api/tests/test_assistant_agent.py
@@ -682,6 +682,58 @@ class TestApplySchemaUpdates:
         assert result.data_characteristics.status == FieldStatus.FILLED
         assert result.data_characteristics.value == "Assembled genome (FASTA)"
 
+    def test_data_characteristics_single_file_read_variant(self, agent):
+        # Flye-style read input uses SANGER_READ_RUN_SINGLE_FILE (not the bare
+        # _SINGLE name); the layout comes from data_requirements.
+        agent.catalog.workflows_by_category = [
+            {
+                "category": "ASSEMBLY",
+                "workflows": [
+                    {
+                        "iwcId": "flye",
+                        "trsId": "trs-flye",
+                        "parameters": [
+                            {
+                                "variable": "SANGER_READ_RUN_SINGLE_FILE",
+                                "data_requirements": {"library_layout": "SINGLE"},
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+        result = agent._data_characteristics_for_workflow("trs-flye")
+        assert result is not None
+        assert result[0] == "Single-end sequencing reads"
+
+    def test_data_characteristics_forward_reverse_file_read_variant(self, agent):
+        # Shovill-style paired reads use SANGER_READ_RUN_FORWARD_FILE +
+        # REVERSE_FILE; both carry library_layout PAIRED.
+        agent.catalog.workflows_by_category = [
+            {
+                "category": "ASSEMBLY",
+                "workflows": [
+                    {
+                        "iwcId": "shovill",
+                        "trsId": "trs-shovill",
+                        "parameters": [
+                            {
+                                "variable": "SANGER_READ_RUN_FORWARD_FILE",
+                                "data_requirements": {"library_layout": "PAIRED"},
+                            },
+                            {
+                                "variable": "SANGER_READ_RUN_REVERSE_FILE",
+                                "data_requirements": {"library_layout": "PAIRED"},
+                            },
+                        ],
+                    }
+                ],
+            }
+        ]
+        result = agent._data_characteristics_for_workflow("trs-shovill")
+        assert result is not None
+        assert result[0] == "Paired-end sequencing reads"
+
     def test_data_characteristics_cleared_when_workflow_unset(self, agent):
         # Clearing the workflow (a mid-conversation correction) must drop a value
         # derived from the old workflow rather than leave it stale.

--- a/backend/api/tests/test_assistant_agent.py
+++ b/backend/api/tests/test_assistant_agent.py
@@ -620,6 +620,83 @@ class TestApplySchemaUpdates:
         assert result.data_characteristics.status == FieldStatus.FILLED
         assert result.data_characteristics.value == "Assembled genome (FASTA)"
 
+    def test_data_characteristics_cleared_when_workflow_unset(self, agent):
+        # Clearing the workflow (a mid-conversation correction) must drop a value
+        # derived from the old workflow rather than leave it stale.
+        agent.catalog.workflows_by_category = [
+            {
+                "category": "VARIANT_CALLING",
+                "workflows": [
+                    {
+                        "iwcId": "ploidy-main",
+                        "trsId": "trs-ploidy",
+                        "parameters": [{"variable": "SANGER_READ_RUN_PAIRED"}],
+                    }
+                ],
+            }
+        ]
+        filled = agent._apply_schema_updates(
+            AnalysisSchema(), {"workflow": "Ploidy-aware calling (ploidy-main)"}
+        )
+        assert filled.data_characteristics.status == FieldStatus.FILLED
+        cleared = agent._apply_schema_updates(filled, {"workflow": None})
+        assert cleared.data_characteristics.status == FieldStatus.EMPTY
+
+    def test_data_characteristics_cleared_when_workflow_has_no_derivation(self, agent):
+        # Swapping to a workflow that supplies no characteristics clears the value
+        # derived from the previous workflow.
+        agent.catalog.workflows_by_category = [
+            {
+                "category": "VARIANT_CALLING",
+                "workflows": [
+                    {
+                        "iwcId": "ploidy-main",
+                        "trsId": "trs-ploidy",
+                        "parameters": [{"variable": "SANGER_READ_RUN_PAIRED"}],
+                    },
+                    {
+                        "iwcId": "asm-only",
+                        "trsId": "trs-asm",
+                        "parameters": [{"variable": "ASSEMBLY_ID"}],
+                    },
+                ],
+            }
+        ]
+        filled = agent._apply_schema_updates(
+            AnalysisSchema(), {"workflow": "Ploidy-aware calling (ploidy-main)"}
+        )
+        assert filled.data_characteristics.status == FieldStatus.FILLED
+        swapped = agent._apply_schema_updates(
+            filled, {"workflow": "Assembly (asm-only)"}
+        )
+        assert swapped.data_characteristics.status == FieldStatus.EMPTY
+
+    def test_data_characteristics_user_value_not_cleared(self, agent):
+        # A value that isn't catalog-derived (no derived-detail marker) is left
+        # untouched even when the workflow supplies no characteristics.
+        agent.catalog.workflows_by_category = [
+            {
+                "category": "ASSEMBLY",
+                "workflows": [
+                    {
+                        "iwcId": "asm-only",
+                        "trsId": "trs-asm",
+                        "parameters": [{"variable": "ASSEMBLY_ID"}],
+                    }
+                ],
+            }
+        ]
+        schema = AnalysisSchema(
+            data_characteristics=SchemaField(
+                value="Long reads (user note)", status=FieldStatus.FILLED
+            )
+        )
+        result = agent._apply_schema_updates(
+            schema, {"workflow": "Assembly (asm-only)"}
+        )
+        assert result.data_characteristics.status == FieldStatus.FILLED
+        assert result.data_characteristics.value == "Long reads (user note)"
+
     def test_gene_annotation_filled_when_assembly_has_gene_model(self, agent):
         # A GTF-requiring workflow whose assembly ships a gene model fills the
         # annotation (setup resolves the URL automatically).

--- a/backend/api/tests/test_assistant_agent.py
+++ b/backend/api/tests/test_assistant_agent.py
@@ -215,6 +215,29 @@ class TestParseStructuredOutput:
         assert "5833" not in text
         assert text == "Recorded it."
 
+    def test_duplicate_schema_update_markers_merged(self, agent):
+        # A model that emits SCHEMA_UPDATE twice must not leave the second block
+        # (and its raw JSON) visible -- both are stripped and merged.
+        raw = (
+            "Recorded.\n"
+            'SCHEMA_UPDATE: {"organism": "A"}\n'
+            'SCHEMA_UPDATE: {"assembly": "B"}'
+        )
+        text, _, updates = agent._parse_structured_output(raw)
+        assert updates == {"organism": "A", "assembly": "B"}
+        assert "SCHEMA_UPDATE" not in text
+        assert "{" not in text and "}" not in text
+        assert text == "Recorded."
+
+    def test_duplicate_suggestions_markers_not_leaked(self, agent):
+        # Two SUGGESTIONS blocks -- neither may leak; the last one wins.
+        raw = 'Pick.\nSUGGESTIONS: ["A"]\nSUGGESTIONS: ["B", "C"]'
+        text, suggestions, _ = agent._parse_structured_output(raw)
+        assert "SUGGESTIONS" not in text
+        assert "[" not in text and "]" not in text
+        assert [c.label for c in suggestions] == ["B", "C"]
+        assert text == "Pick."
+
     def test_schema_update_inline_after_prose(self, agent):
         # Same for SCHEMA_UPDATE emitted inline after prose.
         raw = 'Recorded it. SCHEMA_UPDATE: {"organism": "Plasmodium falciparum"}'

--- a/backend/api/tests/test_assistant_agent.py
+++ b/backend/api/tests/test_assistant_agent.py
@@ -238,6 +238,23 @@ class TestParseStructuredOutput:
         assert [c.label for c in suggestions] == ["B", "C"]
         assert text == "Pick."
 
+    def test_malformed_schema_update_preserves_following_suggestions(self, agent):
+        # A broken SCHEMA_UPDATE trailer must not reach through and delete the
+        # SUGGESTIONS the prompt places after it. The malformed update is
+        # dropped (never leaked), but the valid chips survive.
+        raw = (
+            "I found a few variant-calling workflows that fit your data.\n"
+            'SCHEMA_UPDATE: {"organism": "Plasmodium falciparum", "workflow": broken\n'
+            'SUGGESTIONS: ["Variant calling", "Transcriptomics"]'
+        )
+        text, suggestions, updates = agent._parse_structured_output(raw)
+        assert updates == {}
+        assert [c.label for c in suggestions] == ["Variant calling", "Transcriptomics"]
+        assert "SCHEMA_UPDATE" not in text
+        assert "broken" not in text
+        assert "{" not in text
+        assert text == "I found a few variant-calling workflows that fit your data."
+
     def test_schema_update_inline_after_prose(self, agent):
         # Same for SCHEMA_UPDATE emitted inline after prose.
         raw = 'Recorded it. SCHEMA_UPDATE: {"organism": "Plasmodium falciparum"}'

--- a/backend/api/tests/test_assistant_agent.py
+++ b/backend/api/tests/test_assistant_agent.py
@@ -503,6 +503,29 @@ class TestApplySchemaUpdates:
         # FILLED with a null detail (Codex #10).
         assert result.workflow.status == FieldStatus.EMPTY
 
+    def test_unresolvable_workflow_clears_existing(self, agent):
+        # Switching to an unresolvable workflow must clear the field, not keep
+        # the OLD filled workflow -- otherwise a handoff fires on the wrong one
+        # (Codex).
+        agent.catalog.workflows_by_category = [
+            {
+                "category": "ASSEMBLY",
+                "workflows": [
+                    {"iwcId": "real", "trsId": "trs-real", "workflowName": "Real"}
+                ],
+            }
+        ]
+        schema = AnalysisSchema(
+            workflow=SchemaField(
+                value="Variant A", detail="trs-a", status=FieldStatus.FILLED
+            )
+        )
+        result = agent._apply_schema_updates(
+            schema, {"workflow": "not-a-visible-workflow"}
+        )
+        assert result.workflow.status == FieldStatus.EMPTY
+        assert result.workflow.detail is None
+
     def test_preserves_existing_fields(self, agent):
         schema = AnalysisSchema(
             organism=SchemaField(value="Existing", status=FieldStatus.FILLED)
@@ -1666,6 +1689,48 @@ class TestParserInvariants:
         assert "bracket" not in text
         assert not any(ch in text for ch in "{}[]")
         assert text == "Recorded."
+
+    def test_marker_word_line_inside_malformed_string_no_leak(self, agent):
+        # A malformed multi-line payload whose string value contains a line that
+        # *starts* with a marker word (but no trailer syntax) must not bound the
+        # excision there and leak the tail (Codex).
+        raw = (
+            "Recorded.\n"
+            'SCHEMA_UPDATE: {"note": "first line\n'
+            'SUGGESTIONS are [not json", "workflow": broken}\n'
+            'SUGGESTIONS: ["Next"]'
+        )
+        text, suggestions, updates = agent._parse_structured_output(raw)
+        assert updates == {}
+        assert [c.label for c in suggestions] == ["Next"]
+        assert not any(ch in text for ch in "{}[]")
+        assert "SUGGESTIONS are" not in text and "broken" not in text
+        assert text == "Recorded."
+
+    def test_wrong_shape_trailing_junk_no_leak(self, agent):
+        # A parseable-but-wrong-shape payload followed by same-line junk (e.g. a
+        # second object) must strip the whole trailer line, not leak the tail.
+        raw = (
+            'Recorded. SCHEMA_UPDATE: {"organism": 5833}, '
+            '{"assembly": "GCF_000146045.2"}'
+        )
+        text, _, updates = agent._parse_structured_output(raw)
+        assert updates == {}
+        assert not any(ch in text for ch in "{}[]")
+        assert "assembly" not in text
+        assert text == "Recorded."
+
+    @_pi_settings
+    @given(prose=_pi_prose, junk=st.text(alphabet="abc [{,: ", max_size=30))
+    def test_malformed_embedding_marker_line_never_leaks(self, agent, prose, junk):
+        # Malformed payloads that embed a newline and a line starting with a
+        # marker word must never leak raw JSON or a marker into the reply.
+        payload = '{"note": "' + junk + '\nSUGGESTIONS are broken [x", "y": nope'
+        raw = prose + "\nSCHEMA_UPDATE: " + payload
+        text, _, updates = agent._parse_structured_output(raw)
+        assert updates == {}
+        assert not any(ch in text for ch in "{}[]")
+        assert "SCHEMA_UPDATE" not in text
 
     def test_whitespace_before_colon_extracted(self, agent):
         raw = 'Recorded. SCHEMA_UPDATE : {"organism": "P. falciparum"}'

--- a/backend/api/tests/test_assistant_agent.py
+++ b/backend/api/tests/test_assistant_agent.py
@@ -671,31 +671,40 @@ class TestApplySchemaUpdates:
         )
         assert swapped.data_characteristics.status == FieldStatus.EMPTY
 
-    def test_data_characteristics_user_value_not_cleared(self, agent):
-        # A value that isn't catalog-derived (no derived-detail marker) is left
-        # untouched even when the workflow supplies no characteristics.
+    def test_data_characteristics_recomputed_when_model_reemits_value(self, agent):
+        # The prompt has the model re-emit committed fields each turn, so it can
+        # re-send a derived data_characteristics as a plain value (detail lost).
+        # The catalog is authoritative: recompute from the new workflow rather
+        # than trust the re-emitted value.
         agent.catalog.workflows_by_category = [
             {
-                "category": "ASSEMBLY",
+                "category": "VARIANT_CALLING",
                 "workflows": [
+                    {
+                        "iwcId": "ploidy-main",
+                        "trsId": "trs-ploidy",
+                        "parameters": [{"variable": "SANGER_READ_RUN_PAIRED"}],
+                    },
                     {
                         "iwcId": "asm-only",
                         "trsId": "trs-asm",
                         "parameters": [{"variable": "ASSEMBLY_ID"}],
-                    }
+                    },
                 ],
             }
         ]
-        schema = AnalysisSchema(
-            data_characteristics=SchemaField(
-                value="Long reads (user note)", status=FieldStatus.FILLED
-            )
+        filled = agent._apply_schema_updates(
+            AnalysisSchema(), {"workflow": "Ploidy-aware calling (ploidy-main)"}
         )
+        assert filled.data_characteristics.value == "Paired-end sequencing reads"
         result = agent._apply_schema_updates(
-            schema, {"workflow": "Assembly (asm-only)"}
+            filled,
+            {
+                "workflow": "Assembly (asm-only)",
+                "data_characteristics": "Paired-end sequencing reads",
+            },
         )
-        assert result.data_characteristics.status == FieldStatus.FILLED
-        assert result.data_characteristics.value == "Long reads (user note)"
+        assert result.data_characteristics.status == FieldStatus.EMPTY
 
     def test_gene_annotation_filled_when_assembly_has_gene_model(self, agent):
         # A GTF-requiring workflow whose assembly ships a gene model fills the
@@ -829,9 +838,10 @@ class TestApplySchemaUpdates:
         cleared = agent._apply_schema_updates(filled, {"workflow": None})
         assert cleared.gene_annotation.status == FieldStatus.EMPTY
 
-    def test_gene_annotation_user_choice_preserved(self, agent):
-        # A gene annotation the user set explicitly (no auto-selected marker) is
-        # left untouched even under a GTF-requiring workflow.
+    def test_gene_annotation_recomputed_when_model_reemits_value(self, agent):
+        # Same for gene annotation: a re-emitted "Reference GTF" (detail lost)
+        # must not pin the field FILLED after the user switches to an assembly
+        # with no gene model.
         agent.catalog.workflows_by_category = [
             {
                 "category": "VARIANT_CALLING",
@@ -844,24 +854,30 @@ class TestApplySchemaUpdates:
                 ],
             }
         ]
-        agent.catalog.get_assembly_details.return_value = {
-            "gene_model_url": "https://example.org/genes.gtf.gz"
-        }
+        agent.catalog.get_assembly_details.side_effect = lambda acc: (
+            {"gene_model_url": "https://example.org/genes.gtf.gz"}
+            if acc == "GCF_000002765.6"
+            else {"gene_model_url": "None"}
+        )
         schema = AnalysisSchema(
             assembly=SchemaField(
                 value="Has model GCF_000002765.6",
                 detail="GCF_000002765.6",
                 status=FieldStatus.FILLED,
-            ),
-            gene_annotation=SchemaField(
-                value="My custom annotation", status=FieldStatus.FILLED
-            ),
+            )
         )
-        result = agent._apply_schema_updates(
+        filled = agent._apply_schema_updates(
             schema, {"workflow": "Variant calling (var-pe)"}
         )
-        assert result.gene_annotation.status == FieldStatus.FILLED
-        assert result.gene_annotation.value == "My custom annotation"
+        assert filled.gene_annotation.value == "Reference GTF"
+        result = agent._apply_schema_updates(
+            filled,
+            {
+                "assembly": "No model GCF_999999999.1",
+                "gene_annotation": "Reference GTF",
+            },
+        )
+        assert result.gene_annotation.status == FieldStatus.NEEDS_ATTENTION
 
 
 # ---------- compute_handoff ----------
@@ -1322,6 +1338,9 @@ async def test_chat_handoff_url_carries_assistant_session_id(agent):
             all_messages=lambda: [],
         )
     )
+    # data_characteristics is derived from the workflow's read inputs (a real
+    # varcall workflow takes reads), so the fixture carries the param; the
+    # model's re-emitted "Paired-end reads" is overridden by the catalog.
     agent.catalog.workflows_by_category = [
         {
             "category": "VARIANT_CALLING",
@@ -1329,6 +1348,7 @@ async def test_chat_handoff_url_carries_assistant_session_id(agent):
                 {
                     "iwcId": "varcall-haploid",
                     "trsId": "#workflow/github.com/iwc/varcall-haploid/main",
+                    "parameters": [{"variable": "SANGER_READ_RUN_PAIRED"}],
                 }
             ],
         }

--- a/backend/api/tests/test_assistant_agent.py
+++ b/backend/api/tests/test_assistant_agent.py
@@ -1651,6 +1651,22 @@ class TestParserInvariants:
         assert not any(ch in text for ch in "[]")
         assert text == "Pick."
 
+    def test_malformed_bracket_in_string_no_leak(self, agent):
+        # A malformed payload with a ]/} inside a string literal must be fully
+        # excised -- cutting at that inner bracket leaves the tail visible
+        # (Copilot). No raw JSON may reach the user.
+        raw = (
+            "Recorded.\n"
+            'SCHEMA_UPDATE: {"note": "has ] bracket", "x": broken\n'
+            'SUGGESTIONS: ["Next"]'
+        )
+        text, suggestions, updates = agent._parse_structured_output(raw)
+        assert updates == {}
+        assert [c.label for c in suggestions] == ["Next"]
+        assert "bracket" not in text
+        assert not any(ch in text for ch in "{}[]")
+        assert text == "Recorded."
+
     def test_whitespace_before_colon_extracted(self, agent):
         raw = 'Recorded. SCHEMA_UPDATE : {"organism": "P. falciparum"}'
         text, _, updates = agent._parse_structured_output(raw)

--- a/backend/api/tests/test_assistant_agent.py
+++ b/backend/api/tests/test_assistant_agent.py
@@ -1,10 +1,13 @@
 """Tests for AssistantAgent parsing and schema update logic."""
 
 import asyncio
+import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
 from pydantic_ai.messages import (
     ModelRequest,
     ModelResponse,
@@ -1555,3 +1558,127 @@ async def test_chat_handoff_url_carries_assistant_session_id(agent):
     assert state.messages[-1] == ChatMessage(
         role=MessageRole.ASSISTANT, content="Ready to go."
     )
+
+
+# ---------- parser invariants (property-based net) ----------
+
+_pi_prose = st.text(
+    alphabet="abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ.,?!()-",
+    max_size=60,
+).filter(lambda t: "schema_update" not in t.lower() and "suggestions" not in t.lower())
+_pi_field = st.sampled_from(
+    ["organism", "assembly", "analysis_type", "workflow", "data_source"]
+)
+_pi_val = (
+    st.text(alphabet="abcdefghijklmnopqrstuvwxyz ", min_size=1, max_size=15)
+    .map(str.strip)
+    .filter(lambda x: x)
+)
+_pi_schema = st.dictionaries(_pi_field, _pi_val, min_size=1, max_size=3)
+_pi_sugg = st.lists(_pi_val, min_size=1, max_size=4, unique=True)
+_pi_ws = st.sampled_from(["", " ", "  "])
+_pi_settings = settings(
+    max_examples=150,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+
+
+class TestParserInvariants:
+    """Property net over _parse_structured_output so new parsing misses surface
+    here, not in review. Three invariants across fuzzed inputs: valid trailers
+    round-trip, malformed trailers never leak raw JSON, pure prose is preserved.
+    Scoped to the trailer-on-its-own-line space the prompt requests; the
+    inherent-ambiguity cases are xfail below and are resolved by the
+    structured-output migration, not by more heuristics."""
+
+    @_pi_settings
+    @given(prose=_pi_prose, su=_pi_schema, sg=_pi_sugg, ws=_pi_ws, bold=st.booleans())
+    def test_valid_trailers_round_trip(self, agent, prose, su, sg, ws, bold):
+        marker = "**SCHEMA_UPDATE**" if bold else "SCHEMA_UPDATE"
+        raw = (
+            prose
+            + "\n"
+            + marker
+            + ws
+            + ": "
+            + json.dumps(su)
+            + "\nSUGGESTIONS: "
+            + json.dumps(sg)
+        )
+        text, suggestions, updates = agent._parse_structured_output(raw)
+        assert updates == su
+        assert [c.label for c in suggestions] == sg
+        assert text == prose.strip()
+        assert "SCHEMA_UPDATE" not in text and "SUGGESTIONS" not in text
+
+    @_pi_settings
+    @given(prose=_pi_prose, su=_pi_schema)
+    def test_malformed_schema_never_leaks(self, agent, prose, su):
+        raw = prose + "\nSCHEMA_UPDATE: " + json.dumps(su)[:-1]
+        text, _, updates = agent._parse_structured_output(raw)
+        assert updates == {}
+        assert not any(ch in text for ch in "{}[]")
+        assert "SCHEMA_UPDATE" not in text
+
+    @_pi_settings
+    @given(prose=_pi_prose)
+    def test_pure_prose_preserved(self, agent, prose):
+        text, suggestions, updates = agent._parse_structured_output(prose)
+        assert text == prose.strip()
+        assert suggestions == []
+        assert updates == {}
+
+    # ---- specific residual leaks surfaced by the Codex adversarial pass ----
+
+    def test_marker_word_inside_malformed_string_no_leak(self, agent):
+        raw = (
+            "Recorded.\n"
+            'SCHEMA_UPDATE: {"organism": "has SUGGESTIONS inside", '
+            '"workflow": broken}\n'
+            'SUGGESTIONS: ["Next"]'
+        )
+        text, suggestions, updates = agent._parse_structured_output(raw)
+        assert updates == {}
+        assert [c.label for c in suggestions] == ["Next"]
+        assert "SUGGESTIONS inside" not in text
+        assert not any(ch in text for ch in "{}")
+        assert text == "Recorded."
+
+    def test_valid_prefix_trailing_junk_stripped(self, agent):
+        raw = 'Pick.\nSUGGESTIONS: ["A"], ["B"]'
+        text, suggestions, _ = agent._parse_structured_output(raw)
+        assert [c.label for c in suggestions] == ["A"]
+        assert not any(ch in text for ch in "[]")
+        assert text == "Pick."
+
+    def test_whitespace_before_colon_extracted(self, agent):
+        raw = 'Recorded. SCHEMA_UPDATE : {"organism": "P. falciparum"}'
+        text, _, updates = agent._parse_structured_output(raw)
+        assert updates == {"organism": "P. falciparum"}
+        assert "SCHEMA_UPDATE" not in text
+        assert text == "Recorded."
+
+    # ---- inherent scrape ambiguity: deferred to the structured-output migration ----
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="Inherent to scraping: an uppercase marker inside a string is "
+        "indistinguishable from a real inline trailer. Resolved by the "
+        "structured-output migration (follow-up PR), not more heuristics.",
+    )
+    def test_uppercase_marker_with_brace_in_suggestion(self, agent):
+        raw = 'Pick.\nSUGGESTIONS: ["config uses SCHEMA_UPDATE: {values}"]'
+        _, suggestions, updates = agent._parse_structured_output(raw)
+        assert updates == {}
+        assert [c.label for c in suggestions] == ["config uses SCHEMA_UPDATE: {values}"]
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="Inherent to scraping: all-caps inline prose is indistinguishable "
+        "from an inline trailer. Resolved by the structured-output migration.",
+    )
+    def test_all_caps_prose_not_a_trailer(self, agent):
+        raw = 'MY SUGGESTIONS: ["check the docs"] before you decide.'
+        text, suggestions, _ = agent._parse_structured_output(raw)
+        assert suggestions == []
+        assert text == raw

--- a/backend/api/tests/test_assistant_agent.py
+++ b/backend/api/tests/test_assistant_agent.py
@@ -526,6 +526,24 @@ class TestApplySchemaUpdates:
         assert result.workflow.status == FieldStatus.EMPTY
         assert result.workflow.detail is None
 
+    def test_restored_invalid_workflow_cleared(self, agent):
+        # A restored session with a FILLED workflow whose detail no longer maps
+        # to a visible catalog entry is cleared, so it can't complete or hand off
+        # on a phantom workflow (Copilot).
+        agent.catalog.workflows_by_category = [
+            {
+                "category": "ASSEMBLY",
+                "workflows": [{"iwcId": "real", "trsId": "trs-real"}],
+            }
+        ]
+        schema = AnalysisSchema(
+            workflow=SchemaField(
+                value="Old WF", detail="trs-gone", status=FieldStatus.FILLED
+            )
+        )
+        result = agent._apply_schema_updates(schema, {})
+        assert result.workflow.status == FieldStatus.EMPTY
+
     def test_preserves_existing_fields(self, agent):
         schema = AnalysisSchema(
             organism=SchemaField(value="Existing", status=FieldStatus.FILLED)
@@ -1731,6 +1749,17 @@ class TestParserInvariants:
         assert updates == {}
         assert not any(ch in text for ch in "{}[]")
         assert "SCHEMA_UPDATE" not in text
+
+    def test_inline_trailer_after_malformed_dropped_no_leak(self, agent):
+        # Trade-off: an inline trailer sharing a line with a malformed one is
+        # dropped rather than risk a leak (an inline boundary can't be told apart
+        # from a marker inside a string). No raw JSON leaks; chips are lost.
+        raw = 'Recorded. SCHEMA_UPDATE: {"organism": broken SUGGESTIONS: ["Next"]'
+        text, suggestions, updates = agent._parse_structured_output(raw)
+        assert updates == {}
+        assert not any(ch in text for ch in "{}[]")
+        assert text == "Recorded."
+        assert suggestions == []
 
     def test_whitespace_before_colon_extracted(self, agent):
         raw = 'Recorded. SCHEMA_UPDATE : {"organism": "P. falciparum"}'


### PR DESCRIPTION
The Analysis Assistant builds an "Analysis Setup" tracker as the conversation
goes, and only hands off to workflow setup once it's complete. Today that
tracker is filled entirely from the SCHEMA_UPDATE lines the model emits -- fine
with a strong model, but it broke in two ways I kept hitting against smaller,
self-hosted models (the TACC MiniMax / gpt-oss endpoints):

- Fields that aren't user choices never filled. "Data characteristics"
  (paired/single-end reads, or an assembled genome) and "Gene annotation" are
  properties of the chosen workflow and assembly, not user decisions -- so the
  model correctly never emits a SCHEMA_UPDATE for them, and they sat Pending,
  blocking the handoff. I derive them deterministically from the catalog
  instead: data characteristics from the workflow's read inputs (or a FASTA
  genome input for annotation workflows), gene annotation from the selected
  assembly's gene model. Same "the catalog decides, don't make the model guess"
  principle the rest of the platform follows.

- The model dropped SCHEMA_UPDATE lines. Smaller models intermittently skip the
  line on the turn a decision is made, and the prompt only asked for it then --
  one missed turn left the tracker permanently behind. The prompt now asks the
  model to re-emit every committed field each turn, which is self-healing.

Separately, I saw raw SUGGESTIONS/SCHEMA_UPDATE JSON leak into the visible reply
when the model emitted it inline, split across lines, or with mangled brackets
-- the old parser only matched a marker at line start and required valid JSON.
The parser now scans the whole reply, decodes the JSON wherever it sits, and
excises an uppercase marker's payload even when it can't parse (so raw JSON is
never shown), while leaving lowercase prose like "a few suggestions: [...]"
alone.

Gene-annotation reconciliation also auto-fills the GTF when the assembly ships
one instead of flagging it for attention (#1324/#1331).

Five commits, each green on its own; tests cover the catalog-derived fills and
the parser's inline / multi-line / mangled-JSON / prose cases.
