### PR TITLE
refactor: stop inlining the full catalog into the assemblies and organisms explore pages (#1472)

### DIFF
--- a/app/views/EntitiesView/entitiesView.tsx
+++ b/app/views/EntitiesView/entitiesView.tsx
@@ -1,4 +1,3 @@
-import { EntityDataGate } from "@/components/EntityDataGate/entityDataGate";
 import { StyledExploreView } from "@/views/ExploreView/exploreView.styles";
 import { JSX } from "react";
 import type { Props } from "./types";
@@ -6,23 +5,22 @@ import { getEntitiesResponse } from "./utils";
 
 /**
  * Renders the explore table for an entity list type, sourcing its rows from the
- * client-loaded entity store rather than inlined static props. Gated on the
- * store being loaded so the table mounts with populated data.
+ * client-loaded entity store rather than inlined static props. Expects the store
+ * to be loaded — the page gates rendering on it — so the response is built only
+ * at runtime, never during static prerender.
  * @param props - Props.
  * @param props.entityListType - Entity list type.
- * @returns explore view, gated on the entity store being loaded.
+ * @returns explore view.
  */
 export const EntitiesView = ({
   entityListType,
   ...props
 }: Props): JSX.Element => {
   return (
-    <EntityDataGate>
-      <StyledExploreView
-        entityListType={entityListType}
-        data={getEntitiesResponse(entityListType)}
-        {...props}
-      />
-    </EntityDataGate>
+    <StyledExploreView
+      entityListType={entityListType}
+      data={getEntitiesResponse(entityListType)}
+      {...props}
+    />
   );
 };

--- a/app/views/EntitiesView/entitiesView.tsx
+++ b/app/views/EntitiesView/entitiesView.tsx
@@ -1,0 +1,28 @@
+import { EntityDataGate } from "@/components/EntityDataGate/entityDataGate";
+import { StyledExploreView } from "@/views/ExploreView/exploreView.styles";
+import { JSX } from "react";
+import type { Props } from "./types";
+import { getEntitiesResponse } from "./utils";
+
+/**
+ * Renders the explore table for an entity list type, sourcing its rows from the
+ * client-loaded entity store rather than inlined static props. Gated on the
+ * store being loaded so the table mounts with populated data.
+ * @param props - Props.
+ * @param props.entityListType - Entity list type.
+ * @returns explore view, gated on the entity store being loaded.
+ */
+export const EntitiesView = ({
+  entityListType,
+  ...props
+}: Props): JSX.Element => {
+  return (
+    <EntityDataGate>
+      <StyledExploreView
+        entityListType={entityListType}
+        data={getEntitiesResponse(entityListType)}
+        {...props}
+      />
+    </EntityDataGate>
+  );
+};

--- a/app/views/EntitiesView/types.ts
+++ b/app/views/EntitiesView/types.ts
@@ -1,0 +1,5 @@
+export interface Props {
+  entityListType: string;
+  pageDescription?: string;
+  pageTitle?: string;
+}

--- a/app/views/EntitiesView/utils.ts
+++ b/app/views/EntitiesView/utils.ts
@@ -1,17 +1,19 @@
 import type { EntitiesResponse } from "@/apis/catalog/brc-analytics-catalog/common/entities";
-import { getEntitiesByType } from "@/services/workflows/store";
+import { getEntities } from "@/services/workflows/query";
 import type { EntityRoute } from "@/services/workflows/types";
 
 /**
  * Build an explore-view data response from the client-loaded entity store.
+ * Throws (via getEntities) when the store has no entry for the requested type,
+ * so a misconfigured or unloaded route surfaces through the error boundary
+ * instead of silently rendering an empty table.
  * @param entityListType - Entity list type.
  * @returns entities response consumed by the explore view.
  */
 export function getEntitiesResponse<T>(
   entityListType: string
 ): EntitiesResponse<T> {
-  const hits = (getEntitiesByType().get(entityListType as EntityRoute) ??
-    []) as T[];
+  const hits = getEntities<T>(entityListType as EntityRoute);
   return {
     hits,
     pagination: {

--- a/app/views/EntitiesView/utils.ts
+++ b/app/views/EntitiesView/utils.ts
@@ -1,0 +1,25 @@
+import type { EntitiesResponse } from "@/apis/catalog/brc-analytics-catalog/common/entities";
+import { getEntitiesByType } from "@/services/workflows/store";
+import type { EntityRoute } from "@/services/workflows/types";
+
+/**
+ * Build an explore-view data response from the client-loaded entity store.
+ * @param entityListType - Entity list type.
+ * @returns entities response consumed by the explore view.
+ */
+export function getEntitiesResponse<T>(
+  entityListType: string
+): EntitiesResponse<T> {
+  const hits = (getEntitiesByType().get(entityListType as EntityRoute) ??
+    []) as T[];
+  return {
+    hits,
+    pagination: {
+      count: hits.length,
+      pages: 1,
+      size: hits.length,
+      total: hits.length,
+    },
+    termFacets: {},
+  };
+}

--- a/app/views/EntitiesView/utils.ts
+++ b/app/views/EntitiesView/utils.ts
@@ -4,23 +4,24 @@ import type { EntityRoute } from "@/services/workflows/types";
 
 /**
  * Build an explore-view data response from the client-loaded entity store.
- * Throws (via getEntities) when the store has no entry for the requested type,
- * so a misconfigured or unloaded route surfaces through the error boundary
- * instead of silently rendering an empty table.
+ * Throws (via getEntities) for an unknown entity list type, so a misconfigured
+ * route surfaces through the error boundary instead of silently rendering an
+ * empty table. Returns a shallow copy of the store's array so downstream
+ * in-place operations (e.g. sorting) can't mutate the shared store.
  * @param entityListType - Entity list type.
  * @returns entities response consumed by the explore view.
  */
 export function getEntitiesResponse<T>(
   entityListType: string
 ): EntitiesResponse<T> {
-  const hits = getEntities<T>(entityListType as EntityRoute);
+  const entities = getEntities<T>(entityListType as EntityRoute);
   return {
-    hits,
+    hits: [...entities],
     pagination: {
-      count: hits.length,
+      count: entities.length,
       pages: 1,
-      size: hits.length,
-      total: hits.length,
+      size: entities.length,
+      total: entities.length,
     },
     termFacets: {},
   };

--- a/pages/data/[entityListType]/index.tsx
+++ b/pages/data/[entityListType]/index.tsx
@@ -1,58 +1,26 @@
-import {
-  BRCCatalog,
-  EntitiesResponse,
-  Outbreak,
-} from "@/apis/catalog/brc-analytics-catalog/common/entities";
-import { GA2Catalog } from "@/apis/catalog/ga2/entities";
 import { getEntityListMeta } from "@/common/meta/utils";
 import { config } from "@/config/config";
-import { seedDatabase } from "@/utils/seedDatabase";
-import { StyledExploreView } from "@/views/ExploreView/exploreView.styles";
-import { PriorityPathogensView } from "@/views/PriorityPathogensView/priorityPathogensView";
+import { EntitiesView } from "@/views/EntitiesView/entitiesView";
+import type { Props as EntitiesPageProps } from "@/views/EntitiesView/types";
 import { Main as DXMain } from "@databiosphere/findable-ui/lib/components/Layout/components/Main/main.styles";
-import { getEntityConfig } from "@databiosphere/findable-ui/lib/config/utils";
-import { getEntityService } from "@databiosphere/findable-ui/lib/hooks/useEntityService";
-import { EXPLORE_MODE } from "@databiosphere/findable-ui/lib/hooks/useExploreMode/types";
 import { GetStaticPaths, GetStaticProps, GetStaticPropsContext } from "next";
 import { ParsedUrlQuery } from "querystring";
 import { JSX } from "react";
 
-interface PageUrl extends ParsedUrlQuery {
+interface Params extends ParsedUrlQuery {
   entityListType: string;
-}
-
-interface EntitiesPageProps<R> {
-  data?: EntitiesResponse<R>;
-  entityListType: string;
-  pageDescription?: string;
-  pageTitle?: string;
 }
 
 /**
- * Explore view page.
- * @param props - Explore view page props.
+ * Explore view page for client-side loaded entity lists (assemblies, organisms).
+ * @param props - Page props.
  * @param props.entityListType - Entity list type.
- * @returns ExploreView component.
+ * @returns EntitiesView component.
  */
-const IndexPage = <R,>({
-  entityListType,
-  ...props
-}: EntitiesPageProps<R>): JSX.Element => {
+const Page = ({ entityListType, ...props }: EntitiesPageProps): JSX.Element => {
   if (!entityListType) return <></>;
 
-  // Return the PriorityPathogensView component for the priority pathogens route.
-  if (entityListType === "priority-pathogens") {
-    // Throw an error if no priority pathogen data is provided.
-    if (!props.data) throw new Error("No priority pathogen data provided");
-
-    // Return the PriorityPathogensView component.
-    return (
-      <PriorityPathogensView data={props.data as EntitiesResponse<Outbreak>} />
-    );
-  }
-
-  // Return the ExploreView component for all other routes.
-  return <StyledExploreView entityListType={entityListType} {...props} />;
+  return <EntitiesView entityListType={entityListType} {...props} />;
 };
 
 /**
@@ -63,7 +31,11 @@ export const getStaticPaths: GetStaticPaths = async () => {
   const appConfig = config();
   const entities = appConfig.entities;
   const paths = entities
-    .filter((entity) => entity.route !== "workflows")
+    // Workflows has no explore list page; priority-pathogens has its own page.
+    .filter(
+      (entity) =>
+        entity.route !== "workflows" && entity.route !== "priority-pathogens"
+    )
     .map((entity) => ({
       params: {
         entityListType: entity.route,
@@ -80,40 +52,22 @@ export const getStaticPaths: GetStaticPaths = async () => {
  * @param context - Object containing values related to the current context.
  * @returns static props.
  */
-export const getStaticProps: GetStaticProps<
-  EntitiesPageProps<BRCCatalog | GA2Catalog>
-> = async (context: GetStaticPropsContext) => {
+export const getStaticProps: GetStaticProps<EntitiesPageProps> = async (
+  context: GetStaticPropsContext
+) => {
   const appConfig = config();
-  const { entityListType } = context.params as PageUrl;
-  const { entities } = appConfig;
-  const entityConfig = getEntityConfig(entities, entityListType);
-  const { exploreMode } = entityConfig;
-  const { fetchAllEntities } = getEntityService(entityConfig, undefined); // Determine the type of fetch, either from an API endpoint or a TSV.
-
+  const { entityListType } = context.params as Params;
   const entityMeta = getEntityListMeta(appConfig.appKey)[entityListType];
 
-  const props: EntitiesPageProps<BRCCatalog | GA2Catalog> = {
-    entityListType,
-    pageDescription: entityMeta?.pageDescription,
-    pageTitle: entityMeta?.pageTitle,
-  };
-
-  // Seed database.
-  if (exploreMode === EXPLORE_MODE.CS_FETCH_CS_FILTERING) {
-    await seedDatabase(entityListType, entityConfig);
-  } else {
-    // Entities are fetched server-side.
-    return { props };
-  }
-
-  // Entities are client-side fetched from a local database seeded from a configured TSV.
-  props.data = await fetchAllEntities(entityListType, undefined);
-
   return {
-    props,
+    props: {
+      entityListType,
+      pageDescription: entityMeta?.pageDescription,
+      pageTitle: entityMeta?.pageTitle,
+    },
   };
 };
 
-IndexPage.Main = DXMain;
+Page.Main = DXMain;
 
-export default IndexPage;
+export default Page;

--- a/pages/data/[entityListType]/index.tsx
+++ b/pages/data/[entityListType]/index.tsx
@@ -1,4 +1,5 @@
 import { getEntityListMeta } from "@/common/meta/utils";
+import { EntityDataGate } from "@/components/EntityDataGate/entityDataGate";
 import { config } from "@/config/config";
 import { EntitiesView } from "@/views/EntitiesView/entitiesView";
 import type { Props as EntitiesPageProps } from "@/views/EntitiesView/types";
@@ -20,7 +21,11 @@ interface Params extends ParsedUrlQuery {
 const Page = ({ entityListType, ...props }: EntitiesPageProps): JSX.Element => {
   if (!entityListType) return <></>;
 
-  return <EntitiesView entityListType={entityListType} {...props} />;
+  return (
+    <EntityDataGate>
+      <EntitiesView entityListType={entityListType} {...props} />
+    </EntityDataGate>
+  );
 };
 
 /**

--- a/pages/data/priority-pathogens/index.tsx
+++ b/pages/data/priority-pathogens/index.tsx
@@ -1,0 +1,69 @@
+import type {
+  EntitiesResponse,
+  Outbreak,
+} from "@/apis/catalog/brc-analytics-catalog/common/entities";
+import { getEntityListMeta } from "@/common/meta/utils";
+import { config } from "@/config/config";
+import { seedDatabase } from "@/utils/seedDatabase";
+import { PriorityPathogensView } from "@/views/PriorityPathogensView/priorityPathogensView";
+import { Main as DXMain } from "@databiosphere/findable-ui/lib/components/Layout/components/Main/main.styles";
+import { getEntityService } from "@databiosphere/findable-ui/lib/hooks/useEntityService";
+import { GetStaticProps } from "next";
+import { JSX } from "react";
+
+const ENTITY_LIST_TYPE = "priority-pathogens";
+
+interface PriorityPathogensPageProps {
+  data: EntitiesResponse<Outbreak>;
+  pageDescription?: string;
+  pageTitle?: string;
+}
+
+/**
+ * Priority pathogens explore page.
+ * @param props - Page props.
+ * @param props.data - Priority pathogens data.
+ * @returns PriorityPathogensView component.
+ */
+const PriorityPathogensPage = ({
+  data,
+}: PriorityPathogensPageProps): JSX.Element => {
+  return <PriorityPathogensView data={data} />;
+};
+
+/**
+ * Build the set of props for pre-rendering of page.
+ * @returns static props.
+ */
+export const getStaticProps: GetStaticProps<
+  PriorityPathogensPageProps
+> = async () => {
+  const appConfig = config();
+  const entityConfig = appConfig.entities.find(
+    ({ route }) => route === ENTITY_LIST_TYPE
+  );
+
+  // The route may be absent from a site's entity config; return notFound when it is.
+  if (!entityConfig) return { notFound: true };
+
+  const { fetchAllEntities } = getEntityService(entityConfig, undefined);
+  await seedDatabase(ENTITY_LIST_TYPE, entityConfig);
+  const data = (await fetchAllEntities(
+    ENTITY_LIST_TYPE,
+    undefined
+  )) as EntitiesResponse<Outbreak>;
+
+  const entityMeta = getEntityListMeta(appConfig.appKey)[ENTITY_LIST_TYPE];
+
+  return {
+    props: {
+      data,
+      pageDescription: entityMeta?.pageDescription,
+      pageTitle: entityMeta?.pageTitle,
+    },
+  };
+};
+
+PriorityPathogensPage.Main = DXMain;
+
+export default PriorityPathogensPage;

--- a/pages/data/priority-pathogens/index.tsx
+++ b/pages/data/priority-pathogens/index.tsx
@@ -15,6 +15,7 @@ const ENTITY_LIST_TYPE = "priority-pathogens";
 
 interface PriorityPathogensPageProps {
   data: EntitiesResponse<Outbreak>;
+  entityListType: string;
   pageDescription?: string;
   pageTitle?: string;
 }
@@ -58,6 +59,7 @@ export const getStaticProps: GetStaticProps<
   return {
     props: {
       data,
+      entityListType: ENTITY_LIST_TYPE,
       pageDescription: entityMeta?.pageDescription,
       pageTitle: entityMeta?.pageTitle,
     },


### PR DESCRIPTION
## Summary

The assemblies and organisms explore list pages inlined the full catalog into their statically-generated HTML via `getStaticProps` (~15 MB each). This change stops that:

- New `EntitiesView` sources the explore table's rows from the client-loaded entity store (`getEntitiesByType`, populated by `useEntities()` in `_app`) rather than inlined static props, gated on load via `EntityDataGate`. `getEntitiesResponse<T>` builds the response the explore view consumes.
- The `[entityListType]` list page drops `props.data` / `seedDatabase` / `fetchAllEntities` and renders `EntitiesView`. `getStaticPaths` now excludes `workflows` and `priority-pathogens`.
- Priority pathogens moves to its own static page (`data/priority-pathogens`) that keeps its page-props data (`seedDatabase` + `fetchAllEntities`), returning `notFound` when the route is absent from a site's entity config. Backing it with the store is deferred to a follow-up.

## Result

| Page | Before | After |
|---|---|---|
| `data/assemblies.html` | ~15 MB | ~40 KB |
| `data/organisms.html` | ~15 MB | ~40 KB |

## Follow-up

- #1477 — surface an error when the entity-cache fetch fails (data pages currently render blank on failure; app-wide `EntityDataGate` behaviour).
- #1479 — back the priority-pathogens explore page with the client entity store (it is still on page-props).

Closes #1472

🤖 Generated with [Claude Code](https://claude.com/claude-code)
