### PR TITLE
refactor: convert viewModelBuilders assembly union to contract type (#1412)

### DIFF
--- a/app/apis/catalog/common/entities.ts
+++ b/app/apis/catalog/common/entities.ts
@@ -1,6 +1,46 @@
 import type { OutbreakPriority as OUTBREAK_PRIORITY } from "../../../../catalog/schema/generated/schema";
 
 /**
+ * Site-neutral structural contract for an assembly as consumed by the shared
+ * catalog viewModelBuilders. Both BRCDataCatalogGenome and GA2AssemblyEntity
+ * satisfy it structurally; shared builders accept this contract rather than a
+ * `BRCDataCatalogGenome | GA2AssemblyEntity` union so a field change in one
+ * catalog cannot silently weaken type safety for the other.
+ */
+export interface AssemblyContract {
+  accession: string;
+  annotationStatus: string | null;
+  chromosomes: number | null;
+  coverage: string | null;
+  galaxyDatacacheUrl: string | null;
+  gcPercent: number | null;
+  isRef: string;
+  length: number;
+  level: string;
+  ncbiTaxonomyId: string;
+  releaseDate: string;
+  scaffoldCount: number | null;
+  scaffoldL50: number | null;
+  scaffoldN50: number | null;
+  strainName: string | null;
+  taxonomicGroup: string[];
+  taxonomicLevelClass: string;
+  taxonomicLevelDomain: string;
+  taxonomicLevelFamily: string;
+  taxonomicLevelGenus: string;
+  // Isolate/serotype are BRC-only assembly taxonomy fields; GA2 assemblies lack
+  // them, so they are optional and consumers must default when absent.
+  taxonomicLevelIsolate?: string;
+  taxonomicLevelKingdom: string;
+  taxonomicLevelOrder: string;
+  taxonomicLevelPhylum: string;
+  taxonomicLevelSerotype?: string;
+  taxonomicLevelSpecies: string;
+  taxonomicLevelStrain: string;
+  ucscBrowserUrl: string | null;
+}
+
+/**
  * Site-neutral structural contract for an organism as consumed by the shared
  * OrganismView and the workflow side panel. Both BRCDataCatalogOrganism and
  * GA2OrganismEntity satisfy it structurally, and an assembly can be mapped into

--- a/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
@@ -1318,7 +1318,10 @@ export function getGenomeSerotypeText(
   genome: AssemblyContract,
   defaultValue = ""
 ): string {
-  if (genome.taxonomicLevelSerotype && genome.taxonomicLevelSerotype !== "None")
+  if (
+    genome.taxonomicLevelSerotype !== undefined &&
+    genome.taxonomicLevelSerotype !== "None"
+  )
     return genome.taxonomicLevelSerotype;
   return defaultValue;
 }
@@ -1333,7 +1336,10 @@ export function getGenomeIsolateText(
   genome: AssemblyContract,
   defaultValue = ""
 ): string {
-  if (genome.taxonomicLevelIsolate && genome.taxonomicLevelIsolate !== "None")
+  if (
+    genome.taxonomicLevelIsolate !== undefined &&
+    genome.taxonomicLevelIsolate !== "None"
+  )
     return genome.taxonomicLevelIsolate;
   return defaultValue;
 }

--- a/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.ts
@@ -30,6 +30,7 @@ import {
   getGenomeOrganismId,
   getOrganismId,
 } from "../../../../apis/catalog/brc-analytics-catalog/common/utils";
+import type { AssemblyContract } from "../../../../apis/catalog/common/entities";
 import { sanitizeEntityId } from "../../../../apis/catalog/common/utils";
 import {
   GA2AssemblyEntity,
@@ -64,7 +65,7 @@ import {
  * @returns Props to be used for the cell.
  */
 export const buildAccession = (
-  entity: BRCDataCatalogGenome | GA2AssemblyEntity
+  entity: AssemblyContract
 ): ComponentProps<typeof C.BasicCell> => {
   return {
     value: entity.accession,
@@ -77,7 +78,7 @@ export const buildAccession = (
  * @returns Props to be used for the AnalyzeGenome component.
  */
 export const buildAnalyzeGenome = (
-  entity: BRCDataCatalogGenome | GA2AssemblyEntity
+  entity: AssemblyContract
 ): ComponentProps<typeof C.AnalyzeGenome> => {
   const { accession, ncbiTaxonomyId, ucscBrowserUrl } = entity;
   return {
@@ -111,7 +112,7 @@ export const buildAnalyzeGenome = (
  * @returns Props for the BasicCell component.
  */
 export const buildAnnotationStatus = (
-  entity: BRCDataCatalogGenome | GA2AssemblyEntity
+  entity: AssemblyContract
 ): ComponentProps<typeof C.BasicCell> => {
   return {
     value: entity.annotationStatus,
@@ -124,7 +125,7 @@ export const buildAnnotationStatus = (
  * @returns Props to be used for the KeyValuePairs component.
  */
 export const buildAssemblyDetails = (
-  assembly: BRCDataCatalogGenome | GA2AssemblyEntity
+  assembly: AssemblyContract
 ): ComponentProps<typeof C.KeyValuePairs> => {
   const keyValuePairs = new Map<Key, Value>();
   keyValuePairs.set(
@@ -161,7 +162,7 @@ export const buildAssemblyCount = (
  * @returns Props for the BasicCell component.
  */
 export const buildChromosomes = (
-  entity: BRCDataCatalogGenome | GA2AssemblyEntity
+  entity: AssemblyContract
 ): ComponentProps<typeof C.BasicCell> => {
   return {
     value: formatNumber(entity.chromosomes),
@@ -187,7 +188,7 @@ export const buildCommonName = (
  * @returns Props for the BasicCell component.
  */
 export const buildCoverage = (
-  entity: BRCDataCatalogGenome | GA2AssemblyEntity
+  entity: AssemblyContract
 ): ComponentProps<typeof C.BasicCell> => {
   return {
     value: entity.coverage,
@@ -200,7 +201,7 @@ export const buildCoverage = (
  * @returns Props for the BasicCell component.
  */
 export const buildGcPercent = (
-  entity: BRCDataCatalogGenome | GA2AssemblyEntity
+  entity: AssemblyContract
 ): ComponentProps<typeof C.BasicCell> => {
   return {
     value: entity.gcPercent,
@@ -323,7 +324,7 @@ export const buildOrganismGenomeSpecies = (
  * @returns Props to be used for the BasicCell component.
  */
 export const buildGenomeTaxonomicLevelStrain = (
-  entity: BRCDataCatalogGenome | GA2AssemblyEntity
+  entity: AssemblyContract
 ): ComponentProps<typeof C.BasicCell> => {
   return {
     value: getGenomeStrainText(entity),
@@ -362,7 +363,7 @@ export const buildGenomeTaxonomicLevelIsolate = (
  * @returns Props for the ChipCell component.
  */
 export const buildIsRef = (
-  entity: BRCDataCatalogGenome | GA2AssemblyEntity
+  entity: AssemblyContract
 ): ComponentProps<typeof C.ChipCell> => {
   return {
     getValue: () => ({
@@ -382,7 +383,7 @@ export const buildIsRef = (
  * @returns Props for the BasicCell component.
  */
 export const buildLength = (
-  entity: BRCDataCatalogGenome | GA2AssemblyEntity
+  entity: AssemblyContract
 ): ComponentProps<typeof C.BasicCell> => {
   return {
     value: formatNumber(entity.length),
@@ -413,7 +414,7 @@ const LEVEL_LABEL: Record<string, string> = {
  * @returns Props for the LevelCell component.
  */
 export const buildLevel = (
-  entity: BRCDataCatalogGenome | GA2AssemblyEntity
+  entity: AssemblyContract
 ): ComponentProps<typeof C.LevelCell> => {
   return {
     filledCount: LEVEL_FILLED_COUNT[entity.level] ?? 0,
@@ -831,7 +832,7 @@ export const buildTaxonomicLevelRealm = (
  * @returns Props for the BasicCell component.
  */
 export const buildReleaseDate = (
-  entity: BRCDataCatalogGenome | GA2AssemblyEntity
+  entity: AssemblyContract
 ): ComponentProps<typeof C.BasicCell> => {
   return {
     value: entity.releaseDate
@@ -846,7 +847,7 @@ export const buildReleaseDate = (
  * @returns Props for the Tooltip component.
  */
 export const buildReleaseDateTooltip = (
-  entity: BRCDataCatalogGenome | GA2AssemblyEntity
+  entity: AssemblyContract
 ): Omit<ComponentProps<typeof C.Tooltip>, "children"> => {
   return {
     arrow: true,
@@ -862,7 +863,7 @@ export const buildReleaseDateTooltip = (
  * @returns Props for the BasicCell component.
  */
 export const buildScaffoldCount = (
-  entity: BRCDataCatalogGenome | GA2AssemblyEntity
+  entity: AssemblyContract
 ): ComponentProps<typeof C.BasicCell> => {
   return {
     value: formatNumber(entity.scaffoldCount),
@@ -875,7 +876,7 @@ export const buildScaffoldCount = (
  * @returns Props for the BasicCell component.
  */
 export const buildScaffoldL50 = (
-  entity: BRCDataCatalogGenome | GA2AssemblyEntity
+  entity: AssemblyContract
 ): ComponentProps<typeof C.BasicCell> => {
   return {
     value: formatNumber(entity.scaffoldL50),
@@ -888,7 +889,7 @@ export const buildScaffoldL50 = (
  * @returns Props for the BasicCell component.
  */
 export const buildScaffoldN50 = (
-  entity: BRCDataCatalogGenome | GA2AssemblyEntity
+  entity: AssemblyContract
 ): ComponentProps<typeof C.BasicCell> => {
   return {
     value: formatNumber(entity.scaffoldN50),
@@ -914,7 +915,7 @@ export const buildTaxonomyId = (
  * @returns Props to be used for the AnalysisPortals component.
  */
 export const buildAssemblyResources = (
-  entity: BRCDataCatalogGenome | GA2AssemblyEntity
+  entity: AssemblyContract
 ): Pick<ComponentProps<typeof C.AnalysisPortals>, "portals"> => {
   return {
     portals: [
@@ -1298,7 +1299,7 @@ function getEntityLinkWithPriorityPathogenFilter(
  * @returns strain text.
  */
 export function getGenomeStrainText(
-  entity: BRCDataCatalogGenome | GA2AssemblyEntity,
+  entity: AssemblyContract,
   defaultValue = ""
 ): string {
   if (entity.strainName) return entity.strainName;
@@ -1314,13 +1315,10 @@ export function getGenomeStrainText(
  * @returns serotype text.
  */
 export function getGenomeSerotypeText(
-  genome: BRCDataCatalogGenome | GA2AssemblyEntity,
+  genome: AssemblyContract,
   defaultValue = ""
 ): string {
-  if (
-    "taxonomicLevelSerotype" in genome &&
-    genome.taxonomicLevelSerotype !== "None"
-  )
+  if (genome.taxonomicLevelSerotype && genome.taxonomicLevelSerotype !== "None")
     return genome.taxonomicLevelSerotype;
   return defaultValue;
 }
@@ -1332,13 +1330,10 @@ export function getGenomeSerotypeText(
  * @returns isolate text.
  */
 export function getGenomeIsolateText(
-  genome: BRCDataCatalogGenome | GA2AssemblyEntity,
+  genome: AssemblyContract,
   defaultValue = ""
 ): string {
-  if (
-    "taxonomicLevelIsolate" in genome &&
-    genome.taxonomicLevelIsolate !== "None"
-  )
+  if (genome.taxonomicLevelIsolate && genome.taxonomicLevelIsolate !== "None")
     return genome.taxonomicLevelIsolate;
   return defaultValue;
 }

--- a/site-config/brc-analytics/local/index/genomeEntityConfig.ts
+++ b/site-config/brc-analytics/local/index/genomeEntityConfig.ts
@@ -243,7 +243,12 @@ export const genomeEntityConfig: AppEntityConfig<BRCDataCatalogGenome> = {
           ],
           component: C.Tooltip,
           viewBuilder: V.buildReleaseDateTooltip,
-        } as ComponentConfig<typeof C.Tooltip, BRCDataCatalogGenome>,
+          // The shared release-date builders take the site-neutral
+          // AssemblyContract, which TS can't reconcile with this cast:
+          // ComponentConfig's data type is invariant and the Tooltip viewBuilder
+          // omits `children` (supplied above). Double cast is the repo's
+          // escape-hatch for this findable-ui typing limitation.
+        } as unknown as ComponentConfig<typeof C.Tooltip, BRCDataCatalogGenome>,
         header: BRC_DATA_CATALOG_CATEGORY_LABEL.RELEASE_DATE,
         id: BRC_DATA_CATALOG_CATEGORY_KEY.RELEASE_DATE,
         width: { max: "1fr", min: "120px" },

--- a/site-config/ga2/local/index/genome/columnDefs.ts
+++ b/site-config/ga2/local/index/genome/columnDefs.ts
@@ -135,7 +135,11 @@ export const RELEASE_DATE: ColumnConfig<GA2AssemblyEntity> = {
     ],
     component: C.Tooltip,
     viewBuilder: buildReleaseDateTooltip,
-  } as ComponentConfig<typeof C.Tooltip, GA2AssemblyEntity>,
+    // The shared release-date builders take the site-neutral AssemblyContract,
+    // which TS can't reconcile with this cast: ComponentConfig's data type is
+    // invariant and the Tooltip viewBuilder omits `children` (supplied above).
+    // Double cast is the repo's escape-hatch for this findable-ui limitation.
+  } as unknown as ComponentConfig<typeof C.Tooltip, GA2AssemblyEntity>,
   header: GA2_CATEGORY_LABEL.RELEASE_DATE,
   id: GA2_CATEGORY_KEY.RELEASE_DATE,
   width: { max: "1fr", min: "120px" },


### PR DESCRIPTION
## Summary

Closes #1412. Part of the GA2/BRC site-separation work (#1246).

Replaces the `BRCDataCatalogGenome | GA2AssemblyEntity` union in the shared assembly viewModelBuilders with a site-neutral `AssemblyContract`, so a field change in one catalog can't silently weaken type safety for the other.

### What changed
- **`app/apis/catalog/common/entities.ts`** — adds `AssemblyContract` alongside the `OrganismContract` from #1411. `taxonomicLevelIsolate`/`taxonomicLevelSerotype` are optional (BRC-only; GA2 assemblies lack them), mirroring `OrganismContract`'s optional-field pattern.
- **`viewModelBuilders.ts`** — the **18** pure assembly-union signatures now take `AssemblyContract`. `getGenomeSerotypeText`/`getGenomeIsolateText` use a truthiness guard instead of `"x" in genome` (same behavior; drops the structural-typing check).
- **2 release-date Tooltip configs** (BRC + GA2) — `as unknown as ComponentConfig<…, ConcreteType>` with an explanatory comment. `ComponentConfig`'s data type is invariant (flows into `ViewContext<D>`) and the Tooltip viewBuilder returns `Omit<…,"children">`, so once the builder takes the neutral contract TS can't reconcile the pre-existing cast. `as unknown as` is the repo's existing escape-hatch (5 prior uses).

### Scope (deliberately narrow)
Assembly union only. **Left for #1414 (2c):** the triple-union in `buildTaxonomyId` and the 4-way `TaxonomicGroupEntity` alias (both mix organism + assembly), plus the eventual per-site split of the serotype/isolate helpers.

### Validation
`tsc` (both sites), ESLint, Prettier clean. No call-site changes beyond the 2 Tooltip casts. Rebased onto current `main` (after #1409/#1410/#1411 merged); `common/entities.ts` cleanly co-locates both contracts.