### PR TITLE
fix: small fixes and optimizations to `build.py` (#1436)

### DIFF
--- a/catalog/py_package/catalog_build/build.py
+++ b/catalog/py_package/catalog_build/build.py
@@ -1635,7 +1635,7 @@ def build_files(
                     rank = outbreak_taxon_rank_map.get(str(tax_id), "").lower()
                     if rank not in taxonomic_levels_for_tree:
                         # Use the taxon name instead of the raw ID
-                        taxa.append(outbreak_taxon_name_map[str(tax_id)])
+                        taxa.append(outbreak_taxon_name_map.get(str(tax_id), ""))
             # Convert list to comma-separated string for build-assemblies.ts
             return ",".join(taxa) if taxa else None
 

--- a/catalog/py_package/catalog_build/build.py
+++ b/catalog/py_package/catalog_build/build.py
@@ -1627,12 +1627,15 @@ def build_files(
             zip(outbreak_taxon_id_strings, outbreak_taxonomy_df["rank"])
         )
 
+        # Set for O(1) membership tests in the per-row loop below
+        outbreak_taxonomy_id_set = set(outbreak_taxonomy_ids)
+
         # For each row, check if any lineage taxonomy ID is in the outbreak taxonomy IDs
         # and add the corresponding taxon name to otherTaxa only if its rank is not in taxonomic_levels_for_tree
         def get_other_taxa(lineage_ids):
             taxa = []
             for tax_id in lineage_ids:
-                if tax_id in outbreak_taxonomy_ids:
+                if tax_id in outbreak_taxonomy_id_set:
                     # Check if this taxon's rank is already covered by taxonomic_levels_for_tree
                     rank = outbreak_taxon_rank_map.get(str(tax_id), "").lower()
                     if rank not in taxonomic_levels_for_tree:

--- a/catalog/py_package/catalog_build/build.py
+++ b/catalog/py_package/catalog_build/build.py
@@ -563,8 +563,7 @@ def add_gene_model_url(genomes_df: pd.DataFrame):
 def report_missing_values_from(
     values_name, message_predicate, all_values_series, *partial_values_series
 ):
-    present_values_mask = all_values_series.astype(bool)
-    present_values_mask[:] = False
+    present_values_mask = pd.Series(False, index=all_values_series.index)
     for series in partial_values_series:
         present_values_mask |= all_values_series.isin(series)
     return report_missing_values(

--- a/catalog/py_package/catalog_build/build.py
+++ b/catalog/py_package/catalog_build/build.py
@@ -1644,9 +1644,13 @@ def build_files(
                 if tax_id in outbreak_taxonomy_id_set:
                     # Check if this taxon's rank is already covered by taxonomic_levels_for_tree
                     rank = outbreak_taxon_rank_map.get(str(tax_id), "").lower()
-                    if rank not in taxonomic_levels_for_tree:
-                        # Use the taxon name instead of the raw ID
-                        taxa.append(outbreak_taxon_name_map.get(str(tax_id), ""))
+                    tax_id_str = str(tax_id)
+                    if (
+                        rank not in taxonomic_levels_for_tree
+                        and tax_id_str in outbreak_taxon_name_map
+                    ):
+                        # Add the taxon name (note: not the raw ID) if available
+                        taxa.append(outbreak_taxon_name_map[tax_id_str])
             # Convert list to comma-separated string for build-assemblies.ts
             return ",".join(taxa) if taxa else None
 

--- a/catalog/py_package/catalog_build/build.py
+++ b/catalog/py_package/catalog_build/build.py
@@ -1303,13 +1303,15 @@ def get_outbreak_taxonomy_ids(
                 if get_primary
                 else ()
             ),
-            # Add any highlight descendant taxonomy IDs
+            # Add any highlight descendant taxonomy IDs. This field is
+            # optional per outbreak, so the column may be absent entirely.
             *(
                 source_outbreaks_df["highlight_descendant_taxonomy_ids"]
                 .explode()
                 .dropna()
                 .astype("string")
                 if get_descendants
+                and "highlight_descendant_taxonomy_ids" in source_outbreaks_df.columns
                 else ()
             ),
         }

--- a/catalog/py_package/catalog_build/build.py
+++ b/catalog/py_package/catalog_build/build.py
@@ -1279,6 +1279,22 @@ def make_qc_report(
     return join_report(lines)
 
 
+def build_taxon_maps(taxonomy_df):
+    """
+    Build lookups from taxonomy ID (as string) to taxon name and rank.
+
+    Args:
+        taxonomy_df: DataFrame with taxonomy_id, taxon_name and rank columns
+
+    Returns:
+        Tuple of (name_map, rank_map) dicts keyed by taxonomy ID string
+    """
+    taxon_id_strings = taxonomy_df["taxonomy_id"].astype("string")
+    name_map = dict(zip(taxon_id_strings, taxonomy_df["taxon_name"]))
+    rank_map = dict(zip(taxon_id_strings, taxonomy_df["rank"]))
+    return name_map, rank_map
+
+
 def get_outbreak_taxonomy_ids(
     source_outbreaks_df, get_primary=True, get_descendants=False
 ):
@@ -1613,12 +1629,8 @@ def build_files(
     # Add otherTaxa field with outbreak-associated taxa names
     if outbreak_taxonomy_ids:
         # Get taxon names and ranks for outbreak taxonomy IDs
-        outbreak_taxon_id_strings = outbreak_taxonomy_df["taxonomy_id"].astype("string")
-        outbreak_taxon_name_map = dict(
-            zip(outbreak_taxon_id_strings, outbreak_taxonomy_df["taxon_name"])
-        )
-        outbreak_taxon_rank_map = dict(
-            zip(outbreak_taxon_id_strings, outbreak_taxonomy_df["rank"])
+        outbreak_taxon_name_map, outbreak_taxon_rank_map = build_taxon_maps(
+            outbreak_taxonomy_df
         )
 
         # Set for O(1) membership tests in the per-row loop below
@@ -1845,12 +1857,8 @@ def build_files(
     )
     print(f"Checked ploidy for {len(genomes_df)} assemblies")
 
-    organism_taxonomy_id_strings = organism_taxonomy_df["taxonomy_id"].astype("string")
-    organism_taxon_name_map = dict(
-        zip(organism_taxonomy_id_strings, organism_taxonomy_df["taxon_name"])
-    )
-    organism_taxon_rank_map = dict(
-        zip(organism_taxonomy_id_strings, organism_taxonomy_df["rank"])
+    organism_taxon_name_map, organism_taxon_rank_map = build_taxon_maps(
+        organism_taxonomy_df
     )
     qc_report_params["organisms_not_species_rank"] = check_organism_ranks(
         source_organisms_df["taxonomy_id"].tolist(),

--- a/catalog/py_package/catalog_build/build.py
+++ b/catalog/py_package/catalog_build/build.py
@@ -1613,11 +1613,6 @@ def build_files(
     print(f"Found {len(outbreak_taxonomy_ids)} outbreak taxonomy IDs")
     # Add otherTaxa field with outbreak-associated taxa names
     if outbreak_taxonomy_ids:
-        # Convert lineageTaxonomyIds from comma-separated string to list of strings
-        species_df["lineageTaxonomyIdsList"] = species_df["lineageTaxonomyIds"].apply(
-            lambda x: [id for id in x.split(",")]
-        )
-
         # Get taxon names and ranks for outbreak taxonomy IDs
         outbreak_taxon_id_strings = outbreak_taxonomy_df["taxonomy_id"].astype("string")
         outbreak_taxon_name_map = dict(
@@ -1632,9 +1627,9 @@ def build_files(
 
         # For each row, check if any lineage taxonomy ID is in the outbreak taxonomy IDs
         # and add the corresponding taxon name to otherTaxa only if its rank is not in taxonomic_levels_for_tree
-        def get_other_taxa(lineage_ids):
+        def get_other_taxa(lineage_taxonomy_ids):
             taxa = []
-            for tax_id in lineage_ids:
+            for tax_id in lineage_taxonomy_ids.split(","):
                 if tax_id in outbreak_taxonomy_id_set:
                     # Check if this taxon's rank is already covered by taxonomic_levels_for_tree
                     rank = outbreak_taxon_rank_map.get(str(tax_id), "").lower()
@@ -1644,12 +1639,7 @@ def build_files(
             # Convert list to comma-separated string for build-assemblies.ts
             return ",".join(taxa) if taxa else None
 
-        species_df["otherTaxa"] = species_df["lineageTaxonomyIdsList"].apply(
-            get_other_taxa
-        )
-
-        # Drop the temporary column
-        species_df = species_df.drop(columns=["lineageTaxonomyIdsList"])
+        species_df["otherTaxa"] = species_df["lineageTaxonomyIds"].apply(get_other_taxa)
 
         all_lineage_ids = {
             id_str


### PR DESCRIPTION
## Description

Several small fixes and optimizations to `build.py`:
- When deriving `otherTaxa` for assemblies from outbreaks, don't assume that name information exists for any taxonomy ID; a taxonomy ID may be absent from the taxon name map if information about the taxon is not available from NCBI
  - Contrary to the ticket, I've handled this by omitting the taxon from `otherTaxa` entirely -- including empty strings in the list seems unhelpful, and anything more defensive would require broader changes. As I have it, a missing name for an unranked taxon would make it so that an outbreak for that taxon couldn't link to related assemblies; however, if something *was* missing, we would at least be able to notice based on the QC report and address it
- Don't assume that a `highlight_descendant_taxonomy_ids` column exists in the source outbreaks dataframe, since it's an optional field and so theoretically could be absent from the entire YAML file, in which case no column would be created for it
- Use a set to identify outbreak taxonomy IDs when deriving `otherTaxa`, rather than testing for membership in the outbreak taxonomy IDs list
- When deriving `otherTaxa`, split each assembly's lineage taxonomy IDs string inline in `get_other_taxa` rather than creating a temporary column containing the lineages as lists, since `get_other_taxa` is only called once per row (and thus per lineage string) anyway
- When reporting missing values, initialize the present values mask as all-false using the `Series` constructor rather than by copying an existing column and filling it with `False`
- Factor out duplicate code for creating taxon name and rank maps from dataframes

## Related Issue

Closes #1436
