### PR TITLE
refactor: move applink and customicon into @repo/shared (#1468)

### DIFF
--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PrimaryContrastsStep/components/ExplicitPairs/components/PairRow/pairRow.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PrimaryContrastsStep/components/ExplicitPairs/components/PairRow/pairRow.tsx
@@ -1,7 +1,7 @@
-import { DeleteIcon } from "@/components/common/CustomIcon/components/DeleteIcon/deleteIcon";
 import { getDisabledValues } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PrimaryContrastsStep/hooks/UseExplicitContrasts/utils";
 import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
 import { IconButton, MenuItem, Stack, Typography } from "@mui/material";
+import { DeleteIcon } from "@repo/shared/components/CustomIcon/components/DeleteIcon/deleteIcon";
 import { JSX } from "react";
 import { ICON_BUTTON_PROPS, SELECT_PROPS, SVG_ICON_PROPS } from "./constants";
 import { StyledSelect, StyledStack } from "./pairRow.styles";

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SampleSheetStep/components/Dropzone/dropzone.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SampleSheetStep/components/Dropzone/dropzone.tsx
@@ -1,4 +1,3 @@
-import { FileUploadIcon } from "@/components/common/CustomIcon/components/FileUploadIcon/fileUploadIcon";
 import { StyledButtonBase } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/components/Dropzone/components/FileUploadButton/fileUploadButton.styles";
 import {
   TYPOGRAPHY_PROPS as COMPONENT_TYPOGRAPHY_PROPS,
@@ -8,6 +7,7 @@ import { Dropzone as DropzoneBase } from "@/components/Entity/components/Configu
 import { Dot } from "@databiosphere/findable-ui/lib/components/common/Dot/dot";
 import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
 import { Stack, Typography } from "@mui/material";
+import { FileUploadIcon } from "@repo/shared/components/CustomIcon/components/FileUploadIcon/fileUploadIcon";
 import { JSX } from "react";
 import { Props } from "./types";
 

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SampleSheetStep/components/UploadedFile/uploadedFile.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SampleSheetStep/components/UploadedFile/uploadedFile.tsx
@@ -1,11 +1,11 @@
-import { DeleteIcon } from "@/components/common/CustomIcon/components/DeleteIcon/deleteIcon";
-import { ScanDeleteIcon } from "@/components/common/CustomIcon/components/ScanDeleteIcon/scanDeleteIcon";
 import { ICON_BUTTON_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/iconButton";
 import { SVG_ICON_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/svgIcon";
 import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
 import { formatFileSize } from "@databiosphere/findable-ui/lib/utils/formatFileSize";
 import { FolderZipRounded } from "@mui/icons-material";
 import { IconButton, Stack, Typography } from "@mui/material";
+import { DeleteIcon } from "@repo/shared/components/CustomIcon/components/DeleteIcon/deleteIcon";
+import { ScanDeleteIcon } from "@repo/shared/components/CustomIcon/components/ScanDeleteIcon/scanDeleteIcon";
 import { JSX, ReactNode } from "react";
 import { Props } from "./types";
 import { StyledRoundedPaper } from "./uploadedFile.styles";

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequenceStep/components/Dropzone/dropzone.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequenceStep/components/Dropzone/dropzone.tsx
@@ -1,4 +1,3 @@
-import { FileUploadIcon } from "@/components/common/CustomIcon/components/FileUploadIcon/fileUploadIcon";
 import { StyledButtonBase } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/components/Dropzone/components/FileUploadButton/fileUploadButton.styles";
 import {
   TYPOGRAPHY_PROPS as COMPONENT_TYPOGRAPHY_PROPS,
@@ -8,6 +7,7 @@ import { Dropzone as DropzoneBase } from "@/components/Entity/components/Configu
 import { Dot } from "@databiosphere/findable-ui/lib/components/common/Dot/dot";
 import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
 import { Stack, Typography } from "@mui/material";
+import { FileUploadIcon } from "@repo/shared/components/CustomIcon/components/FileUploadIcon/fileUploadIcon";
 import { JSX } from "react";
 import { Props } from "./types";
 

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/UploadMyData/uploadMyData.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/UploadMyData/uploadMyData.tsx
@@ -1,7 +1,7 @@
-import { AppLink } from "@/components/common/AppLink/appLink";
 import { ALERT_PROPS } from "@databiosphere/findable-ui/lib/components/common/Alert/constants";
 import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
 import { AlertTitle, Typography } from "@mui/material";
+import { AppLink } from "@repo/shared/components/AppLink/appLink";
 import { JSX } from "react";
 import { StyledAlert } from "./uploadMyData.styles";
 

--- a/app/components/index.ts
+++ b/app/components/index.ts
@@ -14,9 +14,9 @@ export { Link } from "@databiosphere/findable-ui/lib/components/Links/components
 export { BasicCell } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/BasicCell/basicCell";
 export { ChipCell } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/ChipCell/chipCell";
 export { NTagCell } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/NTagCell/nTagCell";
+export { CalendarIcon } from "@repo/shared/components/CustomIcon/components/CalendarIcon/calendarIcon";
 export { Main as OrganismViewMain } from "../views/OrganismView/components/Main/main";
 export { Chip } from "./common/Chip/chip";
-export { CalendarIcon } from "./common/CustomIcon/components/CalendarIcon/calendarIcon";
 export { Tooltip } from "./common/Tooltip/tooltip";
 export { OrganismAvatar } from "./Entity/components/OrganismAvatar/organismAvatar";
 export { MDXSection } from "./Entity/components/Section/MDXSection/mdxSection";

--- a/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.tsx
+++ b/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.tsx
@@ -9,7 +9,6 @@ import {
   getOrganismId,
 } from "@/apis/catalog/brc-analytics-catalog/common/utils";
 import { SLUGIFY_OPTIONS } from "@/common/constants";
-import { AppLink } from "@/components/common/AppLink/appLink";
 import { Chip } from "@/components/common/Chip/chip";
 import { Tooltip } from "@/components/common/Tooltip/tooltip";
 import { StepConfig } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/types";
@@ -74,6 +73,7 @@ import type {
   OrganismContract,
 } from "@repo/shared/apis/types";
 import type { Workflow } from "@repo/shared/apis/workflow";
+import { AppLink } from "@repo/shared/components/AppLink/appLink";
 import { ROUTES } from "@repo/shared/routes/constants";
 import {
   BRC_DATA_CATALOG_CATEGORY_KEY,

--- a/app/views/AboutView/common/constants.ts
+++ b/app/views/AboutView/common/constants.ts
@@ -1,7 +1,7 @@
 import { SectionContentCard } from "@/components/common/Card/components/SectionContentCard/sectionContentCard";
-import { GalaxyIcon } from "@/components/common/CustomIcon/components/GalaxyIcon/galaxyIcon";
-import { RocketLaunchIcon } from "@/components/common/CustomIcon/components/RocketLaunchIcon/rocketLaunchIcon";
-import { SparkleIcon } from "@/components/common/CustomIcon/components/SparkleIcon/sparkleIcon";
+import { GalaxyIcon } from "@repo/shared/components/CustomIcon/components/GalaxyIcon/galaxyIcon";
+import { RocketLaunchIcon } from "@repo/shared/components/CustomIcon/components/RocketLaunchIcon/rocketLaunchIcon";
+import { SparkleIcon } from "@repo/shared/components/CustomIcon/components/SparkleIcon/sparkleIcon";
 import { ComponentProps } from "react";
 
 export const BRC_CARDS: ComponentProps<typeof SectionContentCard>[] = [

--- a/app/views/LearnView/constants.ts
+++ b/app/views/LearnView/constants.ts
@@ -1,7 +1,7 @@
 import { SectionContentCard } from "@/components/common/Card/components/SectionContentCard/sectionContentCard";
-import { GalaxyIcon } from "@/components/common/CustomIcon/components/GalaxyIcon/galaxyIcon";
-import { RocketLaunchIcon } from "@/components/common/CustomIcon/components/RocketLaunchIcon/rocketLaunchIcon";
 import { SearchIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/SearchIcon/searchIcon";
+import { GalaxyIcon } from "@repo/shared/components/CustomIcon/components/GalaxyIcon/galaxyIcon";
+import { RocketLaunchIcon } from "@repo/shared/components/CustomIcon/components/RocketLaunchIcon/rocketLaunchIcon";
 import { ComponentProps } from "react";
 import { BookmarkStarIcon } from "./components/icon/BookmarkStarIcon/bookmarkStarIcon";
 import { LiveHelpIcon } from "./components/icon/LiveHelpIcon/liveHelpIcon";

--- a/packages/shared/components/AppLink/appLink.tsx
+++ b/packages/shared/components/AppLink/appLink.tsx
@@ -1,6 +1,7 @@
-import { ChildrenProps } from "@databiosphere/findable-ui/lib/components/types";
+import type { ChildrenProps } from "@databiosphere/findable-ui/lib/components/types";
 import { Link as MLink } from "@mui/material";
-import Link, { LinkProps } from "next/link";
+import type { LinkProps } from "next/link";
+import Link from "next/link";
 import { JSX } from "react";
 
 export const AppLink = ({

--- a/packages/shared/components/CustomIcon/components/AnalyzeGenomeIcon/analyzeGenomeIcon.tsx
+++ b/packages/shared/components/CustomIcon/components/AnalyzeGenomeIcon/analyzeGenomeIcon.tsx
@@ -1,4 +1,5 @@
-import { CustomSVGIconProps } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/common/entities";
+import { SVG_ICON_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/svgIcon";
+import type { SvgIconProps } from "@mui/material";
 import { SvgIcon } from "@mui/material";
 import { JSX } from "react";
 
@@ -7,10 +8,10 @@ import { JSX } from "react";
  */
 
 export const AnalyzeGenomeIcon = ({
-  fontSize = "xsmall",
+  fontSize = SVG_ICON_PROPS.FONT_SIZE.XSMALL,
   viewBox = "0 0 18 18",
   ...props /* Spread props to allow for Mui SvgIconProps specific prop overrides e.g. "htmlColor". */
-}: CustomSVGIconProps): JSX.Element => {
+}: SvgIconProps): JSX.Element => {
   return (
     <SvgIcon fontSize={fontSize} viewBox={viewBox} {...props}>
       <path

--- a/packages/shared/components/CustomIcon/components/CalendarIcon/calendarIcon.tsx
+++ b/packages/shared/components/CustomIcon/components/CalendarIcon/calendarIcon.tsx
@@ -1,4 +1,5 @@
-import { SvgIcon, SvgIconProps } from "@mui/material";
+import type { SvgIconProps } from "@mui/material";
+import { SvgIcon } from "@mui/material";
 import { JSX } from "react";
 
 /**

--- a/packages/shared/components/CustomIcon/components/DeleteIcon/deleteIcon.tsx
+++ b/packages/shared/components/CustomIcon/components/DeleteIcon/deleteIcon.tsx
@@ -1,4 +1,6 @@
-import { SvgIcon, SvgIconProps } from "@mui/material";
+import { SVG_ICON_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/svgIcon";
+import type { SvgIconProps } from "@mui/material";
+import { SvgIcon } from "@mui/material";
 import { JSX } from "react";
 
 /**
@@ -6,7 +8,7 @@ import { JSX } from "react";
  */
 
 export const DeleteIcon = ({
-  fontSize = "xsmall",
+  fontSize = SVG_ICON_PROPS.FONT_SIZE.XSMALL,
   viewBox = "0 0 18 18",
   ...props
 }: SvgIconProps): JSX.Element => {

--- a/packages/shared/components/CustomIcon/components/FileUploadIcon/fileUploadIcon.tsx
+++ b/packages/shared/components/CustomIcon/components/FileUploadIcon/fileUploadIcon.tsx
@@ -1,5 +1,7 @@
 import { PALETTE } from "@databiosphere/findable-ui/lib/styles/common/constants/palette";
-import { SvgIcon, SvgIconProps } from "@mui/material";
+import { SVG_ICON_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/svgIcon";
+import type { SvgIconProps } from "@mui/material";
+import { SvgIcon } from "@mui/material";
 import { JSX } from "react";
 
 /**
@@ -7,7 +9,7 @@ import { JSX } from "react";
  */
 
 export const FileUploadIcon = ({
-  fontSize = "xsmall",
+  fontSize = SVG_ICON_PROPS.FONT_SIZE.XSMALL,
   viewBox = "0 0 72 72",
   ...props
 }: SvgIconProps): JSX.Element => {

--- a/packages/shared/components/CustomIcon/components/GalaxyIcon/galaxyIcon.tsx
+++ b/packages/shared/components/CustomIcon/components/GalaxyIcon/galaxyIcon.tsx
@@ -1,9 +1,11 @@
 import { PALETTE } from "@databiosphere/findable-ui/lib/styles/common/constants/palette";
-import { SvgIcon, SvgIconProps } from "@mui/material";
+import { SVG_ICON_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/svgIcon";
+import type { SvgIconProps } from "@mui/material";
+import { SvgIcon } from "@mui/material";
 import { JSX } from "react";
 
 export const GalaxyIcon = ({
-  fontSize = "large",
+  fontSize = SVG_ICON_PROPS.FONT_SIZE.LARGE,
   viewBox = "0 0 48 48",
   ...props
 }: SvgIconProps): JSX.Element => {

--- a/packages/shared/components/CustomIcon/components/RocketLaunchIcon/rocketLaunchIcon.tsx
+++ b/packages/shared/components/CustomIcon/components/RocketLaunchIcon/rocketLaunchIcon.tsx
@@ -1,9 +1,11 @@
 import { PALETTE } from "@databiosphere/findable-ui/lib/styles/common/constants/palette";
-import { SvgIcon, SvgIconProps } from "@mui/material";
+import { SVG_ICON_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/svgIcon";
+import type { SvgIconProps } from "@mui/material";
+import { SvgIcon } from "@mui/material";
 import { JSX } from "react";
 
 export const RocketLaunchIcon = ({
-  fontSize = "large",
+  fontSize = SVG_ICON_PROPS.FONT_SIZE.LARGE,
   viewBox = "0 0 48 48",
   ...props
 }: SvgIconProps): JSX.Element => {

--- a/packages/shared/components/CustomIcon/components/ScanDeleteIcon/scanDeleteIcon.tsx
+++ b/packages/shared/components/CustomIcon/components/ScanDeleteIcon/scanDeleteIcon.tsx
@@ -1,4 +1,6 @@
-import { SvgIcon, SvgIconProps } from "@mui/material";
+import { SVG_ICON_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/svgIcon";
+import type { SvgIconProps } from "@mui/material";
+import { SvgIcon } from "@mui/material";
 import { JSX } from "react";
 
 /**
@@ -6,7 +8,7 @@ import { JSX } from "react";
  */
 
 export const ScanDeleteIcon = ({
-  fontSize = "xsmall",
+  fontSize = SVG_ICON_PROPS.FONT_SIZE.XSMALL,
   viewBox = "0 0 18 18",
   ...props
 }: SvgIconProps): JSX.Element => {

--- a/packages/shared/components/CustomIcon/components/SparkleIcon/sparkleIcon.tsx
+++ b/packages/shared/components/CustomIcon/components/SparkleIcon/sparkleIcon.tsx
@@ -1,9 +1,11 @@
 import { PALETTE } from "@databiosphere/findable-ui/lib/styles/common/constants/palette";
-import { SvgIcon, SvgIconProps } from "@mui/material";
+import { SVG_ICON_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/svgIcon";
+import type { SvgIconProps } from "@mui/material";
+import { SvgIcon } from "@mui/material";
 import { JSX } from "react";
 
 export const SparkleIcon = ({
-  fontSize = "large",
+  fontSize = SVG_ICON_PROPS.FONT_SIZE.LARGE,
   viewBox = "0 0 48 48",
   ...props
 }: SvgIconProps): JSX.Element => {

--- a/packages/shared/components/CustomIcon/components/ViewGenomeIcon/viewGenomeIcon.tsx
+++ b/packages/shared/components/CustomIcon/components/ViewGenomeIcon/viewGenomeIcon.tsx
@@ -1,4 +1,5 @@
-import { CustomSVGIconProps } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/common/entities";
+import { SVG_ICON_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/svgIcon";
+import type { SvgIconProps } from "@mui/material";
 import { SvgIcon } from "@mui/material";
 import { JSX } from "react";
 
@@ -7,10 +8,10 @@ import { JSX } from "react";
  */
 
 export const ViewGenomeIcon = ({
-  fontSize = "xsmall",
+  fontSize = SVG_ICON_PROPS.FONT_SIZE.XSMALL,
   viewBox = "0 0 18 18",
   ...props /* Spread props to allow for Mui SvgIconProps specific prop overrides e.g. "htmlColor". */
-}: CustomSVGIconProps): JSX.Element => {
+}: SvgIconProps): JSX.Element => {
   return (
     <SvgIcon fontSize={fontSize} viewBox={viewBox} {...props}>
       <path


### PR DESCRIPTION
## Summary

Moves two self-contained leaf components into the shared workspace package (`@repo/shared`):

- `AppLink` → `packages/shared/components/AppLink/appLink.tsx`
- `CustomIcon` icons → `packages/shared/components/CustomIcon/components/*` (all 9: AnalyzeGenome, Calendar, Delete, FileUpload, Galaxy, RocketLaunch, ScanDelete, Sparkle, ViewGenome)

All importers are repointed to `@repo/shared/components/…` (including the `CalendarIcon` barrel re-export in `app/components/index.ts`). The components depend only on react/mui/next/findable-ui, so they resolve cleanly from the shared package.

Small cleanups made while in these files:
- Type-only imports now use `import type` (`ChildrenProps`, `LinkProps`, `SvgIconProps`).
- The two genome icons drop findable-ui's `CustomSVGIconProps` alias in favour of MUI's `SvgIconProps` directly.
- Icon `fontSize` defaults use findable-ui's `SVG_ICON_PROPS.FONT_SIZE.*` constant instead of string literals.

Move + repoint only; no build-script changes.

## Verification

tsc / eslint / prettier / jest (581) all green.

Closes #1468

🤖 Generated with [Claude Code](https://claude.com/claude-code)