### PR TITLE
ci: add cross-site ci matrix — ga2 build + smoke tests (#1409)

### DIFF
--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -30,6 +30,38 @@ jobs:
           path: playwright-report/
           retention-days: 7
 
+  ga2-smoke-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22.13.0"
+      - name: Cache npm cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+      - name: Install dependencies
+        run: npm ci
+      # Builds the GA2 site (build-local:ga2), covering GA2's build on every PR
+      # alongside the BRC build in the e2e-tests job, then runs the GA2-only
+      # smoke suite against it. Chromium only — this is a smoke check, not the
+      # full cross-browser e2e run.
+      - name: Build GA2 production bundle
+        run: npm run build-local:ga2
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+      - name: Run GA2 smoke tests
+        run: npm run test:e2e:ga2
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report-ga2
+          path: playwright-report/
+          retention-days: 7
+
   run-checks:
     runs-on: ubuntu-latest
     steps:

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test": "jest --runInBand --passWithNoTests",
     "test:e2e": "npx playwright test",
     "test:e2e:api": "npx playwright test --config=playwright.api.config.ts",
+    "test:e2e:ga2": "npx playwright test --config=playwright.ga2.config.ts",
     "select-ga2-organism-images": "python3 -m catalog.ga2.build.py.select_images_for_organism",
     "build-brc-db": "NODE_ENV=production esrun catalog/build/ts/build-catalog.ts",
     "build-ga2-db": "esrun catalog/ga2/build/ts/build-catalog.ts",

--- a/playwright.ga2.config.ts
+++ b/playwright.ga2.config.ts
@@ -5,9 +5,12 @@ import { defineConfig, devices } from "@playwright/test";
  * required).
  *
  * The default playwright.config.ts builds and tests the BRC Analytics site.
- * This config builds and serves the GA2 site and runs the GA2-only smoke suite
- * in tests/e2e/ga2. It is kept separate so the default `npx playwright test`
- * (BRC) is unaffected — the two sites are exercised by independent jobs.
+ * This config runs the GA2-only smoke suite in tests/e2e/ga2 against a served
+ * GA2 build. Locally the webServer builds GA2 first (`build-local:ga2 &&
+ * start`); in CI it only runs `npm run start`, relying on the ga2-smoke-tests
+ * workflow job to build GA2 beforehand. It is kept separate so the default
+ * `npx playwright test` (BRC) is unaffected — the two sites are exercised by
+ * independent jobs.
  *
  * Run with:
  *   npx playwright test --config=playwright.ga2.config.ts

--- a/playwright.ga2.config.ts
+++ b/playwright.ga2.config.ts
@@ -1,0 +1,42 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Playwright configuration for GA2 (Genome Ark 2) UI smoke tests (no backend
+ * required).
+ *
+ * The default playwright.config.ts builds and tests the BRC Analytics site.
+ * This config builds and serves the GA2 site and runs the GA2-only smoke suite
+ * in tests/e2e/ga2. It is kept separate so the default `npx playwright test`
+ * (BRC) is unaffected — the two sites are exercised by independent jobs.
+ *
+ * Run with:
+ *   npx playwright test --config=playwright.ga2.config.ts
+ */
+export default defineConfig({
+  forbidOnly: !!process.env.CI,
+  fullyParallel: true,
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  reporter: "html",
+  retries: process.env.CI ? 2 : 0,
+  testDir: "./tests/e2e/ga2",
+  use: {
+    baseURL: "http://localhost:3000",
+    screenshot: "only-on-failure",
+    trace: "on-first-retry",
+    video: "retain-on-failure",
+  },
+  webServer: {
+    command: process.env.CI
+      ? "npm run start"
+      : "npm run build-local:ga2 && npm run start",
+    reuseExistingServer: !process.env.CI,
+    timeout: process.env.CI ? 120 * 1000 : 600 * 1000,
+    url: "http://localhost:3000",
+  },
+  workers: 3,
+});

--- a/tests/e2e/ga2/01-smoke.spec.ts
+++ b/tests/e2e/ga2/01-smoke.spec.ts
@@ -1,0 +1,47 @@
+import { ROUTES } from "../../../routes/constants";
+import { expect, test } from "../utils/fixtures";
+
+const PAGES = [
+  { name: "About", url: ROUTES.ABOUT },
+  { name: "Partner Resources", url: ROUTES.ABOUT_PARTNER_RESOURCES },
+  { name: "Roadmap", url: ROUTES.ABOUT_ROADMAP },
+  { name: "Organisms", url: ROUTES.ORGANISMS },
+  { name: "Assemblies", url: ROUTES.GENOMES },
+  { name: "Workflows", url: ROUTES.WORKFLOWS },
+];
+
+test.describe("Genome Ark 2 - UI Smoke Tests", () => {
+  test("homepage should load", async ({ page }) => {
+    await page.goto("/");
+
+    // Page should have a title
+    await expect(page).toHaveTitle(/Genome Ark 2$/);
+  });
+
+  test("navigation should be present", async ({ page }) => {
+    await page.goto("/");
+
+    // Header should be visible
+    const header = page.locator("header");
+    await expect(header).toBeVisible();
+
+    // Navigation should be visible
+    const navigation = page.getByTestId("navigation");
+    await expect(navigation).toBeVisible();
+  });
+
+  for (const { name, url } of PAGES) {
+    test(`${name} page should load`, async ({ page }) => {
+      await page.goto(url);
+
+      // Page should have title
+      await expect(page).toHaveTitle(/Genome Ark 2$/);
+
+      // Page should have content
+      await expect(page.locator("main")).toBeVisible();
+
+      // Page heading should be visible
+      await expect(page.locator("h1").first()).toBeVisible();
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Closes #1409. Part of the GA2/BRC site-separation work (#1246).

Adds cross-site CI coverage so a change that breaks the GA2 site can't land silently. Today CI type-checks the whole repo (both sites) but only **builds** and **e2e-tests** BRC.

### What changed
- **New `ga2-smoke-tests` job** in `run-checks.yml`: builds the GA2 site (`build-local:ga2`) and runs a GA2-only Playwright smoke suite (chromium). This covers GA2's build on every PR, alongside the existing BRC build in the `e2e-tests` job.
- **New `playwright.ga2.config.ts`**: isolated GA2 config (`testDir: tests/e2e/ga2`), following the existing `playwright.api.config.ts` precedent. Kept separate so the default `npx playwright test` (BRC) is unaffected.
- **New `tests/e2e/ga2/01-smoke.spec.ts`**: GA2 analog of the BRC smoke spec — loads home + About, Partner Resources, Roadmap, Organisms, Assemblies, Workflows and asserts title / `main` / `h1`.
- **New `test:e2e:ga2` npm script**.

### Coverage after this PR
| | Build | e2e | Type-check |
|---|---|---|---|
| BRC | ✅ existing `e2e-tests` job | ✅ existing (unchanged) | ✅ `tsc` (whole-repo) |
| GA2 | ✅ new `ga2-smoke-tests` job | ✅ smoke (new) | ✅ `tsc` (whole-repo) |

### Validation
- GA2 smoke suite: **8/8 passing** locally against a real GA2 build.
- Prettier, ESLint, `tsc` clean. BRC e2e job untouched.

### Notes / follow-ups
- **GA2 e2e is a smoke suite, not full parity** with the BRC e2e suite — deliberate for this ticket. Expanding GA2 e2e coverage is separate work.
- Acceptance criterion "a deliberately broken cross-site change fails CI" is best confirmed by watching this PR's CI run.