### PR TITLE
refactor: minimal-type taxonomic-level builders; drop assembly structural checks (#1428)

### DIFF
--- a/app/apis/catalog/common/entities.ts
+++ b/app/apis/catalog/common/entities.ts
@@ -12,6 +12,9 @@ export interface AssemblyContract {
   accession: string;
   annotationStatus: string | null;
   chromosomes: number | null;
+  // commonName is a BRC-only assembly field; GA2 assemblies lack it, so it is
+  // optional and consumers must default when absent.
+  commonName?: string | null;
   coverage: string | null;
   galaxyDatacacheUrl: string | null;
   gcPercent: number | null;
@@ -42,6 +45,9 @@ export interface AssemblyContract {
   taxonomicLevelKingdom: string;
   taxonomicLevelOrder: string;
   taxonomicLevelPhylum: string;
+  // taxonomicLevelRealm is a BRC-only assembly field; GA2 assemblies lack it, so
+  // it is optional and consumers must default when absent.
+  taxonomicLevelRealm?: string;
   taxonomicLevelSerotype?: string;
   taxonomicLevelSpecies: string;
   taxonomicLevelStrain: string;

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/ReferenceAssemblyStep/components/AssemblyData/components/AssemblySelector/hooks/UseTable/accessorFn.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/ReferenceAssemblyStep/components/AssemblyData/components/AssemblySelector/hooks/UseTable/accessorFn.ts
@@ -1,15 +1,13 @@
+import type { AssemblyContract } from "@/apis/catalog/common/entities";
 import { LABEL } from "@databiosphere/findable-ui/lib/apis/azul/common/entities";
-import { Assembly } from "./types";
 
 /**
  * Returns the isolate value for an assembly, or LABEL.UNSPECIFIED if not available.
  * @param assembly - Assembly to get isolate from.
  * @returns The isolate value or LABEL.UNSPECIFIED.
  */
-export function getAssemblyIsolate(assembly: Assembly): string {
-  if ("taxonomicLevelIsolate" in assembly)
-    return assembly.taxonomicLevelIsolate;
-  return LABEL.UNSPECIFIED;
+export function getAssemblyIsolate(assembly: AssemblyContract): string {
+  return assembly.taxonomicLevelIsolate ?? LABEL.UNSPECIFIED;
 }
 
 /**
@@ -17,8 +15,6 @@ export function getAssemblyIsolate(assembly: Assembly): string {
  * @param assembly - Assembly to get serotype from.
  * @returns The serotype value or LABEL.UNSPECIFIED.
  */
-export function getAssemblySerotype(assembly: Assembly): string {
-  if ("taxonomicLevelSerotype" in assembly)
-    return assembly.taxonomicLevelSerotype;
-  return LABEL.UNSPECIFIED;
+export function getAssemblySerotype(assembly: AssemblyContract): string {
+  return assembly.taxonomicLevelSerotype ?? LABEL.UNSPECIFIED;
 }

--- a/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.tsx
+++ b/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.tsx
@@ -14,10 +14,6 @@ import type {
   OrganismContract,
 } from "@/apis/catalog/common/entities";
 import { sanitizeEntityId } from "@/apis/catalog/common/utils";
-import {
-  GA2AssemblyEntity,
-  GA2OrganismEntity,
-} from "@/apis/catalog/ga2/entities";
 import { SLUGIFY_OPTIONS } from "@/common/constants";
 import { AppLink } from "@/components/common/AppLink/appLink";
 import { Chip } from "@/components/common/Chip/chip";
@@ -726,17 +722,6 @@ export const buildPriorityPathogenResources = (
   };
 };
 
-// Union consumed by the buildTaxonomicLevel* cell builders below, which run on
-// both organisms and assemblies across both sites. Splitting these into
-// per-contract variants is deferred — the taxonomic-level fields live on the
-// organism *entity* but not on the assembly-derived organism projection, so it
-// needs the entity-vs-projection contract separation (tracked in #1428).
-type TaxonomicGroupEntity =
-  | BRCDataCatalogOrganism
-  | BRCDataCatalogGenome
-  | GA2AssemblyEntity
-  | GA2OrganismEntity;
-
 /**
  * Build props for the taxonomic group cell of an assembly.
  * @param entity - Assembly with a taxonomicGroup property.
@@ -767,12 +752,13 @@ export const buildOrganismTaxonomicGroup = (
 
 /**
  * Build props for the class cell.
- * @param entity - Organism or genome entity.
+ * @param entity - Entity with a taxonomicLevelClass property.
+ * @param entity.taxonomicLevelClass - Taxonomic class.
  * @returns Props to be used for the cell.
  */
-export const buildTaxonomicLevelClass = (
-  entity: TaxonomicGroupEntity
-): ComponentProps<typeof BasicCell> => {
+export const buildTaxonomicLevelClass = (entity: {
+  taxonomicLevelClass: string;
+}): ComponentProps<typeof BasicCell> => {
   return {
     value: entity.taxonomicLevelClass,
   };
@@ -780,12 +766,13 @@ export const buildTaxonomicLevelClass = (
 
 /**
  * Build props for the domain cell.
- * @param entity - Organism or genome entity.
+ * @param entity - Entity with a taxonomicLevelDomain property.
+ * @param entity.taxonomicLevelDomain - Taxonomic domain.
  * @returns Props to be used for the cell.
  */
-export const buildTaxonomicLevelDomain = (
-  entity: TaxonomicGroupEntity
-): ComponentProps<typeof BasicCell> => {
+export const buildTaxonomicLevelDomain = (entity: {
+  taxonomicLevelDomain: string;
+}): ComponentProps<typeof BasicCell> => {
   return {
     value: entity.taxonomicLevelDomain,
   };
@@ -793,12 +780,13 @@ export const buildTaxonomicLevelDomain = (
 
 /**
  * Build props for the family cell.
- * @param entity - Organism or genome entity.
+ * @param entity - Entity with a taxonomicLevelFamily property.
+ * @param entity.taxonomicLevelFamily - Taxonomic family.
  * @returns Props to be used for the cell.
  */
-export const buildTaxonomicLevelFamily = (
-  entity: TaxonomicGroupEntity
-): ComponentProps<typeof BasicCell> => {
+export const buildTaxonomicLevelFamily = (entity: {
+  taxonomicLevelFamily: string;
+}): ComponentProps<typeof BasicCell> => {
   return {
     value: entity.taxonomicLevelFamily,
   };
@@ -806,12 +794,13 @@ export const buildTaxonomicLevelFamily = (
 
 /**
  * Build props for the genus cell.
- * @param entity - Organism or genome entity.
+ * @param entity - Entity with a taxonomicLevelGenus property.
+ * @param entity.taxonomicLevelGenus - Taxonomic genus.
  * @returns Props to be used for the cell.
  */
-export const buildTaxonomicLevelGenus = (
-  entity: TaxonomicGroupEntity
-): ComponentProps<typeof BasicCell> => {
+export const buildTaxonomicLevelGenus = (entity: {
+  taxonomicLevelGenus: string;
+}): ComponentProps<typeof BasicCell> => {
   return {
     value: entity.taxonomicLevelGenus,
   };
@@ -819,12 +808,13 @@ export const buildTaxonomicLevelGenus = (
 
 /**
  * Build props for the kingdom cell.
- * @param entity - Organism or genome entity.
+ * @param entity - Entity with a taxonomicLevelKingdom property.
+ * @param entity.taxonomicLevelKingdom - Taxonomic kingdom.
  * @returns Props to be used for the cell.
  */
-export const buildTaxonomicLevelKingdom = (
-  entity: TaxonomicGroupEntity
-): ComponentProps<typeof BasicCell> => {
+export const buildTaxonomicLevelKingdom = (entity: {
+  taxonomicLevelKingdom: string;
+}): ComponentProps<typeof BasicCell> => {
   return {
     value: entity.taxonomicLevelKingdom,
   };
@@ -832,12 +822,13 @@ export const buildTaxonomicLevelKingdom = (
 
 /**
  * Build props for the order cell.
- * @param entity - Organism or genome entity.
+ * @param entity - Entity with a taxonomicLevelOrder property.
+ * @param entity.taxonomicLevelOrder - Taxonomic order.
  * @returns Props to be used for the cell.
  */
-export const buildTaxonomicLevelOrder = (
-  entity: TaxonomicGroupEntity
-): ComponentProps<typeof BasicCell> => {
+export const buildTaxonomicLevelOrder = (entity: {
+  taxonomicLevelOrder: string;
+}): ComponentProps<typeof BasicCell> => {
   return {
     value: entity.taxonomicLevelOrder,
   };
@@ -845,12 +836,13 @@ export const buildTaxonomicLevelOrder = (
 
 /**
  * Build props for the phylum cell.
- * @param entity - Organism or genome entity.
+ * @param entity - Entity with a taxonomicLevelPhylum property.
+ * @param entity.taxonomicLevelPhylum - Taxonomic phylum.
  * @returns Props to be used for the cell.
  */
-export const buildTaxonomicLevelPhylum = (
-  entity: TaxonomicGroupEntity
-): ComponentProps<typeof BasicCell> => {
+export const buildTaxonomicLevelPhylum = (entity: {
+  taxonomicLevelPhylum: string;
+}): ComponentProps<typeof BasicCell> => {
   return {
     value: entity.taxonomicLevelPhylum,
   };
@@ -858,12 +850,13 @@ export const buildTaxonomicLevelPhylum = (
 
 /**
  * Build props for the realm cell.
- * @param entity - Organism or genome entity.
+ * @param entity - Entity with a taxonomicLevelRealm property.
+ * @param entity.taxonomicLevelRealm - Taxonomic realm.
  * @returns Props to be used for the cell.
  */
-export const buildTaxonomicLevelRealm = (
-  entity: BRCDataCatalogOrganism | BRCDataCatalogGenome
-): ComponentProps<typeof BasicCell> => {
+export const buildTaxonomicLevelRealm = (entity: {
+  taxonomicLevelRealm: string;
+}): ComponentProps<typeof BasicCell> => {
   return {
     value: entity.taxonomicLevelRealm,
   };

--- a/app/views/WorkflowsView/utils.ts
+++ b/app/views/WorkflowsView/utils.ts
@@ -3,13 +3,13 @@ import type {
   WorkflowCategory,
 } from "@/apis/catalog/brc-analytics-catalog/common/entities";
 import { workflowMeetsAssemblyMinimum } from "@/apis/catalog/brc-analytics-catalog/common/workflowAssembly";
+import type { AssemblyContract } from "@/apis/catalog/common/entities";
 import { WorkflowCategoryId } from "../../../catalog/schema/generated/schema";
 import { DIFFERENTIAL_EXPRESSION_ANALYSIS } from "../AnalyzeWorkflowsView/differentialExpressionAnalysis/constants";
 import { LEXICMAP } from "../AnalyzeWorkflowsView/lexicmap/constants";
 import { LOGAN_SEARCH } from "../AnalyzeWorkflowsView/loganSearch/constants";
-import { Assembly } from "../WorkflowInputsView/types";
-import type { WorkflowAssembly, WorkflowEntity } from "./types";
-import { Organism } from "./types";
+import type { Assembly } from "../WorkflowInputsView/types";
+import type { Organism, WorkflowAssembly, WorkflowEntity } from "./types";
 
 /**
  * Finds the first assembly matching the given taxonomy ID from a pre-built index.
@@ -32,12 +32,11 @@ function findAssemblyByTaxonomyId(
  * @param assembly - Assembly.
  * @returns The common name, "null", or "Any".
  */
-function getCommonName(assembly: Assembly | undefined): string {
-  if (hasCommonName(assembly)) {
-    return assembly.commonName ?? "null";
-  }
-
-  return "Any";
+function getCommonName(assembly: AssemblyContract | undefined): string {
+  // A missing commonName field (GA2 assemblies) reads as "Any"; a present-but-
+  // null commonName (BRC) reads as the string "null".
+  if (!assembly || assembly.commonName === undefined) return "Any";
+  return assembly.commonName ?? "null";
 }
 
 /**
@@ -46,11 +45,10 @@ function getCommonName(assembly: Assembly | undefined): string {
  * @param assembly - Assembly.
  * @returns The taxonomic level realm, or "Any".
  */
-function getTaxonomicLevelRealm(assembly: Assembly | undefined): string {
-  if (assembly && "taxonomicLevelRealm" in assembly)
-    return assembly.taxonomicLevelRealm;
-
-  return "Any";
+function getTaxonomicLevelRealm(
+  assembly: AssemblyContract | undefined
+): string {
+  return assembly?.taxonomicLevelRealm ?? "Any";
 }
 
 /**
@@ -164,17 +162,6 @@ export function getWorkflows(
   }
 
   return workflows;
-}
-
-/**
- * Type guard to check if an assembly has a commonName property.
- * @param assembly - The assembly to check.
- * @returns True if the assembly has a commonName property; false otherwise.
- */
-function hasCommonName(
-  assembly: Assembly | undefined
-): assembly is Assembly & { commonName: string | null } {
-  return assembly !== undefined && "commonName" in assembly;
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #1428 (2c-ii). Finishes the structural-typing removal from the shared view builders; the entity-vs-projection design "knot" is dissolved by minimal per-field typing rather than a contract split (see below).

### Bucket 2 — taxonomic-level builders (design → mechanical)
Instead of splitting `OrganismContract` into entity/projection, each `buildTaxonomicLevel*` builder is typed by the **single field it reads** — the honest minimal contract, since these builders genuinely run on both organisms *and* assemblies:
```ts
export const buildTaxonomicLevelClass = (
  entity: { taxonomicLevelClass: string }
): ComponentProps<typeof BasicCell> => ({ value: entity.taxonomicLevelClass });
```
- All 8 builders (`Class/Domain/Family/Genus/Kingdom/Order/Phylum` + `Realm`) retyped.
- **Deleted the 4-way `TaxonomicGroupEntity` union** (`BRC organism | BRC genome | GA2 assembly | GA2 organism`) — the actual cross-site leak.
- `OrganismContract` is unchanged; no entity-vs-projection split needed (this was the only entangled consumer).

### Bucket 1 — remove `"x" in assembly` structural site-detection
Typed the detector functions to `AssemblyContract` with optional-field access:
- `getAssemblyIsolate` / `getAssemblySerotype` (`accessorFn.ts`) → `assembly.taxonomicLevelIsolate ?? …`
- `getTaxonomicLevelRealm` / `getCommonName` (`WorkflowsView/utils.ts`) → optional access; removed the `hasCommonName` guard.
- Added `taxonomicLevelRealm?` and `commonName?` to `AssemblyContract` (both BRC-only).
- `AssemblyContract`/`Assembly`/`Organism` imports switched to `import type`.

### Deferred (Bucket 3 — tracked on #1417/#1418, no change here)
- The shared `Assembly = BRCDataCatalogGenome | GA2AssemblyEntity` union is **retained** — it feeds `side.tsx`'s `"image" in assembly` dispatch to `GA2Side`/`BRCSide`, which resolves via **per-site Side composition** in the component split (#1418), not via contracts. Swapping the union is coupled to that; forcing it now would break the dispatch.
- Page-level `BRCCatalog | GA2Catalog` → per-site `pages/` split (#1417).

## Testing
- `npx tsc --noEmit`, lint, prettier — clean
- `npm test` — 577 pass
- `npm run build:local` (BRC) + `npm run build-local:ga2` (GA2) — both succeed
- No `"x" in assembly` remains in `accessorFn` / `WorkflowsView` (only `side.tsx`, Bucket 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
