### PR TITLE
perf: memoize seeddatabase to avoid re-parsing catalog per page (#1470)

### DIFF
--- a/app/utils/seedDatabase.ts
+++ b/app/utils/seedDatabase.ts
@@ -1,14 +1,23 @@
-import { EntityConfig } from "@databiosphere/findable-ui/lib/config/entities";
+import type { EntityConfig } from "@databiosphere/findable-ui/lib/config/entities";
 import { database } from "@databiosphere/findable-ui/lib/utils/database";
 import fsp from "fs/promises";
 
+// The catalog files are immutable for the lifetime of a build (generated before
+// the static export) and findable-ui's `database` is a module-level singleton,
+// so re-reading and re-seeding is pure waste. getStaticProps calls seedDatabase
+// once per page — thousands of detail pages, rendered in parallel — so memoize
+// the in-flight seed promise per entity type: every call after the first shares
+// the single read/parse/seed instead of re-parsing the multi-MB catalog (or
+// racing it).
+const seedPromises = new Map<string, Promise<void>>();
+
 /**
- * Seed database.
+ * Read the configured catalog JSON and seed the database for an entity type.
  * @param entityListType - Entity list type.
  * @param entityConfig - Entity config.
  * @returns Promise<void>.
  */
-export const seedDatabase = async function seedDatabase(
+async function doSeedDatabase(
   entityListType: string,
   entityConfig: EntityConfig
 ): Promise<void> {
@@ -33,4 +42,29 @@ export const seedDatabase = async function seedDatabase(
 
   // Seed entities.
   database.get().seed(entityListType, entities);
-};
+}
+
+/**
+ * Seed database, memoized per entity type for the lifetime of the process.
+ * @param entityListType - Entity list type.
+ * @param entityConfig - Entity config.
+ * @returns Promise<void>.
+ */
+export function seedDatabase(
+  entityListType: string,
+  entityConfig: EntityConfig
+): Promise<void> {
+  let seedPromise = seedPromises.get(entityListType);
+  if (!seedPromise) {
+    // Don't cache a failed read — evict on rejection, but re-throw so awaiters
+    // (and unhandled-rejection tracking) still see the failure.
+    seedPromise = doSeedDatabase(entityListType, entityConfig).catch(
+      (error: unknown) => {
+        seedPromises.delete(entityListType);
+        throw error;
+      }
+    );
+    seedPromises.set(entityListType, seedPromise);
+  }
+  return seedPromise;
+}

--- a/tests/utils/seedDatabase.test.ts
+++ b/tests/utils/seedDatabase.test.ts
@@ -1,0 +1,60 @@
+import { seedDatabase } from "@/utils/seedDatabase";
+import type { EntityConfig } from "@databiosphere/findable-ui/lib/config/entities";
+import { database } from "@databiosphere/findable-ui/lib/utils/database";
+import fsp from "fs/promises";
+
+const seed = jest.fn();
+
+const config = (staticLoadFile: string): EntityConfig =>
+  ({ label: staticLoadFile, staticLoadFile }) as unknown as EntityConfig;
+
+// seedDatabase's cache is module-level and persists for the file's lifetime, so
+// each test uses a unique entityListType key to stay isolated.
+describe("seedDatabase", () => {
+  let readFile: jest.Mock;
+
+  beforeEach(() => {
+    seed.mockReset();
+    jest
+      .spyOn(database, "get")
+      .mockReturnValue({ seed } as unknown as ReturnType<typeof database.get>);
+    readFile = jest.spyOn(fsp, "readFile") as unknown as jest.Mock;
+    readFile.mockResolvedValue('{"a":{"id":1}}');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("reads and seeds once across repeated calls for the same entity type", async () => {
+    for (let i = 0; i < 5; i++) {
+      await seedDatabase("repeat", config("repeat.json"));
+    }
+    expect(readFile).toHaveBeenCalledTimes(1);
+    expect(seed).toHaveBeenCalledTimes(1);
+  });
+
+  test("reads once per entity type", async () => {
+    await seedDatabase("typeA", config("typeA.json"));
+    await seedDatabase("typeB", config("typeB.json"));
+    await seedDatabase("typeA", config("typeA.json"));
+    expect(readFile).toHaveBeenCalledTimes(2);
+  });
+
+  test("shares a single read across a concurrent burst", async () => {
+    await Promise.all(
+      Array.from({ length: 10 }, () =>
+        seedDatabase("burst", config("burst.json"))
+      )
+    );
+    expect(readFile).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not cache a failed read; a later call retries", async () => {
+    readFile.mockRejectedValueOnce(new Error("boom"));
+    await expect(seedDatabase("retry", config("retry.json"))).rejects.toThrow();
+    await seedDatabase("retry", config("retry.json"));
+    expect(readFile).toHaveBeenCalledTimes(2);
+    expect(seed).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Closes #1470

## Summary
`seedDatabase` read, `JSON.parse`d, and re-seeded the entire catalog file on **every** call — once per page in `getStaticProps` — so the static export re-parsed the multi-MB catalog thousands of times (assemblies 9 MB × 5,499 pages; organisms 12 MB × 1,970 pages ≈ **172 s** of pure re-parse).

This memoizes the **in-flight seed promise per entity type** in a module-level `Map`, so every call after the first shares one read/parse/seed instead of racing it. findable-ui's `database` is a module-level singleton and the catalog files are immutable for the build's lifetime, so re-seeding was pure waste.

- `doSeedDatabase` = the original read/parse/map/seed body.
- `seedDatabase` = the memoized wrapper.
- A failed read is **not** cached (evicted via `.catch`), so a transient failure doesn't poison every page of that type.

## Tests
`tests/utils/seedDatabase.test.ts` — memoizes once per type, one read per type, single read across a concurrent burst, and retry-after-failure (no cached rejection).

## Verification
tsc clean · jest 581/581 · no build-script changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)