### PR TITLE
refactor: drop ga2 cross-catalog import of organism_ploidy (#1410)

### DIFF
--- a/app/apis/catalog/common/schema-entities.ts
+++ b/app/apis/catalog/common/schema-entities.ts
@@ -1,0 +1,9 @@
+/**
+ * Site-neutral re-exports of shared catalog schema enums.
+ *
+ * These enums originate from the shared LinkML-generated schema and are
+ * consumed by both the BRC and GA2 catalogs. Re-exporting them here gives each
+ * site a site-neutral import path so that neither catalog has to import from
+ * the other's directory.
+ */
+export { OrganismPloidy as ORGANISM_PLOIDY } from "../../../../catalog/schema/generated/schema";

--- a/app/apis/catalog/ga2/entities.ts
+++ b/app/apis/catalog/ga2/entities.ts
@@ -1,4 +1,4 @@
-import { ORGANISM_PLOIDY } from "../brc-analytics-catalog/common/schema-entities";
+import type { ORGANISM_PLOIDY } from "../common/schema-entities";
 
 export type GA2Catalog = GA2AssemblyEntity | GA2OrganismEntity;
 


### PR DESCRIPTION
## Summary

Closes #1410. Part of the GA2/BRC site-separation work (#1246).

GA2's `entities.ts` imported `ORGANISM_PLOIDY` from the BRC catalog (`brc-analytics-catalog/common/schema-entities`), a hard cross-catalog dependency that prevented GA2's catalog module from type-checking independently of BRC.

### What changed
- **New `app/apis/catalog/common/schema-entities.ts`** — a site-neutral module that re-exports `ORGANISM_PLOIDY` from the shared generated schema (`catalog/schema/generated/schema.ts`), which is already consumed directly by shared views.
- **`app/apis/catalog/ga2/entities.ts`** — imports the enum from the neutral path via `import type` (it's used only in type position).
- No BRC changes.

### Result
- **Zero imports from `brc-analytics-catalog/` in `app/apis/catalog/ga2/`** (the catalog module — this ticket's target).
- `tsc`, ESLint, Prettier clean. GA2 build is exercised by the `ga2-smoke-tests` CI job added in #1409.

### Scope (deliberately narrow)
This ticket removes the **`app/apis/catalog/ga2/` → `app/apis/catalog/brc-analytics-catalog/`** dependency (the ORGANISM_PLOIDY import). It does **not** attempt to remove every cross-catalog import from all GA2-namespaced files:
- **Reverse direction (brc→ga2):** `brc-analytics-catalog/common/utils.ts` imports GA2 types — union-type leakage, scoped in **#1414 (2c)**.
- **GA2 view/builder reuse of BRC builders:** `viewModelBuilders/catalog/ga2/` and `views/.../Side/ga2/` import BRC *viewModelBuilders* (shared builder reuse) — structural coupling addressed by the later contract-type + component/builder-move work (Phase 1/2), not this ticket.