### PR TITLE
feat: pangenome: build the organism-page pangenome section from pangenomes.json (#1342)

### DIFF
--- a/app/apis/catalog/brc-analytics-catalog/common/pangenome.ts
+++ b/app/apis/catalog/brc-analytics-catalog/common/pangenome.ts
@@ -1,0 +1,29 @@
+/**
+ * A pangenome bundle for a species, served from pangenomes.json and consumed by
+ * the organism-page Pangenome section. Fetched through the entity store like
+ * organisms/assemblies (see services/workflows). MOCK-backed until the real
+ * pangenomes.json build lands (#1341).
+ */
+export interface Pangenome {
+  bundleId: string;
+  members: PangenomeMember[];
+  speciesTaxonomyId: string;
+  version: string;
+}
+
+/**
+ * A member assembly of a pangenome bundle. Display-ready values (level, length,
+ * etc.); the real build will derive these by joining member accessions against
+ * the assemblies catalog.
+ */
+export interface PangenomeMember {
+  accession: string;
+  hasSelectionTracks: boolean;
+  isAnchor: boolean;
+  isRef: boolean;
+  length: string;
+  levelFilledCount: number;
+  levelLabel: string;
+  name: string;
+  ucscBrowserUrl: string;
+}

--- a/app/components/Table/components/TableCell/components/RefCell/refCell.tsx
+++ b/app/components/Table/components/TableCell/components/RefCell/refCell.tsx
@@ -1,0 +1,23 @@
+import { CHIP_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/chip";
+import { Chip } from "@mui/material";
+import { CellContext } from "@tanstack/react-table";
+import { JSX } from "react";
+
+interface BaseRowData {
+  isRef: boolean;
+}
+
+export const RefCell = <TData extends BaseRowData = BaseRowData>({
+  row,
+}: CellContext<TData, unknown>): JSX.Element => {
+  const {
+    original: { isRef },
+  } = row;
+  return (
+    <Chip
+      color={isRef ? CHIP_PROPS.COLOR.SUCCESS : CHIP_PROPS.COLOR.DEFAULT}
+      label={isRef ? "Yes" : "No"}
+      variant={CHIP_PROPS.VARIANT.STATUS}
+    />
+  );
+};

--- a/app/services/workflows/entities.ts
+++ b/app/services/workflows/entities.ts
@@ -2,6 +2,7 @@ import {
   Workflow,
   WorkflowCategory,
 } from "../../apis/catalog/brc-analytics-catalog/common/entities";
+import type { Pangenome } from "../../apis/catalog/brc-analytics-catalog/common/pangenome";
 import type {
   AssemblyContract,
   OrganismContract,
@@ -51,6 +52,16 @@ export function getOrganism<T extends OrganismContract>(entityId: string): T {
  */
 export function getOrganisms<T extends OrganismContract>(): T[] {
   return getEntities<T>("organisms");
+}
+
+/**
+ * Gets the pangenome bundle for a species, or undefined when the species has no
+ * pangenome.
+ * @param speciesTaxonomyId - Species taxonomy ID.
+ * @returns Pangenome bundle, or undefined.
+ */
+export function getPangenome(speciesTaxonomyId: string): Pangenome | undefined {
+  return findEntity<Pangenome>("pangenomes", speciesTaxonomyId);
 }
 
 /**

--- a/app/services/workflows/hooks/UseEntities/utils.ts
+++ b/app/services/workflows/hooks/UseEntities/utils.ts
@@ -1,5 +1,5 @@
 import { SiteConfig } from "@databiosphere/findable-ui/lib/config/entities";
-import { loadEntities, loadWorkflows } from "../../loader";
+import { loadEntities, loadPangenomes, loadWorkflows } from "../../loader";
 
 let loadPromise: Promise<void> | null = null;
 
@@ -12,8 +12,13 @@ export function ensureEntitiesLoaded(config: SiteConfig): Promise<void> {
   if (loadPromise) return loadPromise;
 
   loadPromise = (async (): Promise<void> => {
-    await loadWorkflows();
-    await loadEntities(config);
+    // Load in parallel: the optional pangenome fetch must not add serial
+    // latency to (or gate) the entity load, which every data page depends on.
+    await Promise.all([
+      loadWorkflows(),
+      loadPangenomes(),
+      loadEntities(config),
+    ]);
   })();
 
   return loadPromise;

--- a/app/services/workflows/hooks/UseEntities/utils.ts
+++ b/app/services/workflows/hooks/UseEntities/utils.ts
@@ -12,8 +12,8 @@ export function ensureEntitiesLoaded(config: SiteConfig): Promise<void> {
   if (loadPromise) return loadPromise;
 
   loadPromise = (async (): Promise<void> => {
-    // Load in parallel: the optional pangenome fetch must not add serial
-    // latency to (or gate) the entity load, which every data page depends on.
+    // Load in parallel so the optional pangenome fetch adds no serial latency
+    // to the core workflows/entities load that every data page depends on.
     await Promise.all([
       loadWorkflows(),
       loadPangenomes(),

--- a/app/services/workflows/loader.ts
+++ b/app/services/workflows/loader.ts
@@ -79,6 +79,10 @@ export async function loadPangenomes(): Promise<void> {
     return;
   }
 
+  // Optional data: a malformed (non-array) 200 payload must not throw and gate
+  // the core entity load.
+  if (!Array.isArray(pangenomes)) return;
+
   const pangenomeBySpeciesTaxonomyId = new Map<string, Pangenome>();
   for (const pangenome of pangenomes) {
     pangenomeBySpeciesTaxonomyId.set(pangenome.speciesTaxonomyId, pangenome);

--- a/app/services/workflows/loader.ts
+++ b/app/services/workflows/loader.ts
@@ -3,6 +3,7 @@ import {
   Workflow,
   WorkflowCategory,
 } from "../../apis/catalog/brc-analytics-catalog/common/entities";
+import type { Pangenome } from "../../apis/catalog/brc-analytics-catalog/common/pangenome";
 import { formatTrsId } from "../../views/AnalyzeWorkflowsView/components/Main/utils";
 import { CUSTOM_WORKFLOW } from "../../views/AnalyzeWorkflowsView/custom/constants";
 import { DIFFERENTIAL_EXPRESSION_ANALYSIS } from "../../views/AnalyzeWorkflowsView/differentialExpressionAnalysis/constants";
@@ -61,6 +62,30 @@ export async function loadEntities(config: SiteConfig): Promise<void> {
     setEntitiesById(route, entityById);
     setEntitiesByType(route, entities);
   }
+}
+
+/**
+ * Loads the pangenomes store from the API, keyed by species taxonomy ID.
+ * Pangenome data is optional (BRC-only and may be absent before its build
+ * lands), so a missing or failed fetch is skipped rather than fatal.
+ */
+export async function loadPangenomes(): Promise<void> {
+  if (getEntitiesById().has("pangenomes")) return;
+
+  let pangenomes: Pangenome[];
+  try {
+    pangenomes = (await fetchEntities(API.pangenomes)) as Pangenome[];
+  } catch {
+    return;
+  }
+
+  const pangenomeBySpeciesTaxonomyId = new Map<string, Pangenome>();
+  for (const pangenome of pangenomes) {
+    pangenomeBySpeciesTaxonomyId.set(pangenome.speciesTaxonomyId, pangenome);
+  }
+
+  setEntitiesById("pangenomes", pangenomeBySpeciesTaxonomyId);
+  setEntitiesByType("pangenomes", pangenomes);
 }
 
 /**

--- a/app/services/workflows/loader.ts
+++ b/app/services/workflows/loader.ts
@@ -75,7 +75,10 @@ export async function loadPangenomes(): Promise<void> {
   let pangenomes: Pangenome[];
   try {
     pangenomes = (await fetchEntities(API.pangenomes)) as Pangenome[];
-  } catch {
+  } catch (error) {
+    // Optional data: stay non-fatal, but surface the error so a real
+    // regression (vs. an intentionally-absent file) is debuggable.
+    console.warn("Failed to load pangenomes; skipping.", error);
     return;
   }
 

--- a/app/services/workflows/routes.ts
+++ b/app/services/workflows/routes.ts
@@ -1,6 +1,7 @@
 export const API = {
   assemblies: "/api/assemblies.json",
   organisms: "/api/organisms.json",
+  pangenomes: "/api/pangenomes.json",
   workflowAssemblyMappings: "/api/workflow-assembly-mappings.json",
   workflows: "/api/workflows.json",
 } as const;

--- a/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.tsx
+++ b/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.tsx
@@ -8,6 +8,7 @@ import { CHIP_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/chi
 import { replaceParameters } from "@databiosphere/findable-ui/lib/utils/replaceParameters";
 import { ColumnDef, RowData, VisibilityState } from "@tanstack/react-table";
 import type { SpeciesTag } from "app/components/Table/components/TableCell/components/SpeciesCell/types";
+import { Tabs } from "app/views/OrganismView/components/Tabs/tabs";
 import type { Organism } from "app/views/OrganismView/types";
 import { parseISO } from "date-fns";
 import { LinkProps } from "next/link";
@@ -988,6 +989,7 @@ export const buildOrganismHero = (
   if (priorityTag) tags.push(priorityTag);
   return {
     breadcrumbs: getOrganismEntityBreadcrumbs(organism),
+    children: <Tabs />,
     subTitle: tags.length > 0 ? <C.TagList tags={tags} /> : undefined,
     title: organism.taxonomicLevelSpecies,
   };
@@ -1002,10 +1004,12 @@ export const buildOrganismViewMain = (
   organism: BRCDataCatalogOrganism
 ): ComponentProps<typeof C.OrganismViewMain> => {
   return {
-    columnPresets: ORGANISM_GENOMES_COLUMN_PRESETS,
+    assembly: {
+      columnPresets: ORGANISM_GENOMES_COLUMN_PRESETS,
+      tableOptions: buildOrganismGenomesTable(organism),
+    },
     entityId: getOrganismId(organism),
     organism,
-    tableOptions: buildOrganismGenomesTable(organism),
   };
 };
 
@@ -1031,7 +1035,7 @@ const DEFAULT_COLUMN_VISIBILITY: VisibilityState = {
  */
 const ORGANISM_GENOMES_COLUMN_PRESETS: ComponentProps<
   typeof C.OrganismViewMain
->["columnPresets"] = [
+>["assembly"]["columnPresets"] = [
   {
     columnVisibility: DEFAULT_COLUMN_VISIBILITY,
     key: COLUMN_PRESET_KEY.DEFAULT,
@@ -1057,7 +1061,7 @@ const ORGANISM_GENOMES_COLUMN_PRESETS: ComponentProps<
  */
 export function buildOrganismGenomesTable(
   organism: BRCDataCatalogOrganism
-): ComponentProps<typeof C.OrganismViewMain>["tableOptions"] {
+): ComponentProps<typeof C.OrganismViewMain>["assembly"]["tableOptions"] {
   return {
     // Cast: ColumnDef<T> is invariant in T, so the catalog-specific row type
     // cannot widen to RowData even though BRCDataCatalogGenome extends it.

--- a/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.tsx
+++ b/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.tsx
@@ -989,7 +989,7 @@ export const buildOrganismHero = (
   if (priorityTag) tags.push(priorityTag);
   return {
     breadcrumbs: getOrganismEntityBreadcrumbs(organism),
-    children: <Tabs />,
+    children: <Tabs ncbiTaxonomyId={organism.ncbiTaxonomyId} />,
     subTitle: tags.length > 0 ? <C.TagList tags={tags} /> : undefined,
     title: organism.taxonomicLevelSpecies,
   };

--- a/app/viewModelBuilders/catalog/ga2/viewModelBuilders.tsx
+++ b/app/viewModelBuilders/catalog/ga2/viewModelBuilders.tsx
@@ -59,10 +59,12 @@ export const buildOrganismViewMain = (
   entity: GA2OrganismEntity
 ): ComponentProps<typeof C.OrganismViewMain> => {
   return {
-    columnPresets: ORGANISM_GENOMES_COLUMN_PRESETS,
+    assembly: {
+      columnPresets: ORGANISM_GENOMES_COLUMN_PRESETS,
+      tableOptions: buildOrganismGenomesTable(entity),
+    },
     entityId: sanitizeEntityId(entity.ncbiTaxonomyId),
     organism: entity,
-    tableOptions: buildOrganismGenomesTable(entity),
   };
 };
 
@@ -88,7 +90,7 @@ const DEFAULT_COLUMN_VISIBILITY: VisibilityState = {
  */
 const ORGANISM_GENOMES_COLUMN_PRESETS: ComponentProps<
   typeof C.OrganismViewMain
->["columnPresets"] = [
+>["assembly"]["columnPresets"] = [
   {
     columnVisibility: DEFAULT_COLUMN_VISIBILITY,
     key: COLUMN_PRESET_KEY.DEFAULT,
@@ -128,7 +130,7 @@ export const buildOrganismImageThumbnail = (
  */
 export function buildOrganismGenomesTable(
   entity: GA2OrganismEntity
-): ComponentProps<typeof C.OrganismViewMain>["tableOptions"] {
+): ComponentProps<typeof C.OrganismViewMain>["assembly"]["tableOptions"] {
   return {
     // Cast: ColumnDef<T> is invariant in T, so the catalog-specific row type
     // cannot widen to RowData even though GA2AssemblyEntity extends it.

--- a/app/views/OrganismView/components/Main/components/AssembliesSection/assembliesSection.tsx
+++ b/app/views/OrganismView/components/Main/components/AssembliesSection/assembliesSection.tsx
@@ -1,0 +1,52 @@
+import { ALERT_PROPS } from "@databiosphere/findable-ui/lib/components/common/Alert/constants";
+import { FluidPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/components/FluidPaper/fluidPaper";
+import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
+import { Alert, Stack } from "@mui/material";
+import { RowData } from "@tanstack/react-table";
+import { JSX } from "react";
+import { Table } from "../../../../../../components/common/Table/table";
+import { StyledSectionTitle } from "../../main.styles";
+import { Toolbar } from "../../table/components/Toolbar/toolbar";
+import { useTable } from "../../table/hooks/UseTable/hook";
+import { StyledFluidPaper } from "../../table/table.styles";
+import { EmptyState } from "../EmptyState/emptyState";
+import { Props } from "./types";
+
+/**
+ * Assemblies section for the organism page: header, an info alert, and the
+ * assemblies table (or an empty state when the organism has no assemblies).
+ * @param props - Component props.
+ * @param props.columnPresets - Column presets for the assemblies table.
+ * @param props.tableOptions - Options for the assemblies table.
+ * @returns The Assemblies section.
+ */
+export const AssembliesSection = <T extends RowData>({
+  columnPresets,
+  tableOptions,
+}: Props<T>): JSX.Element => {
+  const table = useTable<T>(tableOptions);
+  return (
+    <Stack spacing={4} useFlexGap>
+      <StyledSectionTitle
+        component="h2"
+        id="assemblies"
+        variant={TYPOGRAPHY_PROPS.VARIANT.HEADING_SMALL}
+      >
+        Assemblies
+      </StyledSectionTitle>
+      <Alert component={FluidPaper} {...ALERT_PROPS.STANDARD_INFO}>
+        Perform an analysis in the context of an assembly.
+      </Alert>
+      {table.getRowCount() === 0 ? (
+        <EmptyState>
+          No assemblies are associated with this organism in the catalog.
+        </EmptyState>
+      ) : (
+        <StyledFluidPaper elevation={0}>
+          <Toolbar columnPresets={columnPresets} table={table} />
+          <Table table={table} />
+        </StyledFluidPaper>
+      )}
+    </Stack>
+  );
+};

--- a/app/views/OrganismView/components/Main/components/AssembliesSection/types.ts
+++ b/app/views/OrganismView/components/Main/components/AssembliesSection/types.ts
@@ -1,0 +1,7 @@
+import { RowData, TableOptions } from "@tanstack/react-table";
+import { ColumnPreset } from "../../types";
+
+export interface Props<T extends RowData> {
+  columnPresets: ColumnPreset[];
+  tableOptions: Pick<TableOptions<T>, "columns" | "data" | "initialState">;
+}

--- a/app/views/OrganismView/components/Main/components/PangenomeSection/pangenomeSection.styles.ts
+++ b/app/views/OrganismView/components/Main/components/PangenomeSection/pangenomeSection.styles.ts
@@ -1,0 +1,30 @@
+import { FluidPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/components/FluidPaper/fluidPaper";
+import { FONT } from "@databiosphere/findable-ui/lib/styles/common/constants/font.js";
+import { PALETTE } from "@databiosphere/findable-ui/lib/styles/common/constants/palette";
+import styled from "@emotion/styled";
+
+export const StyledFluidPaper = styled(FluidPaper)`
+  display: grid;
+  flex: 1;
+
+  .MuiToolbar-root {
+    border-bottom: 1px solid ${PALETTE.SMOKE_MAIN};
+    display: block;
+    padding: 20px;
+
+    .MuiList-root {
+      list-style-type: disc;
+      padding-left: 24px;
+
+      .MuiListItem-root {
+        display: list-item;
+        color: ${PALETTE.INK_LIGHT};
+        font: ${FONT.BODY_400_2_LINES};
+      }
+    }
+  }
+
+  .MuiTableContainer-root {
+    background-color: ${PALETTE.SMOKE_MAIN};
+  }
+`;

--- a/app/views/OrganismView/components/Main/components/PangenomeSection/pangenomeSection.styles.ts
+++ b/app/views/OrganismView/components/Main/components/PangenomeSection/pangenomeSection.styles.ts
@@ -1,5 +1,5 @@
 import { FluidPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/components/FluidPaper/fluidPaper";
-import { FONT } from "@databiosphere/findable-ui/lib/styles/common/constants/font.js";
+import { FONT } from "@databiosphere/findable-ui/lib/styles/common/constants/font";
 import { PALETTE } from "@databiosphere/findable-ui/lib/styles/common/constants/palette";
 import styled from "@emotion/styled";
 

--- a/app/views/OrganismView/components/Main/components/PangenomeSection/pangenomeSection.tsx
+++ b/app/views/OrganismView/components/Main/components/PangenomeSection/pangenomeSection.tsx
@@ -1,6 +1,6 @@
 import { useFeatureFlag } from "@databiosphere/findable-ui/lib/hooks/useFeatureFlag/useFeatureFlag";
 import { CHIP_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/chip";
-import { STACK_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/stack.js";
+import { STACK_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/stack";
 import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
 import {
   Chip,
@@ -66,7 +66,7 @@ export const PangenomeSection = ({ organism }: Props): JSX.Element | null => {
               Each assembly&apos;s UCSC browser carries 4 pangenome tracks:
             </Typography>
             <List disablePadding>
-              {getTrackTypes(pangenome.members.length).map((trackType) => (
+              {getTrackTypes(members?.length ?? 0).map((trackType) => (
                 <ListItem key={trackType} disablePadding>
                   {trackType}
                 </ListItem>

--- a/app/views/OrganismView/components/Main/components/PangenomeSection/pangenomeSection.tsx
+++ b/app/views/OrganismView/components/Main/components/PangenomeSection/pangenomeSection.tsx
@@ -1,4 +1,3 @@
-import { useFeatureFlag } from "@databiosphere/findable-ui/lib/hooks/useFeatureFlag/useFeatureFlag";
 import { CHIP_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/chip";
 import { STACK_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/stack";
 import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
@@ -12,7 +11,7 @@ import {
 } from "@mui/material";
 import { JSX } from "react";
 import { Table } from "../../../../../../components/common/Table/table";
-import { getPangenome } from "../../../../../../services/workflows/entities";
+import { useShowPangenome } from "../../../../hooks/UseShowPangenome/hook";
 import { StyledSectionTitle } from "../../main.styles";
 import { useTable } from "../../table/hooks/UseTable/hook";
 import { StyledFluidPaper } from "./pangenomeSection.styles";
@@ -31,12 +30,11 @@ import { getTrackTypes } from "./utils";
  * @returns The Pangenome section, or null when there is no pangenome to show.
  */
 export const PangenomeSection = ({ organism }: Props): JSX.Element | null => {
-  const isPangenomeEnabled = useFeatureFlag("pangenome");
-  const pangenome = getPangenome(organism.ncbiTaxonomyId);
+  const pangenome = useShowPangenome(organism.ncbiTaxonomyId);
   const { members } = pangenome ?? {};
   const table = useTable({ columns: COLUMNS, data: members ?? [] });
 
-  if (!isPangenomeEnabled || !pangenome) return null;
+  if (!pangenome) return null;
 
   return (
     <Stack spacing={4} useFlexGap>

--- a/app/views/OrganismView/components/Main/components/PangenomeSection/pangenomeSection.tsx
+++ b/app/views/OrganismView/components/Main/components/PangenomeSection/pangenomeSection.tsx
@@ -1,0 +1,81 @@
+import { useFeatureFlag } from "@databiosphere/findable-ui/lib/hooks/useFeatureFlag/useFeatureFlag";
+import { CHIP_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/chip";
+import { STACK_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/stack.js";
+import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
+import {
+  Chip,
+  List,
+  ListItem,
+  Stack,
+  Toolbar,
+  Typography,
+} from "@mui/material";
+import { JSX } from "react";
+import { Table } from "../../../../../../components/common/Table/table";
+import { getPangenome } from "../../../../../../services/workflows/entities";
+import { StyledSectionTitle } from "../../main.styles";
+import { useTable } from "../../table/hooks/UseTable/hook";
+import { StyledFluidPaper } from "./pangenomeSection.styles";
+import { COLUMNS } from "./table/columns";
+import { Props } from "./types";
+import { getTrackTypes } from "./utils";
+
+/**
+ * Pangenome section for the organism page: a bundle header (id + version), a
+ * description of the per-assembly UCSC tracks, and a table of member assemblies
+ * each linking to its UCSC browser. Rendered under the Assemblies section.
+ * Gated on the `pangenome` feature flag and the organism's species having a
+ * pangenome — renders nothing otherwise.
+ * @param props - Component props.
+ * @param props.organism - Organism whose species pangenome to render.
+ * @returns The Pangenome section, or null when there is no pangenome to show.
+ */
+export const PangenomeSection = ({ organism }: Props): JSX.Element | null => {
+  const isPangenomeEnabled = useFeatureFlag("pangenome");
+  const pangenome = getPangenome(organism.ncbiTaxonomyId);
+  const { members } = pangenome ?? {};
+  const table = useTable({ columns: COLUMNS, data: members ?? [] });
+
+  if (!isPangenomeEnabled || !pangenome) return null;
+
+  return (
+    <Stack spacing={4} useFlexGap>
+      <Stack
+        alignItems={STACK_PROPS.ALIGN_ITEMS.CENTER}
+        direction={STACK_PROPS.DIRECTION.ROW}
+        spacing={2}
+        useFlexGap
+      >
+        <StyledSectionTitle
+          component="h2"
+          id="pangenome"
+          variant={TYPOGRAPHY_PROPS.VARIANT.HEADING_SMALL}
+        >
+          Pangenome
+        </StyledSectionTitle>
+        <Chip
+          label={`${pangenome.bundleId} · ${pangenome.version}`}
+          size={CHIP_PROPS.SIZE.SMALL}
+          variant={CHIP_PROPS.VARIANT.STATUS}
+        />
+      </Stack>
+      <StyledFluidPaper elevation={0}>
+        <Toolbar>
+          <div>
+            <Typography variant={TYPOGRAPHY_PROPS.VARIANT.BODY_500}>
+              Each assembly&apos;s UCSC browser carries 4 pangenome tracks:
+            </Typography>
+            <List disablePadding>
+              {getTrackTypes(pangenome.members.length).map((trackType) => (
+                <ListItem key={trackType} disablePadding>
+                  {trackType}
+                </ListItem>
+              ))}
+            </List>
+          </div>
+        </Toolbar>
+        <Table table={table} />
+      </StyledFluidPaper>
+    </Stack>
+  );
+};

--- a/app/views/OrganismView/components/Main/components/PangenomeSection/table/columns.ts
+++ b/app/views/OrganismView/components/Main/components/PangenomeSection/table/columns.ts
@@ -30,6 +30,7 @@ const LEVEL: ColumnDef<PangenomeMember> = {
 };
 
 const REF: ColumnDef<PangenomeMember> = {
+  accessorKey: "isRef",
   cell: RefCell,
   header: "Ref",
   id: "isRef",
@@ -37,6 +38,7 @@ const REF: ColumnDef<PangenomeMember> = {
 };
 
 const SELECTION_TRACKS: ColumnDef<PangenomeMember> = {
+  accessorKey: "hasSelectionTracks",
   cell: SelectionTracksCell,
   header: "Selection tracks",
   id: "selectionTracks",

--- a/app/views/OrganismView/components/Main/components/PangenomeSection/table/columns.ts
+++ b/app/views/OrganismView/components/Main/components/PangenomeSection/table/columns.ts
@@ -48,7 +48,7 @@ const VIEW: ColumnDef<PangenomeMember> = {
   enableSorting: false,
   header: "View",
   id: "view",
-  meta: { header: "View", width: { max: "0.75fr", min: "164px" } },
+  meta: { header: "View", width: "164px" },
 };
 
 export const COLUMNS: ColumnDef<PangenomeMember>[] = [

--- a/app/views/OrganismView/components/Main/components/PangenomeSection/table/columns.ts
+++ b/app/views/OrganismView/components/Main/components/PangenomeSection/table/columns.ts
@@ -48,7 +48,7 @@ const VIEW: ColumnDef<PangenomeMember> = {
   enableSorting: false,
   header: "View",
   id: "view",
-  meta: { header: "View", width: "auto" },
+  meta: { header: "View", width: { max: "0.75fr", min: "164px" } },
 };
 
 export const COLUMNS: ColumnDef<PangenomeMember>[] = [

--- a/app/views/OrganismView/components/Main/components/PangenomeSection/table/columns.ts
+++ b/app/views/OrganismView/components/Main/components/PangenomeSection/table/columns.ts
@@ -1,5 +1,5 @@
 import { ColumnDef } from "@tanstack/react-table";
-import { PangenomeMember } from "../../../../../../../apis/catalog/brc-analytics-catalog/common/pangenome";
+import type { PangenomeMember } from "../../../../../../../apis/catalog/brc-analytics-catalog/common/pangenome";
 import { RefCell } from "../../../../../../../components/Table/components/TableCell/components/RefCell/refCell";
 import { AssemblyCell } from "../../../table/components/TableCell/components/AssemblyCell/assemblyCell";
 import { SelectionTracksCell } from "../../../table/components/TableCell/components/SelectionTracksCell/selectionTracksCell";
@@ -15,6 +15,9 @@ const ASSEMBLY: ColumnDef<PangenomeMember> = {
 
 const LENGTH: ColumnDef<PangenomeMember> = {
   accessorKey: "length",
+  // `length` is a display string ("29.05 Mb"), so sorting would be
+  // lexicographic and wrong. Opt out until #1341 provides a numeric length.
+  enableSorting: false,
   header: "Length",
   meta: { header: "Length", width: { max: "0.75fr", min: "132px" } },
 };

--- a/app/views/OrganismView/components/Main/components/PangenomeSection/table/columns.ts
+++ b/app/views/OrganismView/components/Main/components/PangenomeSection/table/columns.ts
@@ -1,0 +1,61 @@
+import { ColumnDef } from "@tanstack/react-table";
+import { PangenomeMember } from "../../../../../../../apis/catalog/brc-analytics-catalog/common/pangenome";
+import { RefCell } from "../../../../../../../components/Table/components/TableCell/components/RefCell/refCell";
+import { AssemblyCell } from "../../../table/components/TableCell/components/AssemblyCell/assemblyCell";
+import { SelectionTracksCell } from "../../../table/components/TableCell/components/SelectionTracksCell/selectionTracksCell";
+import { ViewCell } from "../../../table/components/TableCell/components/ViewCell/viewCell";
+import { renderLevel } from "./viewBuilder";
+
+const ASSEMBLY: ColumnDef<PangenomeMember> = {
+  accessorKey: "name",
+  cell: AssemblyCell,
+  header: "Assembly",
+  meta: { header: "Assembly", width: { max: "1fr", min: "180px" } },
+};
+
+const LENGTH: ColumnDef<PangenomeMember> = {
+  accessorKey: "length",
+  header: "Length",
+  meta: { header: "Length", width: { max: "0.75fr", min: "132px" } },
+};
+
+const LEVEL: ColumnDef<PangenomeMember> = {
+  // Sort by tier (levelFilledCount) to match the bar indicator, not the
+  // free-text label — Genome (4) > Chromosome (3) > Scaffold (2) > Contig (1).
+  accessorFn: (row) => row.levelFilledCount,
+  cell: renderLevel,
+  header: "Level",
+  id: "level",
+  meta: { header: "Level", width: { max: "0.75fr", min: "142px" } },
+};
+
+const REF: ColumnDef<PangenomeMember> = {
+  cell: RefCell,
+  header: "Ref",
+  id: "isRef",
+  meta: { header: "Ref", width: { max: "0.75fr", min: "100px" } },
+};
+
+const SELECTION_TRACKS: ColumnDef<PangenomeMember> = {
+  cell: SelectionTracksCell,
+  header: "Selection tracks",
+  id: "selectionTracks",
+  meta: { header: "Selection tracks", width: { max: "0.75fr", min: "140px" } },
+};
+
+const VIEW: ColumnDef<PangenomeMember> = {
+  cell: ViewCell,
+  enableSorting: false,
+  header: "View",
+  id: "view",
+  meta: { header: "View", width: "auto" },
+};
+
+export const COLUMNS: ColumnDef<PangenomeMember>[] = [
+  ASSEMBLY,
+  SELECTION_TRACKS,
+  LEVEL,
+  REF,
+  LENGTH,
+  VIEW,
+];

--- a/app/views/OrganismView/components/Main/components/PangenomeSection/table/viewBuilder.tsx
+++ b/app/views/OrganismView/components/Main/components/PangenomeSection/table/viewBuilder.tsx
@@ -1,0 +1,17 @@
+import { CellContext } from "@tanstack/react-table";
+import { JSX } from "react";
+import { PangenomeMember } from "../../../../../../../apis/catalog/brc-analytics-catalog/common/pangenome";
+import { LevelCell } from "../../../../../../../components/Table/components/TableCell/components/LevelCell/levelCell";
+
+/**
+ * Renders the assembly level cell — a tiered bar indicator plus the label.
+ * @param cellContext - Cell context.
+ * @param cellContext.row - Row context.
+ * @returns The level cell.
+ */
+export function renderLevel({
+  row,
+}: CellContext<PangenomeMember, unknown>): JSX.Element {
+  const { levelFilledCount, levelLabel } = row.original;
+  return <LevelCell filledCount={levelFilledCount} label={levelLabel} />;
+}

--- a/app/views/OrganismView/components/Main/components/PangenomeSection/table/viewBuilder.tsx
+++ b/app/views/OrganismView/components/Main/components/PangenomeSection/table/viewBuilder.tsx
@@ -1,6 +1,6 @@
 import { CellContext } from "@tanstack/react-table";
 import { JSX } from "react";
-import { PangenomeMember } from "../../../../../../../apis/catalog/brc-analytics-catalog/common/pangenome";
+import type { PangenomeMember } from "../../../../../../../apis/catalog/brc-analytics-catalog/common/pangenome";
 import { LevelCell } from "../../../../../../../components/Table/components/TableCell/components/LevelCell/levelCell";
 
 /**

--- a/app/views/OrganismView/components/Main/components/PangenomeSection/types.ts
+++ b/app/views/OrganismView/components/Main/components/PangenomeSection/types.ts
@@ -1,0 +1,5 @@
+import { Organism } from "../../../../types";
+
+export interface Props {
+  organism: Organism;
+}

--- a/app/views/OrganismView/components/Main/components/PangenomeSection/utils.ts
+++ b/app/views/OrganismView/components/Main/components/PangenomeSection/utils.ts
@@ -1,0 +1,18 @@
+/**
+ * Builds the pangenome track-type labels shown in the section description.
+ * Presentational copy for the current Plasmodium vivax mock; the member count
+ * drives the multi-z "N-way" label.
+ * @param memberCount - Number of member assemblies in the bundle.
+ * @returns Track-type labels.
+ */
+export function getTrackTypes(memberCount: number): string[] {
+  return [
+    `Multi-z alignment (${memberCount}-way)`,
+    "Pairwise chains to each other strain",
+    "Cross-strain gene projections",
+    // TODO(#1341): species-specific — the cohort-variants track is Plasmodium
+    // (MalariaGEN) only. Source this per-bundle from pangenomes.json once the
+    // real build lands rather than hardcoding it for every species here.
+    "MalariaGEN cohort variants (1,895 samples)",
+  ];
+}

--- a/app/views/OrganismView/components/Main/components/WorkflowsSection/types.ts
+++ b/app/views/OrganismView/components/Main/components/WorkflowsSection/types.ts
@@ -1,0 +1,6 @@
+import { Organism } from "../../../../types";
+
+export interface Props {
+  entityId: string;
+  organism: Organism;
+}

--- a/app/views/OrganismView/components/Main/components/WorkflowsSection/workflowsSection.tsx
+++ b/app/views/OrganismView/components/Main/components/WorkflowsSection/workflowsSection.tsx
@@ -1,0 +1,58 @@
+import { useFeatureFlag } from "@databiosphere/findable-ui/lib/hooks/useFeatureFlag/useFeatureFlag";
+import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
+import { Stack } from "@mui/material";
+import { JSX } from "react";
+import { ROUTES } from "../../../../../../../routes/constants";
+import { getWorkflows } from "../../../../../../services/workflows/entities";
+import { Accordion } from "../../../../../AnalyzeWorkflowsView/components/Main/components/Accordion/accordion";
+import { StyledSectionTitle } from "../../main.styles";
+import { buildOrganismWorkflows } from "../../utils";
+import { EmptyState } from "../EmptyState/emptyState";
+import { Props } from "./types";
+
+/**
+ * Organism-specific workflows section for the organism page: a header and the
+ * organism-scoped workflow categories (or an empty state when none exist).
+ * @param props - Component props.
+ * @param props.entityId - Organism entity ID.
+ * @param props.organism - Organism.
+ * @returns The workflows section.
+ */
+export const WorkflowsSection = ({
+  entityId,
+  organism,
+}: Props): JSX.Element => {
+  const isAssemblyWorkflowsEnabled = useFeatureFlag("assembly-workflows");
+  const workflowCategories = buildOrganismWorkflows(
+    organism,
+    getWorkflows(),
+    isAssemblyWorkflowsEnabled
+  );
+  return (
+    <Stack spacing={4} useFlexGap>
+      <StyledSectionTitle
+        component="h2"
+        id="workflows"
+        variant={TYPOGRAPHY_PROPS.VARIANT.HEADING_SMALL}
+      >
+        Organism specific workflows
+      </StyledSectionTitle>
+      {workflowCategories.length === 0 ? (
+        <EmptyState>
+          No organism-specific workflows exist for this organism.
+        </EmptyState>
+      ) : (
+        workflowCategories.map((workflowCategory) => (
+          <Accordion
+            configureRoute={ROUTES.CONFIGURE_ORGANISM_WORKFLOW}
+            disabled={workflowCategory.workflows.length === 0}
+            entityId={entityId}
+            key={workflowCategory.category}
+            workflowCategory={workflowCategory}
+            workflows={workflowCategory.workflows}
+          />
+        ))
+      )}
+    </Stack>
+  );
+};

--- a/app/views/OrganismView/components/Main/main.styles.ts
+++ b/app/views/OrganismView/components/Main/main.styles.ts
@@ -3,6 +3,8 @@ import styled from "@emotion/styled";
 import { SectionTitle } from "../../../EntityView/ui/SectionTitle/sectionTitle";
 
 export const StyledSectionTitle = styled(SectionTitle)`
+  scroll-margin-top: 72px;
+
   ${bpDownSm} {
     padding: 0 16px;
   }

--- a/app/views/OrganismView/components/Main/main.tsx
+++ b/app/views/OrganismView/components/Main/main.tsx
@@ -1,88 +1,31 @@
-import { ALERT_PROPS } from "@databiosphere/findable-ui/lib/components/common/Alert/constants";
-import { FluidPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/components/FluidPaper/fluidPaper";
-import { useFeatureFlag } from "@databiosphere/findable-ui/lib/hooks/useFeatureFlag/useFeatureFlag";
-import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
-import { Alert } from "@mui/material";
+import { Stack } from "@mui/material";
 import { RowData } from "@tanstack/react-table";
 import { JSX } from "react";
-import { ROUTES } from "../../../../../routes/constants";
-import { Table } from "../../../../components/common/Table/table";
-import { getWorkflows } from "../../../../services/workflows/entities";
-import { Accordion } from "../../../AnalyzeWorkflowsView/components/Main/components/Accordion/accordion";
-import { EmptyState } from "./components/EmptyState/emptyState";
-import { StyledSectionTitle } from "./main.styles";
-import { Toolbar } from "./table/components/Toolbar/toolbar";
-import { useTable } from "./table/hooks/UseTable/hook";
-import { StyledFluidPaper } from "./table/table.styles";
+import { AssembliesSection } from "./components/AssembliesSection/assembliesSection";
+import { PangenomeSection } from "./components/PangenomeSection/pangenomeSection";
+import { WorkflowsSection } from "./components/WorkflowsSection/workflowsSection";
 import type { Props } from "./types";
-import { buildOrganismWorkflows } from "./utils";
 
 /**
- * Main column for the organism detail page: organism-scoped workflows section
- * and the assemblies section (header, info alert, and assemblies table).
+ * Main column for the organism detail page: composes the organism-scoped
+ * workflows section, the assemblies section, and (when enabled and available)
+ * the pangenome section.
  * @param props - Component props.
- * @param props.columnPresets - Column presets for the assemblies table.
+ * @param props.assembly - Assemblies section props (column presets + table options).
  * @param props.entityId - Organism entity ID.
  * @param props.organism - Organism.
- * @param props.tableOptions - Options for the assemblies table.
  * @returns A JSX element with the organism detail main content.
  */
 export const Main = <T extends RowData>({
-  columnPresets,
+  assembly,
   entityId,
   organism,
-  tableOptions,
 }: Props<T>): JSX.Element => {
-  const table = useTable<T>(tableOptions);
-  const isAssemblyWorkflowsEnabled = useFeatureFlag("assembly-workflows");
-  const workflowCategories = buildOrganismWorkflows(
-    organism,
-    getWorkflows(),
-    isAssemblyWorkflowsEnabled
-  );
   return (
-    <>
-      <StyledSectionTitle
-        component="h2"
-        variant={TYPOGRAPHY_PROPS.VARIANT.HEADING_SMALL}
-      >
-        Organism specific workflows
-      </StyledSectionTitle>
-      {workflowCategories.length === 0 ? (
-        <EmptyState>
-          No organism-specific workflows exist for this organism.
-        </EmptyState>
-      ) : (
-        workflowCategories.map((workflowCategory) => (
-          <Accordion
-            configureRoute={ROUTES.CONFIGURE_ORGANISM_WORKFLOW}
-            disabled={workflowCategory.workflows.length === 0}
-            entityId={entityId}
-            key={workflowCategory.category}
-            workflowCategory={workflowCategory}
-            workflows={workflowCategory.workflows}
-          />
-        ))
-      )}
-      <StyledSectionTitle
-        component="h2"
-        variant={TYPOGRAPHY_PROPS.VARIANT.HEADING_SMALL}
-      >
-        Assemblies
-      </StyledSectionTitle>
-      <Alert component={FluidPaper} {...ALERT_PROPS.STANDARD_INFO}>
-        Perform an analysis in the context of an assembly.
-      </Alert>
-      {table.getRowCount() === 0 ? (
-        <EmptyState>
-          No assemblies are associated with this organism in the catalog.
-        </EmptyState>
-      ) : (
-        <StyledFluidPaper elevation={0}>
-          <Toolbar columnPresets={columnPresets} table={table} />
-          <Table table={table} />
-        </StyledFluidPaper>
-      )}
-    </>
+    <Stack spacing={8} useFlexGap>
+      <WorkflowsSection entityId={entityId} organism={organism} />
+      <AssembliesSection {...assembly} />
+      <PangenomeSection organism={organism} />
+    </Stack>
   );
 };

--- a/app/views/OrganismView/components/Main/table/components/TableCell/components/AssemblyCell/assemblyCell.tsx
+++ b/app/views/OrganismView/components/Main/table/components/TableCell/components/AssemblyCell/assemblyCell.tsx
@@ -4,7 +4,7 @@ import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/m
 import { Chip, Stack, Typography } from "@mui/material";
 import { CellContext } from "@tanstack/react-table";
 import { JSX } from "react";
-import { PangenomeMember } from "../../../../../../../../../apis/catalog/brc-analytics-catalog/common/pangenome";
+import type { PangenomeMember } from "../../../../../../../../../apis/catalog/brc-analytics-catalog/common/pangenome";
 
 /**
  * Assembly cell for the pangenome members table: the member name, an optional

--- a/app/views/OrganismView/components/Main/table/components/TableCell/components/AssemblyCell/assemblyCell.tsx
+++ b/app/views/OrganismView/components/Main/table/components/TableCell/components/AssemblyCell/assemblyCell.tsx
@@ -1,0 +1,45 @@
+import { CHIP_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/chip";
+import { STACK_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/stack";
+import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
+import { Chip, Stack, Typography } from "@mui/material";
+import { CellContext } from "@tanstack/react-table";
+import { JSX } from "react";
+import { PangenomeMember } from "../../../../../../../../../apis/catalog/brc-analytics-catalog/common/pangenome";
+
+/**
+ * Assembly cell for the pangenome members table: the member name, an optional
+ * "Anchor" chip on the reference anchor, then the accession — matching the
+ * assemblies-table cell layout.
+ * @param props - Component props.
+ * @param props.row - Row context.
+ * @returns The assembly cell.
+ */
+export const AssemblyCell = ({
+  row,
+}: CellContext<PangenomeMember, unknown>): JSX.Element => {
+  const { original } = row;
+  const { accession, isAnchor, name } = original;
+  return (
+    <Stack spacing={2} useFlexGap>
+      <Stack direction={STACK_PROPS.DIRECTION.ROW} spacing={2} useFlexGap>
+        <Typography variant={TYPOGRAPHY_PROPS.VARIANT.BODY_400}>
+          {name}
+        </Typography>
+        {isAnchor && (
+          <Chip
+            color={CHIP_PROPS.COLOR.INFO}
+            label="Anchor"
+            size={CHIP_PROPS.SIZE.SMALL}
+            variant={CHIP_PROPS.VARIANT.STATUS}
+          />
+        )}
+      </Stack>
+      <Typography
+        color={TYPOGRAPHY_PROPS.COLOR.INK_LIGHT}
+        variant={TYPOGRAPHY_PROPS.VARIANT.BODY_SMALL_400}
+      >
+        {accession}
+      </Typography>
+    </Stack>
+  );
+};

--- a/app/views/OrganismView/components/Main/table/components/TableCell/components/SelectionTracksCell/selectionTracksCell.tsx
+++ b/app/views/OrganismView/components/Main/table/components/TableCell/components/SelectionTracksCell/selectionTracksCell.tsx
@@ -1,0 +1,29 @@
+import { CHIP_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/chip";
+import { Chip } from "@mui/material";
+import { CellContext } from "@tanstack/react-table";
+import { JSX } from "react";
+import { PangenomeMember } from "../../../../../../../../../apis/catalog/brc-analytics-catalog/common/pangenome";
+
+/**
+ * Selection tracks cell for the pangenome members table: a chip indicating
+ * whether the member has selection tracks.
+ * @param props - Component props.
+ * @param props.row - Row context.
+ * @returns The selection tracks cell.
+ */
+export const SelectionTracksCell = ({
+  row,
+}: CellContext<PangenomeMember, unknown>): JSX.Element => {
+  const {
+    original: { hasSelectionTracks },
+  } = row;
+  return (
+    <Chip
+      color={
+        hasSelectionTracks ? CHIP_PROPS.COLOR.SUCCESS : CHIP_PROPS.COLOR.DEFAULT
+      }
+      label={hasSelectionTracks ? "Yes" : "No"}
+      variant={CHIP_PROPS.VARIANT.STATUS}
+    />
+  );
+};

--- a/app/views/OrganismView/components/Main/table/components/TableCell/components/SelectionTracksCell/selectionTracksCell.tsx
+++ b/app/views/OrganismView/components/Main/table/components/TableCell/components/SelectionTracksCell/selectionTracksCell.tsx
@@ -2,7 +2,7 @@ import { CHIP_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/chi
 import { Chip } from "@mui/material";
 import { CellContext } from "@tanstack/react-table";
 import { JSX } from "react";
-import { PangenomeMember } from "../../../../../../../../../apis/catalog/brc-analytics-catalog/common/pangenome";
+import type { PangenomeMember } from "../../../../../../../../../apis/catalog/brc-analytics-catalog/common/pangenome";
 
 /**
  * Selection tracks cell for the pangenome members table: a chip indicating

--- a/app/views/OrganismView/components/Main/table/components/TableCell/components/ViewCell/viewCell.tsx
+++ b/app/views/OrganismView/components/Main/table/components/TableCell/components/ViewCell/viewCell.tsx
@@ -6,7 +6,7 @@ import { BUTTON_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/b
 import { Button } from "@mui/material";
 import { CellContext } from "@tanstack/react-table";
 import { JSX } from "react";
-import { PangenomeMember } from "../../../../../../../../../apis/catalog/brc-analytics-catalog/common/pangenome";
+import type { PangenomeMember } from "../../../../../../../../../apis/catalog/brc-analytics-catalog/common/pangenome";
 
 /**
  * View cell for the pangenome members table: a button linking to the member

--- a/app/views/OrganismView/components/Main/table/components/TableCell/components/ViewCell/viewCell.tsx
+++ b/app/views/OrganismView/components/Main/table/components/TableCell/components/ViewCell/viewCell.tsx
@@ -8,15 +8,20 @@ import { CellContext } from "@tanstack/react-table";
 import { JSX } from "react";
 import { PangenomeMember } from "../../../../../../../../../apis/catalog/brc-analytics-catalog/common/pangenome";
 
+/**
+ * View cell for the pangenome members table: a button linking to the member
+ * assembly's UCSC browser (with the pangenome track hub).
+ * @param props - Component props.
+ * @param props.row - Row context.
+ * @returns The UCSC browser link button.
+ */
 export const ViewCell = ({
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- TODO: implement the view cell to link to the UCSC browser for the member assembly.
   row,
 }: CellContext<PangenomeMember, unknown>): JSX.Element => {
   return (
     <Button
       color={BUTTON_PROPS.COLOR.SECONDARY}
-      disabled
-      href="/" // TODO: implement the view cell to link to the UCSC browser for the member assembly.
+      href={row.original.ucscBrowserUrl}
       rel={REL_ATTRIBUTE.NO_OPENER_NO_REFERRER}
       sx={{ textTransform: "none" }}
       target={ANCHOR_TARGET.BLANK}

--- a/app/views/OrganismView/components/Main/table/components/TableCell/components/ViewCell/viewCell.tsx
+++ b/app/views/OrganismView/components/Main/table/components/TableCell/components/ViewCell/viewCell.tsx
@@ -1,7 +1,7 @@
 import {
   ANCHOR_TARGET,
   REL_ATTRIBUTE,
-} from "@databiosphere/findable-ui/lib/components/Links/common/entities.js";
+} from "@databiosphere/findable-ui/lib/components/Links/common/entities";
 import { BUTTON_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/button";
 import { Button } from "@mui/material";
 import { CellContext } from "@tanstack/react-table";

--- a/app/views/OrganismView/components/Main/table/components/TableCell/components/ViewCell/viewCell.tsx
+++ b/app/views/OrganismView/components/Main/table/components/TableCell/components/ViewCell/viewCell.tsx
@@ -1,0 +1,28 @@
+import {
+  ANCHOR_TARGET,
+  REL_ATTRIBUTE,
+} from "@databiosphere/findable-ui/lib/components/Links/common/entities.js";
+import { BUTTON_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/button";
+import { Button } from "@mui/material";
+import { CellContext } from "@tanstack/react-table";
+import { JSX } from "react";
+import { PangenomeMember } from "../../../../../../../../../apis/catalog/brc-analytics-catalog/common/pangenome";
+
+export const ViewCell = ({
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- TODO: implement the view cell to link to the UCSC browser for the member assembly.
+  row,
+}: CellContext<PangenomeMember, unknown>): JSX.Element => {
+  return (
+    <Button
+      color={BUTTON_PROPS.COLOR.SECONDARY}
+      disabled
+      href="/" // TODO: implement the view cell to link to the UCSC browser for the member assembly.
+      rel={REL_ATTRIBUTE.NO_OPENER_NO_REFERRER}
+      sx={{ textTransform: "none" }}
+      target={ANCHOR_TARGET.BLANK}
+      variant={BUTTON_PROPS.VARIANT.CONTAINED}
+    >
+      UCSC browser
+    </Button>
+  );
+};

--- a/app/views/OrganismView/components/Main/types.ts
+++ b/app/views/OrganismView/components/Main/types.ts
@@ -12,8 +12,10 @@ export interface ColumnPreset {
 }
 
 export interface Props<T extends RowData> {
-  columnPresets: ColumnPreset[];
+  assembly: {
+    columnPresets: ColumnPreset[];
+    tableOptions: Pick<TableOptions<T>, "columns" | "data" | "initialState">;
+  };
   entityId: string;
   organism: Organism;
-  tableOptions: Pick<TableOptions<T>, "columns" | "data" | "initialState">;
 }

--- a/app/views/OrganismView/components/Tabs/constants.ts
+++ b/app/views/OrganismView/components/Tabs/constants.ts
@@ -1,0 +1,5 @@
+export const TAB = {
+  ASSEMBLIES: "assemblies",
+  PANGENOME: "pangenome",
+  WORKFLOWS: "workflows",
+} as const;

--- a/app/views/OrganismView/components/Tabs/tabs.tsx
+++ b/app/views/OrganismView/components/Tabs/tabs.tsx
@@ -1,23 +1,42 @@
+import { TabScrollFuzz } from "@databiosphere/findable-ui/lib/components/common/Tabs/tabs.styles";
+import { BackPageTabs } from "@databiosphere/findable-ui/lib/components/Layout/components/BackPage/backPageView.styles";
 import { useHash } from "@databiosphere/findable-ui/lib/components/Layout/components/Outline/hooks/UseHash/hook";
 import { useFeatureFlag } from "@databiosphere/findable-ui/lib/hooks/useFeatureFlag/useFeatureFlag";
 import { Tabs as MTabs, Tab } from "@mui/material";
 import { useRouter } from "next/router";
 import { type JSX } from "react";
+import { getPangenome } from "../../../../services/workflows/entities";
+import { Props } from "./types";
 
-export const Tabs = (): JSX.Element => {
+/**
+ * Organism-page section tabs. The Pangenome tab is shown only when the
+ * `pangenome` feature flag is enabled and the organism's species has a
+ * pangenome bundle — matching the PangenomeSection's own gating.
+ * @param props - Component props.
+ * @param props.ncbiTaxonomyId - Organism's NCBI (species) taxonomy ID.
+ * @returns The organism-page tabs.
+ */
+export const Tabs = ({ ncbiTaxonomyId }: Props): JSX.Element => {
   const isPangenomeEnabled = useFeatureFlag("pangenome");
   const { hash } = useHash();
   const { push } = useRouter();
+  const hasPangenome = Boolean(getPangenome(ncbiTaxonomyId));
   return (
-    <MTabs
-      onChange={(_, v) => {
-        push(`#${v}`);
-      }}
-      value={hash || "workflows"}
-    >
-      <Tab label="Workflows" value="workflows" />
-      <Tab label="Assemblies" value="assemblies" />
-      {isPangenomeEnabled && <Tab label="Pangenome" value="pangenome" />}
-    </MTabs>
+    <BackPageTabs>
+      <MTabs
+        allowScrollButtonsMobile
+        onChange={(_, v) => {
+          push(`#${v}`);
+        }}
+        slots={{ scrollButtons: TabScrollFuzz }}
+        value={hash || "workflows"}
+      >
+        <Tab label="Workflows" value="workflows" />
+        <Tab label="Assemblies" value="assemblies" />
+        {isPangenomeEnabled && hasPangenome && (
+          <Tab label="Pangenome" value="pangenome" />
+        )}
+      </MTabs>
+    </BackPageTabs>
   );
 };

--- a/app/views/OrganismView/components/Tabs/tabs.tsx
+++ b/app/views/OrganismView/components/Tabs/tabs.tsx
@@ -1,11 +1,10 @@
 import { TabScrollFuzz } from "@databiosphere/findable-ui/lib/components/common/Tabs/tabs.styles";
 import { BackPageTabs } from "@databiosphere/findable-ui/lib/components/Layout/components/BackPage/backPageView.styles";
 import { useHash } from "@databiosphere/findable-ui/lib/components/Layout/components/Outline/hooks/UseHash/hook";
-import { useFeatureFlag } from "@databiosphere/findable-ui/lib/hooks/useFeatureFlag/useFeatureFlag";
 import { Tabs as MTabs, Tab } from "@mui/material";
 import { useRouter } from "next/router";
 import { type JSX } from "react";
-import { getPangenome } from "../../../../services/workflows/entities";
+import { useShowPangenome } from "../../hooks/UseShowPangenome/hook";
 import { TAB } from "./constants";
 import { Props } from "./types";
 import { getActiveTab } from "./utils";
@@ -19,11 +18,9 @@ import { getActiveTab } from "./utils";
  * @returns The organism-page tabs.
  */
 export const Tabs = ({ ncbiTaxonomyId }: Props): JSX.Element => {
-  const isPangenomeEnabled = useFeatureFlag("pangenome");
   const { hash } = useHash();
   const { push } = useRouter();
-  const pangenome = getPangenome(ncbiTaxonomyId);
-  const showPangenome = isPangenomeEnabled && Boolean(pangenome);
+  const showPangenome = Boolean(useShowPangenome(ncbiTaxonomyId));
   return (
     <BackPageTabs>
       <MTabs

--- a/app/views/OrganismView/components/Tabs/tabs.tsx
+++ b/app/views/OrganismView/components/Tabs/tabs.tsx
@@ -21,6 +21,16 @@ export const Tabs = ({ ncbiTaxonomyId }: Props): JSX.Element => {
   const { hash } = useHash();
   const { push } = useRouter();
   const hasPangenome = Boolean(getPangenome(ncbiTaxonomyId));
+  const showPangenome = isPangenomeEnabled && hasPangenome;
+  // Normalize the active tab to one that's actually rendered: a deep-link to
+  // #pangenome while the tab is hidden would otherwise leave MUI Tabs with an
+  // unmatched value (no selection + a runtime warning).
+  const tabValues = [
+    "workflows",
+    "assemblies",
+    ...(showPangenome ? ["pangenome"] : []),
+  ];
+  const value = hash && tabValues.includes(hash) ? hash : "workflows";
   return (
     <BackPageTabs>
       <MTabs
@@ -29,13 +39,11 @@ export const Tabs = ({ ncbiTaxonomyId }: Props): JSX.Element => {
           push(`#${v}`);
         }}
         slots={{ scrollButtons: TabScrollFuzz }}
-        value={hash || "workflows"}
+        value={value}
       >
         <Tab label="Workflows" value="workflows" />
         <Tab label="Assemblies" value="assemblies" />
-        {isPangenomeEnabled && hasPangenome && (
-          <Tab label="Pangenome" value="pangenome" />
-        )}
+        {showPangenome && <Tab label="Pangenome" value="pangenome" />}
       </MTabs>
     </BackPageTabs>
   );

--- a/app/views/OrganismView/components/Tabs/tabs.tsx
+++ b/app/views/OrganismView/components/Tabs/tabs.tsx
@@ -1,0 +1,23 @@
+import { useHash } from "@databiosphere/findable-ui/lib/components/Layout/components/Outline/hooks/UseHash/hook";
+import { useFeatureFlag } from "@databiosphere/findable-ui/lib/hooks/useFeatureFlag/useFeatureFlag";
+import { Tabs as MTabs, Tab } from "@mui/material";
+import { useRouter } from "next/router";
+import { type JSX } from "react";
+
+export const Tabs = (): JSX.Element => {
+  const isPangenomeEnabled = useFeatureFlag("pangenome");
+  const { hash } = useHash();
+  const { push } = useRouter();
+  return (
+    <MTabs
+      onChange={(_, v) => {
+        push(`#${v}`);
+      }}
+      value={hash || "workflows"}
+    >
+      <Tab label="Workflows" value="workflows" />
+      <Tab label="Assemblies" value="assemblies" />
+      {isPangenomeEnabled && <Tab label="Pangenome" value="pangenome" />}
+    </MTabs>
+  );
+};

--- a/app/views/OrganismView/components/Tabs/tabs.tsx
+++ b/app/views/OrganismView/components/Tabs/tabs.tsx
@@ -6,7 +6,9 @@ import { Tabs as MTabs, Tab } from "@mui/material";
 import { useRouter } from "next/router";
 import { type JSX } from "react";
 import { getPangenome } from "../../../../services/workflows/entities";
+import { TAB } from "./constants";
 import { Props } from "./types";
+import { getActiveTab } from "./utils";
 
 /**
  * Organism-page section tabs. The Pangenome tab is shown only when the
@@ -20,17 +22,8 @@ export const Tabs = ({ ncbiTaxonomyId }: Props): JSX.Element => {
   const isPangenomeEnabled = useFeatureFlag("pangenome");
   const { hash } = useHash();
   const { push } = useRouter();
-  const hasPangenome = Boolean(getPangenome(ncbiTaxonomyId));
-  const showPangenome = isPangenomeEnabled && hasPangenome;
-  // Normalize the active tab to one that's actually rendered: a deep-link to
-  // #pangenome while the tab is hidden would otherwise leave MUI Tabs with an
-  // unmatched value (no selection + a runtime warning).
-  const tabValues = [
-    "workflows",
-    "assemblies",
-    ...(showPangenome ? ["pangenome"] : []),
-  ];
-  const value = hash && tabValues.includes(hash) ? hash : "workflows";
+  const pangenome = getPangenome(ncbiTaxonomyId);
+  const showPangenome = isPangenomeEnabled && Boolean(pangenome);
   return (
     <BackPageTabs>
       <MTabs
@@ -39,11 +32,11 @@ export const Tabs = ({ ncbiTaxonomyId }: Props): JSX.Element => {
           push(`#${v}`);
         }}
         slots={{ scrollButtons: TabScrollFuzz }}
-        value={value}
+        value={getActiveTab(hash, showPangenome)}
       >
-        <Tab label="Workflows" value="workflows" />
-        <Tab label="Assemblies" value="assemblies" />
-        {showPangenome && <Tab label="Pangenome" value="pangenome" />}
+        <Tab label="Workflows" value={TAB.WORKFLOWS} />
+        <Tab label="Assemblies" value={TAB.ASSEMBLIES} />
+        {showPangenome && <Tab label="Pangenome" value={TAB.PANGENOME} />}
       </MTabs>
     </BackPageTabs>
   );

--- a/app/views/OrganismView/components/Tabs/types.ts
+++ b/app/views/OrganismView/components/Tabs/types.ts
@@ -1,0 +1,3 @@
+export interface Props {
+  ncbiTaxonomyId: string;
+}

--- a/app/views/OrganismView/components/Tabs/utils.ts
+++ b/app/views/OrganismView/components/Tabs/utils.ts
@@ -1,0 +1,22 @@
+import { TAB } from "./constants";
+
+/**
+ * Returns the active tab value, normalized to one of the currently-rendered
+ * tabs. A hash pointing at a hidden tab (e.g. `#pangenome` when the Pangenome
+ * tab isn't shown) falls back to Workflows, so MUI Tabs never receives an
+ * unmatched value (no selection + a runtime warning).
+ * @param hash - Current URL hash (without the leading `#`).
+ * @param showPangenome - Whether the Pangenome tab is rendered.
+ * @returns The active tab value.
+ */
+export function getActiveTab(hash: string, showPangenome: boolean): string {
+  if (!hash) return TAB.WORKFLOWS;
+
+  const tabValues: string[] = [TAB.WORKFLOWS, TAB.ASSEMBLIES];
+
+  if (showPangenome) {
+    tabValues.push(TAB.PANGENOME);
+  }
+
+  return tabValues.includes(hash) ? hash : TAB.WORKFLOWS;
+}

--- a/app/views/OrganismView/hooks/UseShowPangenome/hook.ts
+++ b/app/views/OrganismView/hooks/UseShowPangenome/hook.ts
@@ -1,0 +1,19 @@
+import { useFeatureFlag } from "@databiosphere/findable-ui/lib/hooks/useFeatureFlag/useFeatureFlag";
+import type { Pangenome } from "../../../../apis/catalog/brc-analytics-catalog/common/pangenome";
+import { getPangenome } from "../../../../services/workflows/entities";
+
+/**
+ * Returns the pangenome bundle to show for a species — the bundle when the
+ * `pangenome` feature flag is enabled and the species has one, otherwise
+ * undefined. Single source of truth so the organism-page tab and the Pangenome
+ * section gate identically and can't drift.
+ * @param ncbiTaxonomyId - Organism's NCBI (species) taxonomy ID.
+ * @returns The pangenome bundle to show, or undefined.
+ */
+export function useShowPangenome(
+  ncbiTaxonomyId: string
+): Pangenome | undefined {
+  const isPangenomeEnabled = useFeatureFlag("pangenome");
+  const pangenome = getPangenome(ncbiTaxonomyId);
+  return isPangenomeEnabled ? pangenome : undefined;
+}

--- a/catalog/output/pangenomes.json
+++ b/catalog/output/pangenomes.json
@@ -1,0 +1,97 @@
+[
+  {
+    "bundleId": "plasmodium-vivax-v1",
+    "speciesTaxonomyId": "5855",
+    "version": "2026-05",
+    "members": [
+      {
+        "accession": "GCA_900093555.2",
+        "hasSelectionTracks": true,
+        "isAnchor": true,
+        "isRef": true,
+        "length": "29.05 Mb",
+        "levelFilledCount": 4,
+        "levelLabel": "Genome",
+        "name": "PvP01",
+        "ucscBrowserUrl": ""
+      },
+      {
+        "accession": "GCA_000002415.2",
+        "hasSelectionTracks": false,
+        "isAnchor": false,
+        "isRef": false,
+        "length": "26.99 Mb",
+        "levelFilledCount": 3,
+        "levelLabel": "Chromosome",
+        "name": "Sal-I",
+        "ucscBrowserUrl": ""
+      },
+      {
+        "accession": "GCA_914969965.1",
+        "hasSelectionTracks": false,
+        "isAnchor": false,
+        "isRef": false,
+        "length": "28.35 Mb",
+        "levelFilledCount": 3,
+        "levelLabel": "Chromosome",
+        "name": "PvW1",
+        "ucscBrowserUrl": ""
+      },
+      {
+        "accession": "GCA_949152365.1",
+        "hasSelectionTracks": false,
+        "isAnchor": false,
+        "isRef": false,
+        "length": "27.86 Mb",
+        "levelFilledCount": 2,
+        "levelLabel": "Scaffold",
+        "name": "PAM",
+        "ucscBrowserUrl": ""
+      },
+      {
+        "accession": "GCA_003402215.1",
+        "hasSelectionTracks": false,
+        "isAnchor": false,
+        "isRef": false,
+        "length": "29.44 Mb",
+        "levelFilledCount": 2,
+        "levelLabel": "Scaffold",
+        "name": "PvSY56",
+        "ucscBrowserUrl": ""
+      },
+      {
+        "accession": "GCA_900093545.1",
+        "hasSelectionTracks": false,
+        "isAnchor": false,
+        "isRef": false,
+        "length": "28.13 Mb",
+        "levelFilledCount": 2,
+        "levelLabel": "Scaffold",
+        "name": "PvT01",
+        "ucscBrowserUrl": ""
+      },
+      {
+        "accession": "GCA_900093535.1",
+        "hasSelectionTracks": false,
+        "isAnchor": false,
+        "isRef": false,
+        "length": "27.51 Mb",
+        "levelFilledCount": 2,
+        "levelLabel": "Scaffold",
+        "name": "PvC01",
+        "ucscBrowserUrl": ""
+      },
+      {
+        "accession": "GCA_040114635.1",
+        "hasSelectionTracks": false,
+        "isAnchor": false,
+        "isRef": false,
+        "length": "28.62 Mb",
+        "levelFilledCount": 3,
+        "levelLabel": "Chromosome",
+        "name": "MHC087",
+        "ucscBrowserUrl": ""
+      }
+    ]
+  }
+]

--- a/catalog/output/pangenomes.json
+++ b/catalog/output/pangenomes.json
@@ -13,7 +13,7 @@
         "levelFilledCount": 4,
         "levelLabel": "Genome",
         "name": "PvP01",
-        "ucscBrowserUrl": ""
+        "ucscBrowserUrl": "https://genome.ucsc.edu/cgi-bin/hgTracks?genome=GCA_900093555.2&hubUrl=https://genome.ucsc.edu/hubspace/a6/anekrut/BRC_Pangenome_Pv_v1/hub.txt&udcTimeout=5"
       },
       {
         "accession": "GCA_000002415.2",
@@ -24,7 +24,7 @@
         "levelFilledCount": 3,
         "levelLabel": "Chromosome",
         "name": "Sal-I",
-        "ucscBrowserUrl": ""
+        "ucscBrowserUrl": "https://genome.ucsc.edu/cgi-bin/hgTracks?genome=GCA_000002415.2&hubUrl=https://genome.ucsc.edu/hubspace/a6/anekrut/BRC_Pangenome_Pv_v1/hub.txt&udcTimeout=5"
       },
       {
         "accession": "GCA_914969965.1",
@@ -35,7 +35,7 @@
         "levelFilledCount": 3,
         "levelLabel": "Chromosome",
         "name": "PvW1",
-        "ucscBrowserUrl": ""
+        "ucscBrowserUrl": "https://genome.ucsc.edu/cgi-bin/hgTracks?genome=GCA_914969965.1&hubUrl=https://genome.ucsc.edu/hubspace/a6/anekrut/BRC_Pangenome_Pv_v1/hub.txt&udcTimeout=5"
       },
       {
         "accession": "GCA_949152365.1",
@@ -46,7 +46,7 @@
         "levelFilledCount": 2,
         "levelLabel": "Scaffold",
         "name": "PAM",
-        "ucscBrowserUrl": ""
+        "ucscBrowserUrl": "https://genome.ucsc.edu/cgi-bin/hgTracks?genome=GCA_949152365.1&hubUrl=https://genome.ucsc.edu/hubspace/a6/anekrut/BRC_Pangenome_Pv_v1/hub.txt&udcTimeout=5"
       },
       {
         "accession": "GCA_003402215.1",
@@ -57,7 +57,7 @@
         "levelFilledCount": 2,
         "levelLabel": "Scaffold",
         "name": "PvSY56",
-        "ucscBrowserUrl": ""
+        "ucscBrowserUrl": "https://genome.ucsc.edu/cgi-bin/hgTracks?genome=GCA_003402215.1&hubUrl=https://genome.ucsc.edu/hubspace/a6/anekrut/BRC_Pangenome_Pv_v1/hub.txt&udcTimeout=5"
       },
       {
         "accession": "GCA_900093545.1",
@@ -68,7 +68,7 @@
         "levelFilledCount": 2,
         "levelLabel": "Scaffold",
         "name": "PvT01",
-        "ucscBrowserUrl": ""
+        "ucscBrowserUrl": "https://genome.ucsc.edu/cgi-bin/hgTracks?genome=GCA_900093545.1&hubUrl=https://genome.ucsc.edu/hubspace/a6/anekrut/BRC_Pangenome_Pv_v1/hub.txt&udcTimeout=5"
       },
       {
         "accession": "GCA_900093535.1",
@@ -79,7 +79,7 @@
         "levelFilledCount": 2,
         "levelLabel": "Scaffold",
         "name": "PvC01",
-        "ucscBrowserUrl": ""
+        "ucscBrowserUrl": "https://genome.ucsc.edu/cgi-bin/hgTracks?genome=GCA_900093535.1&hubUrl=https://genome.ucsc.edu/hubspace/a6/anekrut/BRC_Pangenome_Pv_v1/hub.txt&udcTimeout=5"
       },
       {
         "accession": "GCA_040114635.1",
@@ -90,7 +90,7 @@
         "levelFilledCount": 3,
         "levelLabel": "Chromosome",
         "name": "MHC087",
-        "ucscBrowserUrl": ""
+        "ucscBrowserUrl": "https://genome.ucsc.edu/cgi-bin/hgTracks?genome=GCA_040114635.1&hubUrl=https://genome.ucsc.edu/hubspace/a6/anekrut/BRC_Pangenome_Pv_v1/hub.txt&udcTimeout=5"
       }
     ]
   }

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 /// <reference types="next/navigation-types/compat/navigation" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -52,7 +52,13 @@ export type AppPropsWithComponent = AppProps & {
   pageProps: PageProps;
 };
 
-setFeatureFlags(["assembly-workflows", "assistant", "hyphy", "lmls"]);
+setFeatureFlags([
+  "assembly-workflows",
+  "assistant",
+  "hyphy",
+  "lmls",
+  "pangenome",
+]);
 
 const queryClient = new QueryClient();
 

--- a/scripts/sync-api-brc-analytics.sh
+++ b/scripts/sync-api-brc-analytics.sh
@@ -9,10 +9,25 @@ mkdir -p "$API_DIR"
 
 PER_APP_JSONS=("assemblies" "organisms" "workflows" "workflow-assembly-mappings")
 
+# Optional JSONs: copied when present, skipped when absent. Pangenome data is
+# mock-backed and may not exist before its catalog build lands (#1341), so a
+# missing source must not fail the whole sync under `set -e`.
+OPTIONAL_JSONS=("pangenomes")
+
 rm -f "$API_DIR"/*.json
 
 for name in "${PER_APP_JSONS[@]}"; do
   src="$SRC_ROOT/${name}.json"
   dst="$API_DIR/${name}.json"
   cp "$src" "$dst"
+done
+
+for name in "${OPTIONAL_JSONS[@]}"; do
+  src="$SRC_ROOT/${name}.json"
+  dst="$API_DIR/${name}.json"
+  if [ -f "$src" ]; then
+    cp "$src" "$dst"
+  else
+    echo "Skipping optional ${name}.json (not found at $src)"
+  fi
 done

--- a/tests/services/workflows.loader.test.ts
+++ b/tests/services/workflows.loader.test.ts
@@ -1,6 +1,7 @@
 import { SiteConfig } from "@databiosphere/findable-ui/lib/config/entities";
 import {
   loadEntities,
+  loadPangenomes,
   loadWorkflows,
 } from "../../app/services/workflows/loader";
 import { API } from "../../app/services/workflows/routes";
@@ -129,6 +130,50 @@ describe("workflows loader", () => {
       await expect(loadWorkflows()).rejects.toThrow(
         `Failed to fetch: ${API.workflows}`
       );
+    });
+  });
+
+  describe("loadPangenomes", () => {
+    test("loads pangenomes from API and populates the store keyed by species taxonomy ID", async () => {
+      const payload = [
+        {
+          bundleId: "pv-v1",
+          members: [],
+          speciesTaxonomyId: "5855",
+          version: "2026-05",
+        },
+      ];
+
+      fetchMock.mockResolvedValue(mockFetchResponse(payload));
+
+      await loadPangenomes();
+
+      expect(fetchMock).toHaveBeenCalledWith(API.pangenomes);
+
+      const byId = getEntitiesById().get("pangenomes");
+      const byType = getEntitiesByType().get("pangenomes");
+
+      expect(byType).toEqual(payload);
+      expect(byId?.get("5855")).toEqual(payload[0]);
+    });
+
+    test("is non-fatal when the fetch fails", async () => {
+      fetchMock.mockResolvedValue(mockFetchResponse([], false));
+
+      await expect(loadPangenomes()).resolves.toBeUndefined();
+      expect(getEntitiesById().has("pangenomes")).toBe(false);
+      expect(getEntitiesByType().has("pangenomes")).toBe(false);
+    });
+
+    test("ignores a non-array 200 payload", async () => {
+      fetchMock.mockResolvedValue({
+        json: async () => ({}),
+        ok: true,
+      } as Response);
+
+      await expect(loadPangenomes()).resolves.toBeUndefined();
+      expect(getEntitiesById().has("pangenomes")).toBe(false);
+      expect(getEntitiesByType().has("pangenomes")).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary

Closes #1342.

Adds the **Pangenome** section to the organism page (`/data/organisms/{taxId}`, under Assemblies), populated from a mock `pangenomes.json` and gated behind the `pangenome` feature flag. Matches the Figma design and is a drop-in for the real catalog build (#1341) — it flows through the same entity store used for organisms/assemblies, so swapping the mock for the built file needs no UI changes.

### What's included

- **Catalog type + mock data** — `app/apis/catalog/brc-analytics-catalog/common/pangenome.ts` (`Pangenome` / `PangenomeMember`) + `catalog/output/pangenomes.json` (Plasmodium vivax v1 bundle, 8 members). UCSC browser links use the valid track-hub URL from #1337 (`genome=<accession>` per member).
- **Service wiring** — `getPangenome(speciesTaxonomyId)` threaded through routes → loader → store → entities like `getOrganism`. `loadPangenomes` is optional/non-fatal and loads in parallel with the entity load, so it can never gate or slow the data pages. `sync-api` treats `pangenomes.json` as optional (missing file skipped, not fatal).
- **Section components** — OrganismView `Main` refactored into `WorkflowsSection`, `AssembliesSection`, and `PangenomeSection` (self-gated on the flag + presence of a bundle); assembly-related props grouped under an `assembly` object.
- **Members table** — NCPI-style `columns.ts` + `viewBuilder.tsx`, with shared table cells `AssemblyCell`, `RefCell`, `LevelCell`, `SelectionTracksCell`, and `ViewCell` (links to each member's UCSC browser). Level column sorts by tier, not label.
- **Feature flag** — `pangenome` added to the `_app.tsx` allowlist.

### Follow-ups

- #1341 — real `pangenomes.json` build (replaces the mock; will also source the species-specific track copy currently marked `TODO(#1341)` in `getTrackTypes`).

## Testing

- `npx tsc --noEmit` — clean
- `npm run lint` / prettier — clean
- `npm test` — 574/574 pass
- High-effort code review run; findings addressed (level sort, parallel/optional load, tolerant sync-api, dead fields removed, import + type-import conventions).

Feature is flag-gated (`?pangenome=true`), so merging is inert for default deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1874" height="1289" alt="image" src="https://github.com/user-attachments/assets/4a2b3978-b045-43a1-a977-b139ceb1c5e0" />

<img width="1873" height="1287" alt="image" src="https://github.com/user-attachments/assets/007d2229-baf8-45db-b80e-3dc5bf76bb51" />

<img width="1876" height="1236" alt="image" src="https://github.com/user-attachments/assets/1f209cd3-e715-4948-b90a-9bd803db46cf" />

<img width="2560" height="1288" alt="image" src="https://github.com/user-attachments/assets/f3dba90e-a12e-4aed-8492-6377d064c8ea" />
