### PR TITLE
refactor: render view-builder components as jsx elements not plain function calls (#1439)

### DIFF
--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/CollectionSelector/hooks/UseTable/columnDef.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/CollectionSelector/hooks/UseTable/columnDef.tsx
@@ -41,7 +41,7 @@ const EXPERIMENT_ACCESSION: ColumnDef<ReadRun> = {
 const FASTQ_FTP: ColumnDef<ReadRun> = {
   ...SORTING_COLUMN_DEF,
   accessorKey: CATEGORY_CONFIGS.FASTQ_FTP.key,
-  cell: (ctx) => BasicCell(buildFastqFTP(ctx)),
+  cell: (ctx) => <BasicCell {...buildFastqFTP(ctx)} />,
   filterFn: SELECT_FILTER_FN,
   header: CATEGORY_CONFIGS.FASTQ_FTP.label,
   meta: { width: { max: "1.8fr", min: "200px" } },
@@ -140,7 +140,7 @@ const SCIENTIFIC_NAME: ColumnDef<ReadRun> = {
 const STUDY_ACCESSION: ColumnDef<ReadRun> = {
   ...SORTING_COLUMN_DEF,
   accessorKey: CATEGORY_CONFIGS.STUDY_ACCESSION.key,
-  cell: (ctx) => LinkCell(buildStudyAccession(ctx)),
+  cell: (ctx) => <LinkCell {...buildStudyAccession(ctx)} />,
   filterFn: SELECT_FILTER_FN,
   header: CATEGORY_CONFIGS.STUDY_ACCESSION.label,
   meta: META,

--- a/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.tsx
+++ b/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.tsx
@@ -12,7 +12,7 @@ import type { Organism } from "app/views/OrganismView/types";
 import { parseISO } from "date-fns";
 import { LinkProps } from "next/link";
 import Router from "next/router";
-import { ComponentProps, createElement } from "react";
+import { ComponentProps } from "react";
 import {
   BRC_DATA_CATALOG_CATEGORY_KEY,
   BRC_DATA_CATALOG_CATEGORY_LABEL,
@@ -130,14 +130,11 @@ export const buildAssemblyDetails = (
   const keyValuePairs = new Map<Key, Value>();
   keyValuePairs.set(
     BRC_DATA_CATALOG_CATEGORY_LABEL.ACCESSION,
-    C.CopyText({
-      children: assembly.accession,
-      value: assembly.accession,
-    })
+    <C.CopyText value={assembly.accession}>{assembly.accession}</C.CopyText>
   );
   return {
     KeyElType: C.KeyElType,
-    KeyValuesElType: (props) => C.Stack({ ...props, gap: 4 }),
+    KeyValuesElType: (props) => <C.Stack {...props} gap={4} />,
     ValueElType: C.ValueElType,
     keyValuePairs,
   };
@@ -457,10 +454,10 @@ export const buildOrganismDetails = (
 
   keyValuePairs.set(
     BRC_DATA_CATALOG_CATEGORY_LABEL.TAXONOMIC_LEVEL_SPECIES,
-    C.Link({
-      label: taxonomicLevelSpecies,
-      url: `${ROUTES.ORGANISMS}/${encodeURIComponent(sanitizeEntityId(ncbiTaxonomyId))}`,
-    })
+    <C.Link
+      label={taxonomicLevelSpecies}
+      url={`${ROUTES.ORGANISMS}/${encodeURIComponent(sanitizeEntityId(ncbiTaxonomyId))}`}
+    />
   );
   const taxonomicLevels: [Key, string[] | undefined][] = [
     [
@@ -482,13 +479,13 @@ export const buildOrganismDetails = (
   if (priorityPathogenName) {
     keyValuePairs.set(
       BRC_DATA_CATALOG_CATEGORY_LABEL.PRIORITY_PATHOGEN_NAME,
-      C.Chip(buildPriorityPathogen(organism))
+      <C.Chip {...buildPriorityPathogen(organism)} />
     );
   }
 
   return {
     KeyElType: C.KeyElType,
-    KeyValuesElType: (props) => C.Stack({ ...props, gap: 4 }),
+    KeyValuesElType: (props) => <C.Stack {...props} gap={4} />,
     ValueElType: C.ValueElType,
     keyValuePairs,
   };
@@ -648,10 +645,10 @@ export const buildPriorityPathogenDetails = (
   const keyValuePairs = new Map<Key, Value>();
   keyValuePairs.set(
     BRC_DATA_CATALOG_CATEGORY_LABEL.PRIORITY,
-    C.Chip({
-      color: getPriorityColor(priorityPathogen.priority),
-      label: getPriorityLabel(priorityPathogen.priority),
-      onClick: (): void => {
+    <C.Chip
+      color={getPriorityColor(priorityPathogen.priority)}
+      label={getPriorityLabel(priorityPathogen.priority)}
+      onClick={(): void => {
         Router.push({
           pathname: ROUTES.ORGANISMS,
           query: {
@@ -663,9 +660,9 @@ export const buildPriorityPathogenDetails = (
             ]),
           },
         });
-      },
-      variant: CHIP_PROPS.VARIANT.STATUS,
-    })
+      }}
+      variant={CHIP_PROPS.VARIANT.STATUS}
+    />
   );
   [
     ["Organisms", ROUTES.ORGANISMS],
@@ -673,13 +670,14 @@ export const buildPriorityPathogenDetails = (
   ].forEach(([key, pathname]) => {
     keyValuePairs.set(
       key,
-      C.AppLink({
-        children: priorityPathogen.taxonName,
-        href: getEntityLinkWithPriorityPathogenFilter(
+      <C.AppLink
+        href={getEntityLinkWithPriorityPathogenFilter(
           priorityPathogen,
           pathname
-        ),
-      })
+        )}
+      >
+        {priorityPathogen.taxonName}
+      </C.AppLink>
     );
   });
   return {
@@ -990,7 +988,7 @@ export const buildOrganismHero = (
   if (priorityTag) tags.push(priorityTag);
   return {
     breadcrumbs: getOrganismEntityBreadcrumbs(organism),
-    subTitle: tags.length > 0 ? createElement(C.TagList, { tags }) : undefined,
+    subTitle: tags.length > 0 ? <C.TagList tags={tags} /> : undefined,
     title: organism.taxonomicLevelSpecies,
   };
 };
@@ -1090,7 +1088,9 @@ function buildOrganismGenomesTableColumns(): ColumnDef<BRCDataCatalogGenome>[] {
   return [
     {
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.ANALYZE_GENOME,
-      cell: ({ row }) => C.AnalyzeGenome(buildAnalyzeGenome(row.original)),
+      cell: ({ row }) => (
+        <C.AnalyzeGenome {...buildAnalyzeGenome(row.original)} />
+      ),
       enableSorting: false,
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.ANALYZE_GENOME,
       meta: {
@@ -1103,8 +1103,9 @@ function buildOrganismGenomesTableColumns(): ColumnDef<BRCDataCatalogGenome>[] {
       // (its primary text); the SpeciesCell renders the accession + per-assembly
       // tags.
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.ACCESSION,
-      cell: ({ row }) =>
-        C.SpeciesCell(buildOrganismGenomeSpecies(row.original)),
+      cell: ({ row }) => (
+        <C.SpeciesCell {...buildOrganismGenomeSpecies(row.original)} />
+      ),
       header: ASSEMBLY_COLUMN_HEADER,
       meta: {
         columnPinned: true,
@@ -1114,11 +1115,11 @@ function buildOrganismGenomesTableColumns(): ColumnDef<BRCDataCatalogGenome>[] {
     },
     {
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.RELEASE_DATE,
-      cell: ({ row }) =>
-        C.Tooltip({
-          ...buildReleaseDateTooltip(row.original),
-          children: createElement(C.BasicCell, buildReleaseDate(row.original)),
-        }),
+      cell: ({ row }) => (
+        <C.Tooltip {...buildReleaseDateTooltip(row.original)}>
+          <C.BasicCell {...buildReleaseDate(row.original)} />
+        </C.Tooltip>
+      ),
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.RELEASE_DATE,
       meta: {
         header: BRC_DATA_CATALOG_CATEGORY_LABEL.RELEASE_DATE,
@@ -1127,7 +1128,7 @@ function buildOrganismGenomesTableColumns(): ColumnDef<BRCDataCatalogGenome>[] {
     },
     {
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.IS_REF,
-      cell: ({ row }) => C.ChipCell(buildIsRef(row.original)),
+      cell: ({ row }) => <C.ChipCell {...buildIsRef(row.original)} />,
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.IS_REF,
       meta: {
         header: BRC_DATA_CATALOG_CATEGORY_LABEL.IS_REF,
@@ -1136,7 +1137,7 @@ function buildOrganismGenomesTableColumns(): ColumnDef<BRCDataCatalogGenome>[] {
     },
     {
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.LEVEL,
-      cell: ({ row }) => C.LevelCell(buildLevel(row.original)),
+      cell: ({ row }) => <C.LevelCell {...buildLevel(row.original)} />,
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.LEVEL,
       meta: {
         header: BRC_DATA_CATALOG_CATEGORY_LABEL.LEVEL,
@@ -1145,7 +1146,7 @@ function buildOrganismGenomesTableColumns(): ColumnDef<BRCDataCatalogGenome>[] {
     },
     {
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.CHROMOSOMES,
-      cell: ({ row }) => C.BasicCell(buildChromosomes(row.original)),
+      cell: ({ row }) => <C.BasicCell {...buildChromosomes(row.original)} />,
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.CHROMOSOMES,
       meta: {
         header: BRC_DATA_CATALOG_CATEGORY_LABEL.CHROMOSOMES,
@@ -1154,7 +1155,7 @@ function buildOrganismGenomesTableColumns(): ColumnDef<BRCDataCatalogGenome>[] {
     },
     {
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.LENGTH,
-      cell: ({ row }) => C.BasicCell(buildLength(row.original)),
+      cell: ({ row }) => <C.BasicCell {...buildLength(row.original)} />,
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.LENGTH,
       meta: {
         header: BRC_DATA_CATALOG_CATEGORY_LABEL.LENGTH,
@@ -1163,7 +1164,7 @@ function buildOrganismGenomesTableColumns(): ColumnDef<BRCDataCatalogGenome>[] {
     },
     {
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.SCAFFOLD_COUNT,
-      cell: ({ row }) => C.BasicCell(buildScaffoldCount(row.original)),
+      cell: ({ row }) => <C.BasicCell {...buildScaffoldCount(row.original)} />,
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.SCAFFOLD_COUNT,
       meta: {
         header: BRC_DATA_CATALOG_CATEGORY_LABEL.SCAFFOLD_COUNT,
@@ -1172,7 +1173,7 @@ function buildOrganismGenomesTableColumns(): ColumnDef<BRCDataCatalogGenome>[] {
     },
     {
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.SCAFFOLD_N50,
-      cell: ({ row }) => C.BasicCell(buildScaffoldN50(row.original)),
+      cell: ({ row }) => <C.BasicCell {...buildScaffoldN50(row.original)} />,
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.SCAFFOLD_N50,
       meta: {
         header: BRC_DATA_CATALOG_CATEGORY_LABEL.SCAFFOLD_N50,
@@ -1181,7 +1182,7 @@ function buildOrganismGenomesTableColumns(): ColumnDef<BRCDataCatalogGenome>[] {
     },
     {
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.SCAFFOLD_L50,
-      cell: ({ row }) => C.BasicCell(buildScaffoldL50(row.original)),
+      cell: ({ row }) => <C.BasicCell {...buildScaffoldL50(row.original)} />,
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.SCAFFOLD_L50,
       meta: {
         header: BRC_DATA_CATALOG_CATEGORY_LABEL.SCAFFOLD_L50,
@@ -1190,7 +1191,7 @@ function buildOrganismGenomesTableColumns(): ColumnDef<BRCDataCatalogGenome>[] {
     },
     {
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.COVERAGE,
-      cell: ({ row }) => C.BasicCell(buildCoverage(row.original)),
+      cell: ({ row }) => <C.BasicCell {...buildCoverage(row.original)} />,
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.COVERAGE,
       meta: {
         header: BRC_DATA_CATALOG_CATEGORY_LABEL.COVERAGE,
@@ -1199,7 +1200,7 @@ function buildOrganismGenomesTableColumns(): ColumnDef<BRCDataCatalogGenome>[] {
     },
     {
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.GC_PERCENT,
-      cell: ({ row }) => C.BasicCell(buildGcPercent(row.original)),
+      cell: ({ row }) => <C.BasicCell {...buildGcPercent(row.original)} />,
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.GC_PERCENT,
       meta: {
         header: BRC_DATA_CATALOG_CATEGORY_LABEL.GC_PERCENT,
@@ -1208,7 +1209,9 @@ function buildOrganismGenomesTableColumns(): ColumnDef<BRCDataCatalogGenome>[] {
     },
     {
       accessorKey: BRC_DATA_CATALOG_CATEGORY_KEY.ANNOTATION_STATUS,
-      cell: ({ row }) => C.BasicCell(buildAnnotationStatus(row.original)),
+      cell: ({ row }) => (
+        <C.BasicCell {...buildAnnotationStatus(row.original)} />
+      ),
       header: BRC_DATA_CATALOG_CATEGORY_LABEL.ANNOTATION_STATUS,
       meta: {
         header: BRC_DATA_CATALOG_CATEGORY_LABEL.ANNOTATION_STATUS,
@@ -1244,7 +1247,7 @@ export const buildWorkflowConfiguration = (
   }
   return {
     KeyElType: C.KeyElType,
-    KeyValuesElType: (props) => C.Stack({ ...props, gap: 4 }),
+    KeyValuesElType: (props) => <C.Stack {...props} gap={4} />,
     ValueElType: C.TypographyWordBreak,
     keyValuePairs,
   };
@@ -1263,7 +1266,7 @@ export const buildWorkflowDetails = (
   keyValuePairs.set("Description", workflow.workflowDescription);
   return {
     KeyElType: C.KeyElType,
-    KeyValuesElType: (props) => C.Stack({ ...props, gap: 4 }),
+    KeyValuesElType: (props) => <C.Stack {...props} gap={4} />,
     ValueElType: C.ValueElType,
     keyValuePairs,
   };

--- a/app/viewModelBuilders/catalog/ga2/viewModelBuilders.tsx
+++ b/app/viewModelBuilders/catalog/ga2/viewModelBuilders.tsx
@@ -1,6 +1,6 @@
 import { COLUMN_IDENTIFIER } from "@databiosphere/findable-ui/lib/components/Table/common/columnIdentifier";
 import { ColumnDef, RowData, VisibilityState } from "@tanstack/react-table";
-import { ComponentProps, createElement } from "react";
+import { ComponentProps } from "react";
 import { ROUTES } from "../../../../routes/constants";
 import {
   GA2_CATEGORY_KEY,
@@ -45,9 +45,7 @@ export const buildOrganismHero = (
       { path: ROUTES.ORGANISMS, text: "Organisms" },
       { path: "", text: entity.taxonomicLevelSpecies },
     ],
-    subTitle: groupTag
-      ? createElement(C.TagList, { tags: [groupTag] })
-      : undefined,
+    subTitle: groupTag ? <C.TagList tags={[groupTag]} /> : undefined,
     title: entity.taxonomicLevelSpecies,
   };
 };
@@ -161,7 +159,9 @@ function buildOrganismGenomesTableColumns(): ColumnDef<GA2AssemblyEntity>[] {
   return [
     {
       accessorKey: GA2_CATEGORY_KEY.ANALYZE_GENOME,
-      cell: ({ row }) => C.AnalyzeGenome(buildAnalyzeGenome(row.original)),
+      cell: ({ row }) => (
+        <C.AnalyzeGenome {...buildAnalyzeGenome(row.original)} />
+      ),
       enableSorting: false,
       header: GA2_CATEGORY_LABEL.ANALYZE_GENOME,
       meta: { header: GA2_CATEGORY_LABEL.ANALYZE_GENOME, width: "auto" },
@@ -171,8 +171,9 @@ function buildOrganismGenomesTableColumns(): ColumnDef<GA2AssemblyEntity>[] {
       // (its primary text); the SpeciesCell renders the accession + per-assembly
       // tags.
       accessorKey: GA2_CATEGORY_KEY.ACCESSION,
-      cell: ({ row }) =>
-        C.SpeciesCell(buildOrganismAssemblySpecies(row.original)),
+      cell: ({ row }) => (
+        <C.SpeciesCell {...buildOrganismAssemblySpecies(row.original)} />
+      ),
       header: ASSEMBLY_COLUMN_HEADER,
       meta: {
         columnPinned: true,
@@ -182,11 +183,11 @@ function buildOrganismGenomesTableColumns(): ColumnDef<GA2AssemblyEntity>[] {
     },
     {
       accessorKey: GA2_CATEGORY_KEY.RELEASE_DATE,
-      cell: ({ row }) =>
-        C.Tooltip({
-          ...buildReleaseDateTooltip(row.original),
-          children: createElement(C.BasicCell, buildReleaseDate(row.original)),
-        }),
+      cell: ({ row }) => (
+        <C.Tooltip {...buildReleaseDateTooltip(row.original)}>
+          <C.BasicCell {...buildReleaseDate(row.original)} />
+        </C.Tooltip>
+      ),
       header: GA2_CATEGORY_LABEL.RELEASE_DATE,
       meta: {
         header: GA2_CATEGORY_LABEL.RELEASE_DATE,
@@ -195,7 +196,7 @@ function buildOrganismGenomesTableColumns(): ColumnDef<GA2AssemblyEntity>[] {
     },
     {
       accessorKey: GA2_CATEGORY_KEY.IS_REF,
-      cell: ({ row }) => C.ChipCell(buildIsRef(row.original)),
+      cell: ({ row }) => <C.ChipCell {...buildIsRef(row.original)} />,
       header: GA2_CATEGORY_LABEL.IS_REF,
       meta: {
         header: GA2_CATEGORY_LABEL.IS_REF,
@@ -204,7 +205,7 @@ function buildOrganismGenomesTableColumns(): ColumnDef<GA2AssemblyEntity>[] {
     },
     {
       accessorKey: GA2_CATEGORY_KEY.LEVEL,
-      cell: ({ row }) => C.LevelCell(buildLevel(row.original)),
+      cell: ({ row }) => <C.LevelCell {...buildLevel(row.original)} />,
       header: GA2_CATEGORY_LABEL.LEVEL,
       meta: {
         header: GA2_CATEGORY_LABEL.LEVEL,


### PR DESCRIPTION
## Summary

Closes #1439.

Renders view-builder components as JSX elements instead of calling them as plain functions, removing the [Rules of Hooks](https://react.dev/link/rules-of-hooks) foot-gun where a hook-using builder component's hooks would run in `ComponentCreator`'s scope rather than their own.

Searched **all** `.ts` files that render a component as a function call (not just the view builders). Three files were affected; each was `git mv`'d to `.tsx`:

| File | Conversions |
|---|---|
| `viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.tsx` | 21 — `C.CopyText`, `C.Link`, `C.Chip` ×2, `C.AppLink`, `C.SpeciesCell`, `C.Tooltip`, `C.AnalyzeGenome`, `C.ChipCell`, `C.LevelCell`, 8× `C.BasicCell`, 4× `C.Stack`, + 2 `createElement(...)` |
| `viewModelBuilders/catalog/ga2/viewModelBuilders.tsx` | 7 |
| `.../CollectionSelector/hooks/UseTable/columnDef.tsx` | 2 — `BasicCell`, `LinkCell` (non-`C.` cases) |

Existing `createElement(...)` render calls were folded into JSX too, so no function-call / `createElement` render form remains, and the now-unused `createElement` import was dropped.

## Out of scope (follow-up)

- Dropping the `C` component barrel in the two view builders in favour of direct imports — filed as #1440. Kept separate to keep this PR focused on the rules-of-hooks fix.

## Testing

- `npx tsc --noEmit` — clean
- `npm run lint` — clean
- `npm test` — 574/574 pass
- `npm run build:local` (BRC) — success
- `npm run build-local:ga2` (GA2) — success

🤖 Generated with [Claude Code](https://claude.com/claude-code)
