### PR TITLE
refactor: convert remaining mechanical catalog unions to contracts (#1414)

### DIFF
--- a/app/apis/catalog/brc-analytics-catalog/common/utils.ts
+++ b/app/apis/catalog/brc-analytics-catalog/common/utils.ts
@@ -1,26 +1,19 @@
 import { WorkflowEntity } from "../../../../../site-config/brc-analytics/local/index/workflow/types";
 import { formatTrsId } from "../../../../views/AnalyzeWorkflowsView/components/Main/utils";
 import { sanitizeEntityId } from "../../common/utils";
-import { GA2AssemblyEntity, GA2OrganismEntity } from "../../ga2/entities";
 import { BRCDataCatalogGenome, BRCDataCatalogOrganism } from "./entities";
 import { ORGANISM_PLOIDY, WORKFLOW_PLOIDY } from "./schema-entities";
 
-export function getGenomeId(
-  genome: BRCDataCatalogGenome | GA2AssemblyEntity
-): string {
+export function getGenomeId(genome: BRCDataCatalogGenome): string {
   return sanitizeEntityId(genome.accession);
 }
 
-export function getGenomeTitle(
-  genome?: BRCDataCatalogGenome | GA2AssemblyEntity
-): string {
+export function getGenomeTitle(genome?: BRCDataCatalogGenome): string {
   if (!genome) return "";
   return `${genome.taxonomicLevelSpecies}`;
 }
 
-export function getOrganismId(
-  organism: BRCDataCatalogOrganism | GA2OrganismEntity
-): string {
+export function getOrganismId(organism: BRCDataCatalogOrganism): string {
   return sanitizeEntityId(organism.ncbiTaxonomyId);
 }
 
@@ -29,9 +22,7 @@ export function getOrganismId(
  * @param genome - Genome.
  * @returns organism ID.
  */
-export function getGenomeOrganismId(
-  genome: BRCDataCatalogGenome | GA2AssemblyEntity
-): string {
+export function getGenomeOrganismId(genome: BRCDataCatalogGenome): string {
   return sanitizeEntityId(genome.speciesTaxonomyId);
 }
 

--- a/app/apis/catalog/common/entities.ts
+++ b/app/apis/catalog/common/entities.ts
@@ -21,10 +21,15 @@ export interface AssemblyContract {
   lineageTaxonomyIds: string[];
   ncbiTaxonomyId: string;
   ploidy: ORGANISM_PLOIDY[];
+  // Priority/priorityPathogenName are BRC-only assembly fields; GA2 assemblies
+  // lack them, so they are optional and consumers must default when absent.
+  priority?: OUTBREAK_PRIORITY | null;
+  priorityPathogenName?: string | null;
   releaseDate: string;
   scaffoldCount: number | null;
   scaffoldL50: number | null;
   scaffoldN50: number | null;
+  speciesTaxonomyId: string;
   strainName: string | null;
   taxonomicGroup: string[];
   taxonomicLevelClass: string;
@@ -52,10 +57,16 @@ export interface AssemblyContract {
  * display when undefined.
  */
 export interface OrganismContract {
+  // assemblyCount/assemblyTaxonomyIds/taxonomicGroup are organism-entity fields
+  // absent on the assembly-derived projection, so they are optional and
+  // consumers must default when absent.
+  assemblyCount?: number;
+  assemblyTaxonomyIds?: string[];
   genomes?: OrganismGenome[];
   ncbiTaxonomyId: string;
   priority?: OUTBREAK_PRIORITY | null;
   priorityPathogenName?: string | null;
+  taxonomicGroup?: string[];
   taxonomicLevelIsolate?: string[];
   taxonomicLevelSerotype?: string[];
   taxonomicLevelSpecies: string;

--- a/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.tsx
+++ b/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.tsx
@@ -31,7 +31,10 @@ import {
   getGenomeOrganismId,
   getOrganismId,
 } from "../../../../apis/catalog/brc-analytics-catalog/common/utils";
-import type { AssemblyContract } from "../../../../apis/catalog/common/entities";
+import type {
+  AssemblyContract,
+  OrganismContract,
+} from "../../../../apis/catalog/common/entities";
 import { sanitizeEntityId } from "../../../../apis/catalog/common/utils";
 import {
   GA2AssemblyEntity,
@@ -147,7 +150,7 @@ export const buildAssemblyDetails = (
  * @returns Props for the BasicCell component.
  */
 export const buildAssemblyCount = (
-  entity: BRCDataCatalogOrganism | GA2OrganismEntity
+  entity: OrganismContract
 ): ComponentProps<typeof C.BasicCell> => {
   return {
     value: formatNumber(entity.assemblyCount),
@@ -426,11 +429,11 @@ export const buildLevel = (
  * @returns Props for the NTagCell component.
  */
 export const buildOrganismAssemblyTaxonomyIds = (
-  entity: BRCDataCatalogOrganism | GA2OrganismEntity
+  entity: OrganismContract
 ): ComponentProps<typeof C.NTagCell> => {
   return {
     label: "taxonomy IDs",
-    values: entity.assemblyTaxonomyIds,
+    values: entity.assemblyTaxonomyIds ?? [],
   };
 };
 
@@ -701,23 +704,42 @@ export const buildPriorityPathogenResources = (
   };
 };
 
-/**
- * Build props for the taxonomic group cell.
- * @param entity - Entity with a taxonomicGroup property.
- * @returns Props for the NTagCell component.
- */
+// Union consumed by the buildTaxonomicLevel* cell builders below, which run on
+// both organisms and assemblies across both sites. Splitting these into
+// per-contract variants is deferred — the taxonomic-level fields live on the
+// organism *entity* but not on the assembly-derived organism projection, so it
+// needs the entity-vs-projection contract separation (tracked in #1414).
 type TaxonomicGroupEntity =
   | BRCDataCatalogOrganism
   | BRCDataCatalogGenome
   | GA2AssemblyEntity
   | GA2OrganismEntity;
 
-export const buildTaxonomicGroup = (
-  entity: TaxonomicGroupEntity
+/**
+ * Build props for the taxonomic group cell of an assembly.
+ * @param entity - Assembly with a taxonomicGroup property.
+ * @returns Props for the NTagCell component.
+ */
+export const buildAssemblyTaxonomicGroup = (
+  entity: AssemblyContract
 ): ComponentProps<typeof C.NTagCell> => {
   return {
     label: "taxonomic groups",
     values: entity.taxonomicGroup,
+  };
+};
+
+/**
+ * Build props for the taxonomic group cell of an organism.
+ * @param entity - Organism with an optional taxonomicGroup property.
+ * @returns Props for the NTagCell component.
+ */
+export const buildOrganismTaxonomicGroup = (
+  entity: OrganismContract
+): ComponentProps<typeof C.NTagCell> => {
+  return {
+    label: "taxonomic groups",
+    values: entity.taxonomicGroup ?? [],
   };
 };
 
@@ -901,7 +923,7 @@ export const buildScaffoldN50 = (
  * @returns Props for the BasicCell component.
  */
 export const buildTaxonomyId = (
-  entity: BRCDataCatalogOrganism | BRCDataCatalogGenome | GA2AssemblyEntity
+  entity: AssemblyContract
 ): ComponentProps<typeof C.BasicCell> => {
   return {
     value: entity.ncbiTaxonomyId,

--- a/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.tsx
+++ b/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.tsx
@@ -708,7 +708,7 @@ export const buildPriorityPathogenResources = (
 // both organisms and assemblies across both sites. Splitting these into
 // per-contract variants is deferred — the taxonomic-level fields live on the
 // organism *entity* but not on the assembly-derived organism projection, so it
-// needs the entity-vs-projection contract separation (tracked in #1414).
+// needs the entity-vs-projection contract separation (tracked in #1428).
 type TaxonomicGroupEntity =
   | BRCDataCatalogOrganism
   | BRCDataCatalogGenome

--- a/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.tsx
+++ b/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.tsx
@@ -146,11 +146,13 @@ export const buildAssemblyDetails = (
 
 /**
  * Build props for the assemblies cell.
- * @param entity - Entity with an assemblyCount property.
+ * @param entity - Entity with a required assemblyCount property.
  * @returns Props for the BasicCell component.
  */
 export const buildAssemblyCount = (
-  entity: OrganismContract
+  // `assemblyCount` is optional on OrganismContract; require it here so callers
+  // can't pass a projection without it and silently render an empty value.
+  entity: OrganismContract & { assemblyCount: number }
 ): ComponentProps<typeof C.BasicCell> => {
   return {
     value: formatNumber(entity.assemblyCount),

--- a/app/views/OrganismWorkflowInputsView/utils.ts
+++ b/app/views/OrganismWorkflowInputsView/utils.ts
@@ -1,5 +1,4 @@
-import type { BRCDataCatalogOrganism } from "../../apis/catalog/brc-analytics-catalog/common/entities";
-import type { GA2OrganismEntity } from "../../apis/catalog/ga2/entities";
+import type { OrganismContract } from "../../apis/catalog/common/entities";
 import type { Organism } from "../OrganismView/types";
 
 /**
@@ -15,16 +14,13 @@ import type { Organism } from "../OrganismView/types";
  * @returns Organism shape for the side panel.
  */
 export function mapOrganismEntityToOrganism(
-  organism: BRCDataCatalogOrganism | GA2OrganismEntity
+  organism: OrganismContract
 ): Organism {
   return {
     genomes: organism.genomes,
     ncbiTaxonomyId: organism.ncbiTaxonomyId,
-    priority: "priority" in organism ? organism.priority : undefined,
-    priorityPathogenName:
-      "priorityPathogenName" in organism
-        ? organism.priorityPathogenName
-        : undefined,
+    priority: organism.priority,
+    priorityPathogenName: organism.priorityPathogenName,
     taxonomicLevelSpecies: organism.taxonomicLevelSpecies,
   };
 }

--- a/app/views/WorkflowInputsView/utils.ts
+++ b/app/views/WorkflowInputsView/utils.ts
@@ -3,8 +3,8 @@ import {
   getGenomeSerotypeText,
   getGenomeStrainText,
 } from "app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders";
+import type { AssemblyContract } from "../../apis/catalog/common/entities";
 import type { Organism } from "../OrganismView/types";
-import type { Assembly } from "./types";
 
 /**
  * Maps an assembly to the shared organism shape consumed by the side panel, so the
@@ -14,16 +14,13 @@ import type { Assembly } from "./types";
  * @param assembly - Assembly to derive organism-level details from.
  * @returns Organism shape for the side panel.
  */
-export function mapAssemblyToOrganism(assembly: Assembly): Organism {
+export function mapAssemblyToOrganism(assembly: AssemblyContract): Organism {
   return {
     // Organism-level link target: the species taxon, not the assembly's own
     // (possibly strain-level) ncbiTaxonomyId.
     ncbiTaxonomyId: assembly.speciesTaxonomyId,
-    priority: "priority" in assembly ? assembly.priority : undefined,
-    priorityPathogenName:
-      "priorityPathogenName" in assembly
-        ? assembly.priorityPathogenName
-        : undefined,
+    priority: assembly.priority,
+    priorityPathogenName: assembly.priorityPathogenName,
     taxonomicLevelIsolate: toValues(getGenomeIsolateText(assembly)),
     taxonomicLevelSerotype: toValues(getGenomeSerotypeText(assembly)),
     taxonomicLevelSpecies: assembly.taxonomicLevelSpecies,

--- a/site-config/brc-analytics/local/index/genomeEntityConfig.ts
+++ b/site-config/brc-analytics/local/index/genomeEntityConfig.ts
@@ -305,7 +305,7 @@ export const genomeEntityConfig: AppEntityConfig<BRCDataCatalogGenome> = {
       {
         componentConfig: {
           component: C.NTagCell,
-          viewBuilder: V.buildTaxonomicGroup,
+          viewBuilder: V.buildAssemblyTaxonomicGroup,
         } as ComponentConfig<typeof C.NTagCell, BRCDataCatalogGenome>,
         enableHiding: false,
         header: BRC_DATA_CATALOG_CATEGORY_LABEL.TAXONOMIC_GROUP,

--- a/site-config/brc-analytics/local/index/organismEntityConfig.ts
+++ b/site-config/brc-analytics/local/index/organismEntityConfig.ts
@@ -228,7 +228,7 @@ export const organismEntityConfig: AppEntityConfig<BRCDataCatalogOrganism> = {
       {
         componentConfig: {
           component: C.NTagCell,
-          viewBuilder: V.buildTaxonomicGroup,
+          viewBuilder: V.buildOrganismTaxonomicGroup,
         } as ComponentConfig<typeof C.NTagCell, BRCDataCatalogOrganism>,
         header: BRC_DATA_CATALOG_CATEGORY_LABEL.TAXONOMIC_GROUP,
         id: BRC_DATA_CATALOG_CATEGORY_KEY.TAXONOMIC_GROUP,

--- a/site-config/ga2/local/index/genome/columnDefs.ts
+++ b/site-config/ga2/local/index/genome/columnDefs.ts
@@ -8,6 +8,7 @@ import {
   buildAccession,
   buildAnalyzeGenome,
   buildAnnotationStatus,
+  buildAssemblyTaxonomicGroup,
   buildChromosomes,
   buildCoverage,
   buildGcPercent,
@@ -20,7 +21,6 @@ import {
   buildScaffoldCount,
   buildScaffoldL50,
   buildScaffoldN50,
-  buildTaxonomicGroup,
   buildTaxonomicLevelClass,
   buildTaxonomicLevelDomain,
   buildTaxonomicLevelFamily,
@@ -248,7 +248,7 @@ export const TAXONOMIC_LEVEL_GENUS: ColumnConfig<GA2AssemblyEntity> = {
 export const TAXONOMIC_GROUP: ColumnConfig<GA2AssemblyEntity> = {
   componentConfig: {
     component: C.NTagCell,
-    viewBuilder: buildTaxonomicGroup,
+    viewBuilder: buildAssemblyTaxonomicGroup,
   } as ComponentConfig<typeof C.NTagCell, GA2AssemblyEntity>,
   enableHiding: false,
   header: GA2_CATEGORY_LABEL.TAXONOMIC_GROUP,

--- a/site-config/ga2/local/index/organism/columnDefs.ts
+++ b/site-config/ga2/local/index/organism/columnDefs.ts
@@ -4,7 +4,7 @@ import {
 } from "@databiosphere/findable-ui/lib/config/entities";
 import {
   buildAssemblyCount,
-  buildTaxonomicGroup,
+  buildOrganismTaxonomicGroup,
   buildTaxonomicLevelClass,
   buildTaxonomicLevelDomain,
   buildTaxonomicLevelFamily,
@@ -112,7 +112,7 @@ export const TAXONOMIC_LEVEL_GENUS: ColumnConfig<GA2OrganismEntity> = {
 export const TAXONOMIC_GROUP: ColumnConfig<GA2OrganismEntity> = {
   componentConfig: {
     component: C.NTagCell,
-    viewBuilder: buildTaxonomicGroup,
+    viewBuilder: buildOrganismTaxonomicGroup,
   } as ComponentConfig<typeof C.NTagCell, GA2OrganismEntity>,
   header: GA2_CATEGORY_LABEL.TAXONOMIC_GROUP,
   id: GA2_CATEGORY_KEY.TAXONOMIC_GROUP,

--- a/site-config/ga2/local/index/organism/columnDefs.ts
+++ b/site-config/ga2/local/index/organism/columnDefs.ts
@@ -2,8 +2,11 @@ import {
   ColumnConfig,
   ComponentConfig,
 } from "@databiosphere/findable-ui/lib/config/entities";
+import { GA2OrganismEntity } from "../../../../../app/apis/catalog/ga2/entities";
+import * as C from "../../../../../app/components";
 import {
   buildAssemblyCount,
+  buildOrganismAssemblyTaxonomyIds,
   buildOrganismTaxonomicGroup,
   buildTaxonomicLevelClass,
   buildTaxonomicLevelDomain,
@@ -12,10 +15,7 @@ import {
   buildTaxonomicLevelKingdom,
   buildTaxonomicLevelOrder,
   buildTaxonomicLevelPhylum,
-} from "app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders";
-import { GA2OrganismEntity } from "../../../../../app/apis/catalog/ga2/entities";
-import * as C from "../../../../../app/components";
-import { buildOrganismAssemblyTaxonomyIds } from "../../../../../app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders";
+} from "../../../../../app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders";
 import * as V from "../../../../../app/viewModelBuilders/catalog/ga2/viewModelBuilders";
 import { GA2_CATEGORY_KEY, GA2_CATEGORY_LABEL } from "../../../category";
 


### PR DESCRIPTION
## Summary

Part of #1414 (2c) and the GA2/BRC site-separation work (#1246). Delivers the **cleanly-isolated** union→contract conversions; the entangled structural-typing cluster is deferred to a follow-up (below).

### What changed
- **`brc-analytics-catalog/common/utils.ts`** — `getGenomeId`/`getGenomeTitle`/`getOrganismId`/`getGenomeOrganismId` now take **concrete BRC types** (GA2 already has its own `ga2/utils.ts`). This **removes the reverse `brc→ga2` import** (the #1410 counterpart).
- **`viewModelBuilders.ts`** — `buildTaxonomyId` → `AssemblyContract`; `buildTaxonomicGroup` split into `buildAssemblyTaxonomicGroup` / `buildOrganismTaxonomicGroup`; `buildAssemblyCount` / `buildOrganismAssemblyTaxonomyIds` → `OrganismContract`.
- **Mappers** — `mapAssemblyToOrganism` → `AssemblyContract`, `mapOrganismEntityToOrganism` → `OrganismContract`; both drop the `"priority" in x` structural checks in favour of contract optionals.
- **Contracts extended** — `AssemblyContract` += `speciesTaxonomyId`, `priority?`, `priorityPathogenName?`; `OrganismContract` += `taxonomicGroup?`, `assemblyCount?`, `assemblyTaxonomyIds?` (optional where absent on the assembly-derived projection).

### Deferred to a follow-up (structural-typing / entity-vs-projection)
Changing the shared `WorkflowInputsView` `Assembly` union cascades into `side.tsx`'s `"image" in assembly` dispatch (agreed deferral), plus `accessorFn` (`getAssemblyIsolate/Serotype`) and `WorkflowsView` (`getTaxonomicLevelRealm`), all using `"x" in assembly`. The 7 `buildTaxonomicLevel*` builders (`TaxonomicGroupEntity` 4-way union) need the organism **entity-vs-projection** contract split. And the page-level `BRCCatalog | GA2Catalog` resolves with the per-site `pages/` split (Issue 5). These want the per-site-composition work, not a mechanical swap.

### Validation
`tsc` (both sites), ESLint, Prettier clean.