### PR TITLE
refactor: centralize findable-ui theme augmentation import in @types (#1493)

### DIFF
--- a/@types/findable-ui.d.ts
+++ b/@types/findable-ui.d.ts
@@ -1,0 +1,13 @@
+// Canonical load point for findable-ui's MUI theme augmentations — the extra
+// Palette colors, Typography variants and SvgIcon colors that its theme adds to
+// `@mui/material`. TypeScript only applies those augmentations when a compiled
+// file bare-imports the findable-ui package root; without one they silently
+// vanish and every use of an augmented member fails to type-check.
+//
+// This file lives in `@types/`, which the tsconfig `include` picks up via
+// `**/*.ts`, so the augmentations load repo-wide from a single place and no
+// source file needs its own bare import.
+//
+// Types-only: the findable-ui package root is empty at runtime (`lib/index.js`
+// is `export {}`, `sideEffects: false`), so this has no bundle impact.
+import "@databiosphere/findable-ui";

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,4 +1,3 @@
-import "@databiosphere/findable-ui";
 import { AzulEntitiesStaticResponse } from "@databiosphere/findable-ui/lib/apis/azul/common/entities";
 import { Error } from "@databiosphere/findable-ui/lib/components/Error/error";
 import { ErrorBoundary } from "@databiosphere/findable-ui/lib/components/ErrorBoundary/errorBoundary";


### PR DESCRIPTION
Closes #1493.

findable-ui's MUI theme augmentations (extra `Palette` colors, `Typography` variants, `SvgIcon` colors) are only applied by TypeScript when a compiled file bare-imports the findable-ui package root. That single bare import previously lived in `pages/_app.tsx`, coupling the augmentations to that one file being in the compile.

## Changes
- Add `@types/findable-ui.d.ts` (sibling to `@types/theme.d.ts`) holding the bare `import "@databiosphere/findable-ui";`. The tsconfig `include` (`**/*.ts`) picks it up, so the augmentations load repo-wide from one canonical place.
- Remove the now-redundant `import "@databiosphere/findable-ui";` from `pages/_app.tsx`.

Runtime-neutral: findable-ui's package root is empty at runtime (`lib/index.js` is `export {}`, `sideEffects: false`).

## Verification
- Only one bare findable-ui import remains (the new `@types` file).
- `tsc --noEmit`, eslint: clean (augmentations still resolve).
- Unit tests: 581/581 pass.
- `build:local`: succeeds (theme-augmented styling type-checks under Next's build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)