### PR TITLE
fix: make hyphy flag version agnostic

### DIFF
--- a/app/views/OrganismView/components/Main/components/PangenomeSection/utils.ts
+++ b/app/views/OrganismView/components/Main/components/PangenomeSection/utils.ts
@@ -10,6 +10,7 @@ export function getTrackTypes(memberCount: number): string[] {
     `Multi-z alignment (${memberCount}-way)`,
     "Pairwise chains to each other strain",
     "Cross-strain gene projections",
+    // eslint-disable-next-line sonarjs/todo-tag -- pre-existing TODO tracked in #1341
     // TODO(#1341): species-specific — the cohort-variants track is Plasmodium
     // (MalariaGEN) only. Source this per-bundle from pangenomes.json once the
     // real build lands rather than hardcoding it for every species here.

--- a/app/views/WorkflowsView/utils.ts
+++ b/app/views/WorkflowsView/utils.ts
@@ -62,9 +62,9 @@ function shouldIncludeWorkflow(
   workflow: { trsId: string },
   isHyphyEnabled: boolean
 ): boolean {
-  const isHyphyWorkflow =
-    workflow.trsId ===
-    "#workflow/github.com/iwc-workflows/hyphy/capheine-core-and-compare/versions/v0.1";
+  const isHyphyWorkflow = workflow.trsId.startsWith(
+    "#workflow/github.com/iwc-workflows/hyphy/capheine-core-and-compare/versions/"
+  );
 
   return !isHyphyWorkflow || isHyphyEnabled;
 }


### PR DESCRIPTION
## Description

just quick fix for something i noticed fri, hyphy flag too specific and not catching updated versions of the workflow