### PR TITLE
refactor: convert workflow service + analyze utils unions to contracts (#1413)

### DIFF
--- a/app/apis/catalog/common/entities.ts
+++ b/app/apis/catalog/common/entities.ts
@@ -1,4 +1,5 @@
 import type { OutbreakPriority as OUTBREAK_PRIORITY } from "../../../../catalog/schema/generated/schema";
+import type { ORGANISM_PLOIDY } from "./schema-entities";
 
 /**
  * Site-neutral structural contract for an assembly as consumed by the shared
@@ -17,7 +18,9 @@ export interface AssemblyContract {
   isRef: string;
   length: number;
   level: string;
+  lineageTaxonomyIds: string[];
   ncbiTaxonomyId: string;
+  ploidy: ORGANISM_PLOIDY[];
   releaseDate: string;
   scaffoldCount: number | null;
   scaffoldL50: number | null;

--- a/app/services/workflows/entities.ts
+++ b/app/services/workflows/entities.ts
@@ -1,13 +1,11 @@
 import {
-  BRCDataCatalogGenome,
-  BRCDataCatalogOrganism,
   Workflow,
   WorkflowCategory,
 } from "../../apis/catalog/brc-analytics-catalog/common/entities";
-import {
-  GA2AssemblyEntity,
-  GA2OrganismEntity,
-} from "../../apis/catalog/ga2/entities";
+import type {
+  AssemblyContract,
+  OrganismContract,
+} from "../../apis/catalog/common/entities";
 import { findEntity, getEntities, getEntity } from "./query";
 
 /**
@@ -15,9 +13,9 @@ import { findEntity, getEntities, getEntity } from "./query";
  * @param entityId - Entity id.
  * @returns Organism, or undefined when not found.
  */
-export function findOrganism<
-  T extends BRCDataCatalogOrganism | GA2OrganismEntity,
->(entityId: string): T | undefined {
+export function findOrganism<T extends OrganismContract>(
+  entityId: string
+): T | undefined {
   return findEntity<T>("organisms", entityId);
 }
 
@@ -25,9 +23,7 @@ export function findOrganism<
  * Gets assemblies.
  * @returns Assemblies.
  */
-export function getAssemblies<
-  T extends BRCDataCatalogGenome | GA2AssemblyEntity,
->(): T[] {
+export function getAssemblies<T extends AssemblyContract>(): T[] {
   return getEntities<T>("assemblies");
 }
 
@@ -36,9 +32,7 @@ export function getAssemblies<
  * @param entityId - Entity id.
  * @returns Assembly.
  */
-export function getAssembly<T extends BRCDataCatalogGenome | GA2AssemblyEntity>(
-  entityId: string
-): T {
+export function getAssembly<T extends AssemblyContract>(entityId: string): T {
   return getEntity<T>("assemblies", entityId);
 }
 
@@ -47,9 +41,7 @@ export function getAssembly<T extends BRCDataCatalogGenome | GA2AssemblyEntity>(
  * @param entityId - Entity id.
  * @returns Organism.
  */
-export function getOrganism<
-  T extends BRCDataCatalogOrganism | GA2OrganismEntity,
->(entityId: string): T {
+export function getOrganism<T extends OrganismContract>(entityId: string): T {
   return getEntity<T>("organisms", entityId);
 }
 
@@ -57,9 +49,7 @@ export function getOrganism<
  * Gets organisms.
  * @returns Organisms.
  */
-export function getOrganisms<
-  T extends BRCDataCatalogOrganism | GA2OrganismEntity,
->(): T[] {
+export function getOrganisms<T extends OrganismContract>(): T[] {
   return getEntities<T>("organisms");
 }
 

--- a/app/views/AnalyzeWorkflowsView/components/Main/utils.ts
+++ b/app/views/AnalyzeWorkflowsView/components/Main/utils.ts
@@ -1,6 +1,5 @@
 import { WorkflowCategoryId } from "../../../../../catalog/schema/generated/schema";
 import {
-  BRCDataCatalogGenome,
   Workflow,
   WorkflowCategory,
 } from "../../../../apis/catalog/brc-analytics-catalog/common/entities";
@@ -9,7 +8,7 @@ import {
   WORKFLOW_SCOPE,
 } from "../../../../apis/catalog/brc-analytics-catalog/common/schema-entities";
 import { workflowPloidyMatchesOrganismPloidy } from "../../../../apis/catalog/brc-analytics-catalog/common/utils";
-import { GA2AssemblyEntity } from "../../../../apis/catalog/ga2/entities";
+import type { AssemblyContract } from "../../../../apis/catalog/common/entities";
 import { DIFFERENTIAL_EXPRESSION_ANALYSIS } from "../../differentialExpressionAnalysis/constants";
 
 /**
@@ -21,7 +20,7 @@ import { DIFFERENTIAL_EXPRESSION_ANALYSIS } from "../../differentialExpressionAn
  * @returns Workflow categories compatible with the given assembly.
  */
 export function buildAssemblyWorkflows(
-  assembly: BRCDataCatalogGenome | GA2AssemblyEntity,
+  assembly: AssemblyContract,
   allWorkflowCategories: WorkflowCategory[],
   isAssemblyWorkflowsEnabled = false
 ): WorkflowCategory[] {
@@ -108,7 +107,7 @@ export function workflowRequiresAssemblyId(workflow: Workflow): boolean {
  */
 export function workflowIsCompatibleWithAssembly(
   workflow: Workflow,
-  assembly: BRCDataCatalogGenome | GA2AssemblyEntity
+  assembly: AssemblyContract
 ): boolean {
   if (
     workflow.taxonomyId !== null &&


### PR DESCRIPTION
## Summary

Closes #1413. Part of the GA2/BRC site-separation work (#1246). Rebased onto `main` after #1411/#1412 merged.

Replaces generic-over-union constraints and union params with the site-neutral contracts from #1411 (`OrganismContract`) / #1412 (`AssemblyContract`).

### What changed
- **`services/workflows/entities.ts`** — the 5 generic functions' `<T extends BRCDataCatalog… | GA2…>` constraints become `<T extends OrganismContract>` / `<T extends AssemblyContract>`. The constraint is a **lower bound**, and the functions return the caller's explicit `T`, so callers passing a concrete/union type still get it back whole (e.g. a future `getOrganism<BRCDataCatalogOrganism>(id)` returns a full BRC organism). No call-site changes — every caller passes `<T>` explicitly.
- **`AnalyzeWorkflowsView/components/Main/utils.ts`** — the two `BRCDataCatalogGenome | GA2AssemblyEntity` params become `AssemblyContract`.
- **`app/apis/catalog/common/entities.ts`** — extend `AssemblyContract` with `lineageTaxonomyIds` and `ploidy` (both on the concrete types; consumed by the analyze utils).

### Scope note (→ 2c)
Deliberately **excludes** `WorkflowInputsView/types.ts`'s `Assembly` union: it's consumed by `mapAssemblyToOrganism`, whose `"priority" in assembly` structural checks are the site-detection smell that **#1414 (2c)** owns.

### Validation
`tsc` (both sites), ESLint, Prettier clean.