### PR TITLE
refactor: relocate organism contract to a site-neutral home (#1411)

### DIFF
--- a/app/apis/catalog/common/entities.ts
+++ b/app/apis/catalog/common/entities.ts
@@ -1,0 +1,24 @@
+import type { OutbreakPriority as OUTBREAK_PRIORITY } from "../../../../catalog/schema/generated/schema";
+
+/**
+ * Site-neutral structural contract for an organism as consumed by the shared
+ * OrganismView and the workflow side panel. Both BRCDataCatalogOrganism and
+ * GA2OrganismEntity satisfy it structurally, and an assembly can be mapped into
+ * it (see mapAssemblyToOrganism). Fields that GA2's organism (or the
+ * assembly-derived case) lacks are optional; consumers must omit them from
+ * display when undefined.
+ */
+export interface OrganismContract {
+  genomes?: OrganismGenome[];
+  ncbiTaxonomyId: string;
+  priority?: OUTBREAK_PRIORITY | null;
+  priorityPathogenName?: string | null;
+  taxonomicLevelIsolate?: string[];
+  taxonomicLevelSerotype?: string[];
+  taxonomicLevelSpecies: string;
+  taxonomicLevelStrain?: string[];
+}
+
+interface OrganismGenome {
+  lineageTaxonomyIds: string[];
+}

--- a/app/views/OrganismView/types.ts
+++ b/app/views/OrganismView/types.ts
@@ -1,23 +1,5 @@
-import type { OUTBREAK_PRIORITY } from "app/apis/catalog/brc-analytics-catalog/common/schema-entities";
-
-/**
- * Organism-scoped shape shared across BRC and GA2 and consumed by the workflow
- * side panel. Both BRCDataCatalogOrganism and GA2OrganismEntity satisfy it
- * structurally, and an assembly can be mapped into it (see mapAssemblyToOrganism).
- * Fields that GA2's organism (or the assembly-derived case) lacks are optional;
- * consumers must omit them from display when undefined.
- */
-export interface Organism {
-  genomes?: OrganismGenome[];
-  ncbiTaxonomyId: string;
-  priority?: OUTBREAK_PRIORITY | null;
-  priorityPathogenName?: string | null;
-  taxonomicLevelIsolate?: string[];
-  taxonomicLevelSerotype?: string[];
-  taxonomicLevelSpecies: string;
-  taxonomicLevelStrain?: string[];
-}
-
-interface OrganismGenome {
-  lineageTaxonomyIds: string[];
-}
+// Transitional shim for the GA2/BRC split (monorepo-split): the organism
+// contract moved to a site-neutral home (app/apis/catalog/common/entities.ts)
+// as OrganismContract. Importers still reference `Organism` here; migrate them,
+// then remove this file.
+export type { OrganismContract as Organism } from "../../apis/catalog/common/entities";


### PR DESCRIPTION
## Summary

Closes #1411. Part of the GA2/BRC site-separation work (#1246).

The structural `Organism` contract — the projection that lets BRC's organism, GA2's organism, and an assembly-derived object all flow through the shared `OrganismView` and workflow side panel — lived in `app/views/OrganismView/types.ts`, a *view* directory that shared `viewModelBuilders` and other views import from. This moves it to a site-neutral home.

### What changed
- **New `app/apis/catalog/common/entities.ts`** — defines `OrganismContract` (the relocated interface). Imports `OUTBREAK_PRIORITY` directly from the generated schema so it stays site-neutral and independent of #1410.
- **`app/views/OrganismView/types.ts`** — now a transitional shim: `export type { OrganismContract as Organism }`. All 8 existing `Organism` importers are unchanged.

### Naming decision
Renamed `Organism` → **`OrganismContract`** (not `BaseOrganism`). The plan's note assumed the colliding `Organism` union in `WorkflowsView/types.ts` was dead, but it's now **actively used** (3 call sites), so it can't be deleted here — that's union-type-leakage work for 2a/2b/2c. `OrganismContract` avoids the clash and, unlike `BaseOrganism`, doesn't imply the WorkflowsView organism type derives from it (it won't).

### Scope (deliberately narrow)
Only the `Organism` contract is relocated. `WorkflowAssembly`/`BaseWorkflowAssembly`/`Assembly` contracts stay put — they move with 2a/2b, which already touch those files. The `WorkflowsView` `Organism` union is untouched.

### Shim marker
Used a `monorepo-split` marker in prose rather than `// TODO(monorepo-split)`: this repo is otherwise TODO-free and `sonarjs/todo-tag` warns on `TODO`, so the literal tag would add lint noise on every shim. The marker stays greppable. (Adjusting #1419's cleanup grep to match.)

### Validation
`tsc` (both sites, all 8 importers), ESLint, Prettier all clean. No behaviour change — pure type relocation.