### PR TITLE
refactor: move favorites into @repo/shared (#1503)

### DIFF
--- a/app/views/EntityView/assembly/components/Side/brc/side.tsx
+++ b/app/views/EntityView/assembly/components/Side/brc/side.tsx
@@ -1,5 +1,4 @@
 import { AnalysisPortals } from "@/components/Entity/components/AnalysisPortals/analysisPortals";
-import { AssemblyFavoriteButton } from "@/components/Favorites/AssemblyFavoriteButton/assemblyFavoriteButton";
 import {
   buildAssemblyDetails,
   buildAssemblyResources,
@@ -8,6 +7,7 @@ import {
 import { KeyValueSection } from "@/views/EntityView/components/KeyValueSection/keyValueSection";
 import { mapAssemblyToOrganism } from "@/views/WorkflowInputsView/utils";
 import { BackPageContentSideColumn } from "@databiosphere/findable-ui/lib/components/Layout/components/BackPage/backPageView.styles";
+import { AssemblyFavoriteButton } from "@repo/shared/components/Favorites/components/AssemblyFavoriteButton/assemblyFavoriteButton";
 import { JSX } from "react";
 import { StyledFluidPaper } from "../side.styles";
 import { StyledSection } from "./side.styles";

--- a/app/views/EntityView/assembly/components/Side/ga2/side.tsx
+++ b/app/views/EntityView/assembly/components/Side/ga2/side.tsx
@@ -1,5 +1,4 @@
 import { AnalysisPortals } from "@/components/Entity/components/AnalysisPortals/analysisPortals";
-import { AssemblyFavoriteButton } from "@/components/Favorites/AssemblyFavoriteButton/assemblyFavoriteButton";
 import {
   buildAssemblyResources,
   buildOrganismDetails,
@@ -8,6 +7,7 @@ import { AssemblyDetails } from "@/views/EntityView/assembly/components/Side/ga2
 import { KeyValueSection } from "@/views/EntityView/components/KeyValueSection/keyValueSection";
 import { mapAssemblyToOrganism } from "@/views/WorkflowInputsView/utils";
 import { BackPageContentSideColumn } from "@databiosphere/findable-ui/lib/components/Layout/components/BackPage/backPageView.styles";
+import { AssemblyFavoriteButton } from "@repo/shared/components/Favorites/components/AssemblyFavoriteButton/assemblyFavoriteButton";
 import { JSX } from "react";
 import { StyledFluidPaper } from "../side.styles";
 import { StyledSection } from "./side.styles";

--- a/packages/shared/components/Favorites/components/AssemblyFavoriteButton/assemblyFavoriteButton.tsx
+++ b/packages/shared/components/Favorites/components/AssemblyFavoriteButton/assemblyFavoriteButton.tsx
@@ -1,13 +1,10 @@
-import { useAssemblyFavorites } from "@/hooks/useAssemblyFavorites";
 import StarIcon from "@mui/icons-material/Star";
 import StarBorderIcon from "@mui/icons-material/StarBorder";
 import { Button, CircularProgress, Tooltip } from "@mui/material";
 import { useAuth } from "@repo/shared/providers/authentication/provider";
 import { JSX } from "react";
-
-interface Props {
-  accession: string;
-}
+import { useAssemblyFavorites } from "../../hooks/UseAssemblyFavorites/hook";
+import type { Props } from "./types";
 
 export function AssemblyFavoriteButton({ accession }: Props): JSX.Element {
   const {

--- a/packages/shared/components/Favorites/components/AssemblyFavoriteButton/types.ts
+++ b/packages/shared/components/Favorites/components/AssemblyFavoriteButton/types.ts
@@ -1,0 +1,3 @@
+export interface Props {
+  accession: string;
+}

--- a/packages/shared/components/Favorites/hooks/UseAssemblyFavorites/hook.ts
+++ b/packages/shared/components/Favorites/hooks/UseAssemblyFavorites/hook.ts
@@ -2,15 +2,7 @@ import { useAuth } from "@repo/shared/providers/authentication/provider";
 import { apiClient } from "@repo/shared/services/api-client/api-client";
 import type { FavoriteResponse } from "@repo/shared/services/api-client/types";
 import { useCallback, useEffect, useMemo, useState } from "react";
-
-interface UseAssemblyFavoritesReturn {
-  error: Error | null;
-  favorites: FavoriteResponse[];
-  isFavorited: (entityId: string) => boolean;
-  isLoading: boolean;
-  isToggling: boolean;
-  toggleFavorite: (entityId: string) => Promise<void>;
-}
+import type { UseAssemblyFavoritesReturn } from "./types";
 
 export function useAssemblyFavorites(): UseAssemblyFavoritesReturn {
   const { isAuthenticated, isConfigured } = useAuth();

--- a/packages/shared/components/Favorites/hooks/UseAssemblyFavorites/types.ts
+++ b/packages/shared/components/Favorites/hooks/UseAssemblyFavorites/types.ts
@@ -1,0 +1,10 @@
+import type { FavoriteResponse } from "@repo/shared/services/api-client/types";
+
+export interface UseAssemblyFavoritesReturn {
+  error: Error | null;
+  favorites: FavoriteResponse[];
+  isFavorited: (entityId: string) => boolean;
+  isLoading: boolean;
+  isToggling: boolean;
+  toggleFavorite: (entityId: string) => Promise<void>;
+}

--- a/pages/data/favorites.tsx
+++ b/pages/data/favorites.tsx
@@ -1,6 +1,5 @@
 import { SectionHero } from "@/components/Layout/components/AppLayout/components/Section/components/SectionHero/sectionHero";
 import { StyledPagesMain } from "@/components/Layout/components/Main/main.styles";
-import { useAssemblyFavorites } from "@/hooks/useAssemblyFavorites";
 import { getEntity } from "@/services/workflows/query";
 import { Assembly } from "@/views/WorkflowInputsView/types";
 import { Breadcrumb } from "@databiosphere/findable-ui/lib/components/common/Breadcrumbs/breadcrumbs";
@@ -13,6 +12,7 @@ import {
   Typography,
 } from "@mui/material";
 import { sanitizeEntityId } from "@repo/shared/apis/utils";
+import { useAssemblyFavorites } from "@repo/shared/components/Favorites/hooks/UseAssemblyFavorites/hook";
 import { useAuth } from "@repo/shared/providers/authentication/provider";
 import Link from "next/link";
 import { JSX } from "react";

--- a/tests/hooks/useAssemblyFavorites.test.ts
+++ b/tests/hooks/useAssemblyFavorites.test.ts
@@ -1,4 +1,4 @@
-import { useAssemblyFavorites } from "@/hooks/useAssemblyFavorites";
+import { useAssemblyFavorites } from "@repo/shared/components/Favorites/hooks/UseAssemblyFavorites/hook";
 import { useAuth } from "@repo/shared/providers/authentication/provider";
 import { apiClient } from "@repo/shared/services/api-client/api-client";
 import type { FavoriteResponse } from "@repo/shared/services/api-client/types";


### PR DESCRIPTION
Closes #1503.

Final step of the Favorites → `@repo/shared` migration (follows the API layer #1501 and auth provider #1504, both merged).

## Changes
- `git mv`:
  - `AssemblyFavoriteButton` → `packages/shared/components/Favorites/components/AssemblyFavoriteButton/` (+ `types.ts` for `Props`).
  - `useAssemblyFavorites` → `packages/shared/components/Favorites/hooks/UseAssemblyFavorites/hook.ts` (+ `types.ts` for `UseAssemblyFavoritesReturn`).
- Repointed consumers → `@repo/shared/...`: the BRC + GA2 assembly `Side` views (button), the favorites page + hook test (hook).
- Button imports the hook relatively (`../../hooks/UseAssemblyFavorites/hook`); type-only imports use `import type`. Hook test stays under `tests/` per the repo convention.

## Notes
- Pure `git mv` reorg — no behaviour change, so no new tests (existing suite + build is the regression signal). The hook's test moved only its imports, not its location.

## Verification
- No `@/components/Favorites` or `@/hooks/useAssemblyFavorites` imports remain; moved code has no `@/`/`@site-config` imports (shared purity).
- `tsc --noEmit`, eslint, prettier: clean. Unit tests: 581/581. `build:local`: succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)