### PR TITLE
refactor: rename local ky instance to httpclient in assistant-api-client (#1508)

### DIFF
--- a/app/services/assistant-api-client.ts
+++ b/app/services/assistant-api-client.ts
@@ -7,7 +7,7 @@ import type {
 } from "@repo/shared/services/api-client/types";
 import ky, { HTTPError } from "ky";
 
-const apiClient = ky.create({
+const httpClient = ky.create({
   // Send the assistant session-binding cookie cross-origin. Without
   // this, ky inherits fetch's "same-origin" default and the browser
   // strips the cookie when NEXT_PUBLIC_BACKEND_URL points off-origin
@@ -44,7 +44,7 @@ export const assistantAPIClient = {
   assistantChat: async (
     request: AssistantChatRequest
   ): Promise<AssistantChatResponse> => {
-    return apiClient
+    return httpClient
       .post("assistant/chat", {
         json: request,
         retry: { limit: 0 },
@@ -58,7 +58,7 @@ export const assistantAPIClient = {
    * @param sessionId - Session to delete
    */
   assistantDeleteSession: async (sessionId: string): Promise<void> => {
-    await apiClient.delete(`assistant/session/${sessionId}`);
+    await httpClient.delete(`assistant/session/${sessionId}`);
   },
 
   /**
@@ -66,7 +66,7 @@ export const assistantAPIClient = {
    * @returns Promise resolving to assistant info
    */
   assistantInfo: async (): Promise<AssistantInfoResponse> => {
-    return apiClient.get("assistant/info").json();
+    return httpClient.get("assistant/info").json();
   },
 
   /**
@@ -77,6 +77,6 @@ export const assistantAPIClient = {
   assistantRestore: async (
     sessionId: string
   ): Promise<SessionRestoreResponse> => {
-    return apiClient.get(`assistant/session/${sessionId}`).json();
+    return httpClient.get(`assistant/session/${sessionId}`).json();
   },
 };


### PR DESCRIPTION
Closes #1508.

Non-blocking follow-up flagged by @NoopDog on #1501: `app/services/assistant-api-client.ts` named its local ky instance `apiClient` — the name #1501 turns into the shared public export (`@repo/shared/services/api-client`). No collision today (this file doesn't import the shared one), but it's a shadowing trap and inconsistent with the `httpClient` rename #1501 applied to the sibling client for exactly this reason.

## Changes
- Renamed the local `const apiClient = ky.create(...)` (and its usages) → `httpClient`. Purely internal — `assistantAPIClient` export and all consumers unchanged.

## Verification
- `tsc --noEmit`, eslint: clean. Unit tests: 581/581.

🤖 Generated with [Claude Code](https://claude.com/claude-code)