### PR TITLE
fix: gate learn assistant card on assistant feature flag

### DIFF
--- a/app/views/LearnView/learnView.tsx
+++ b/app/views/LearnView/learnView.tsx
@@ -7,10 +7,12 @@ import { Fragment, JSX } from "react";
 import { CARDS } from "./constants";
 
 export const LearnView = (): JSX.Element => {
+  const isAssistantEnabled = useFeatureFlag("assistant");
   const isLmlsEnabled = useFeatureFlag("lmls");
   const filteredCards = CARDS.filter(
     (card) =>
-      card.cardUrl !== "/learn/sequence-search-workflows" || isLmlsEnabled
+      (card.cardUrl !== "/learn/sequence-search-workflows" || isLmlsEnabled) &&
+      (card.cardUrl !== "/learn/assistant" || isAssistantEnabled)
   );
 
   return (


### PR DESCRIPTION
## Description

i didnt open an issue for it, just noticed when double checking what all new stuff would be in a potential release that the learn page for the assistant doesnt respond to the existing feature flag
