### PR TITLE
refactor: back the priority-pathogens explore page with the client entity store (#1479)

### DIFF
--- a/app/services/workflows/routes.ts
+++ b/app/services/workflows/routes.ts
@@ -2,6 +2,7 @@ export const API = {
   assemblies: "/api/assemblies.json",
   organisms: "/api/organisms.json",
   pangenomes: "/api/pangenomes.json",
+  "priority-pathogens": "/api/priority-pathogens.json",
   workflowAssemblyMappings: "/api/workflow-assembly-mappings.json",
   workflows: "/api/workflows.json",
 } as const;

--- a/app/views/PriorityPathogensView/priorityPathogensView.tsx
+++ b/app/views/PriorityPathogensView/priorityPathogensView.tsx
@@ -1,19 +1,19 @@
+import type { Outbreak } from "@/apis/catalog/brc-analytics-catalog/common/entities";
+import { getEntities } from "@/services/workflows/query";
 import { useLayoutSpacing } from "@databiosphere/findable-ui/lib/hooks/UseLayoutSpacing/hook";
 import { JSX } from "react";
 import { PriorityPathogens } from "./components/PriorityPathogens/priorityPathogens";
 import { StyledGrid, StyledTitle } from "./priorityPathogensView.styles";
-import { Props } from "./types";
 import { sortPriorityPathogen } from "./utils";
 
-export const PriorityPathogensView = (props: Props): JSX.Element => {
+const ENTITY_LIST_TYPE = "priority-pathogens";
+
+export const PriorityPathogensView = (): JSX.Element => {
   const { spacing } = useLayoutSpacing();
 
-  // Get priority pathogens data.
-  const { data } = props;
-  const { hits } = data;
-
-  // Sort priority pathogens.
-  const priorityPathogens = hits.sort(sortPriorityPathogen);
+  const priorityPathogens = [...getEntities<Outbreak>(ENTITY_LIST_TYPE)].sort(
+    sortPriorityPathogen
+  );
 
   return (
     <StyledGrid {...spacing}>

--- a/app/views/PriorityPathogensView/types.ts
+++ b/app/views/PriorityPathogensView/types.ts
@@ -1,8 +1,0 @@
-import {
-  EntitiesResponse,
-  Outbreak,
-} from "@/apis/catalog/brc-analytics-catalog/common/entities";
-
-export interface Props {
-  data: EntitiesResponse<Outbreak>;
-}

--- a/pages/data/priority-pathogens/index.tsx
+++ b/pages/data/priority-pathogens/index.tsx
@@ -1,44 +1,35 @@
-import type {
-  EntitiesResponse,
-  Outbreak,
-} from "@/apis/catalog/brc-analytics-catalog/common/entities";
 import { getEntityListMeta } from "@/common/meta/utils";
+import { EntityDataGate } from "@/components/EntityDataGate/entityDataGate";
 import { config } from "@/config/config";
-import { seedDatabase } from "@/utils/seedDatabase";
 import { PriorityPathogensView } from "@/views/PriorityPathogensView/priorityPathogensView";
 import { Main as DXMain } from "@databiosphere/findable-ui/lib/components/Layout/components/Main/main.styles";
-import { getEntityService } from "@databiosphere/findable-ui/lib/hooks/useEntityService";
 import { GetStaticProps } from "next";
 import { JSX } from "react";
 
 const ENTITY_LIST_TYPE = "priority-pathogens";
 
-interface PriorityPathogensPageProps {
-  data: EntitiesResponse<Outbreak>;
+interface Props {
   entityListType: string;
   pageDescription?: string;
   pageTitle?: string;
 }
 
 /**
- * Priority pathogens explore page.
- * @param props - Page props.
- * @param props.data - Priority pathogens data.
+ * Priority pathogens explore page. Sources its data from the client-loaded
+ * entity store (gated on the store being loaded).
  * @returns PriorityPathogensView component.
  */
-const PriorityPathogensPage = ({
-  data,
-}: PriorityPathogensPageProps): JSX.Element => {
-  return <PriorityPathogensView data={data} />;
-};
+const Page = (): JSX.Element => (
+  <EntityDataGate>
+    <PriorityPathogensView />
+  </EntityDataGate>
+);
 
 /**
  * Build the set of props for pre-rendering of page.
  * @returns static props.
  */
-export const getStaticProps: GetStaticProps<
-  PriorityPathogensPageProps
-> = async () => {
+export const getStaticProps: GetStaticProps<Props> = async () => {
   const appConfig = config();
   const entityConfig = appConfig.entities.find(
     ({ route }) => route === ENTITY_LIST_TYPE
@@ -47,18 +38,10 @@ export const getStaticProps: GetStaticProps<
   // The route may be absent from a site's entity config; return notFound when it is.
   if (!entityConfig) return { notFound: true };
 
-  const { fetchAllEntities } = getEntityService(entityConfig, undefined);
-  await seedDatabase(ENTITY_LIST_TYPE, entityConfig);
-  const data = (await fetchAllEntities(
-    ENTITY_LIST_TYPE,
-    undefined
-  )) as EntitiesResponse<Outbreak>;
-
   const entityMeta = getEntityListMeta(appConfig.appKey)[ENTITY_LIST_TYPE];
 
   return {
     props: {
-      data,
       entityListType: ENTITY_LIST_TYPE,
       pageDescription: entityMeta?.pageDescription,
       pageTitle: entityMeta?.pageTitle,
@@ -66,6 +49,6 @@ export const getStaticProps: GetStaticProps<
   };
 };
 
-PriorityPathogensPage.Main = DXMain;
+Page.Main = DXMain;
 
-export default PriorityPathogensPage;
+export default Page;

--- a/scripts/sync-api-brc-analytics.sh
+++ b/scripts/sync-api-brc-analytics.sh
@@ -31,3 +31,7 @@ for name in "${OPTIONAL_JSONS[@]}"; do
     echo "Skipping optional ${name}.json (not found at $src)"
   fi
 done
+
+# Priority pathogens: the catalog output is outbreaks.json, served at the
+# priority-pathogens route so the client entity store can load it.
+cp "$SRC_ROOT/outbreaks.json" "$API_DIR/priority-pathogens.json"


### PR DESCRIPTION
## Summary

The priority-pathogens explore page was the last data explore page still inlining its full catalog — the outbreak data, including pre-compiled MDX descriptions, was serialized into the static HTML (~184 KB). It now sources its rows from the client-loaded entity store, matching the assemblies/organisms explore pages:

- **`app/services/workflows/routes.ts`** — add `"priority-pathogens": "/api/priority-pathogens.json"` so `loadEntities` fetches + seeds it (it already has a `getId`).
- **`scripts/sync-api-brc-analytics.sh`** — copy `catalog/output/outbreaks.json` → `public/api/priority-pathogens.json` (the catalog output name differs from the route). BRC-only; GA2's sync is untouched.
- **`PriorityPathogensView`** — reads the store (`[...getEntities<Outbreak>("priority-pathogens")].sort(...)`, shallow-copied so the sort can't mutate the shared store); dropped its `data` prop; removed the now-empty `types.ts`.
- **pp explore page** — gated on `EntityDataGate` (the store read is deferred past static prerender); `getStaticProps` reduced to `{ entityListType, meta }` + the `notFound` guard for sites without priority-pathogens (GA2).

## Result

| | Before | After |
|---|---|---|
| `data/priority-pathogens.html` | ~184 KB | ~37 KB |

Detail pages (24) unchanged. `Outbreak.description` (`MDXRemoteSerializeResult`) round-trips through the client fetch and renders correctly (verified in-browser: cards, priority chips, and MDX body all render).

## Verification

tsc / eslint / prettier / jest (581) / build all green; no inlined outbreak data remaining in the explore HTML; GA2 build unaffected.

Closes #1479

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2560" height="1128" alt="image" src="https://github.com/user-attachments/assets/9df2944c-c787-401a-92aa-c6aab1d57c4a" />
