### PR TITLE
fix: stop a list-field group-by killing the assistant turn

### DIFF
--- a/backend/api/app/api/v1/assistant.py
+++ b/backend/api/app/api/v1/assistant.py
@@ -2,6 +2,7 @@ import logging
 from typing import Optional
 
 from fastapi import APIRouter, Cookie, Depends, HTTPException, Response
+from pydantic_ai.exceptions import AgentRunError
 
 from app.core.config import SESSION_COOKIE_NAME
 from app.core.dependencies import (
@@ -96,7 +97,18 @@ async def assistant_chat(
             status_code=403,
             detail="Assistant session belongs to another user",
         ) from e
+    except AgentRunError as e:
+        # pydantic-ai hangs every agent failure off AgentRunError, which is a
+        # RuntimeError -- so a single malformed tool call, a provider 4xx and a
+        # usage cap all used to land in the branch below and tell the user the
+        # assistant was down. It isn't: the run failed, nobody else is affected,
+        # and "try again later" is wrong because the same question fails again.
+        logger.exception("Assistant chat run failed")
+        raise HTTPException(
+            status_code=500, detail="The assistant could not complete that request"
+        ) from e
     except RuntimeError as e:
+        # What's left is the deliberate one: the agent isn't configured.
         logger.exception("Assistant chat unavailable (RuntimeError)")
         raise HTTPException(status_code=503, detail=str(e)) from e
     except Exception as e:

--- a/backend/api/app/api/v1/assistant.py
+++ b/backend/api/app/api/v1/assistant.py
@@ -2,7 +2,12 @@ import logging
 from typing import Optional
 
 from fastapi import APIRouter, Cookie, Depends, HTTPException, Response
-from pydantic_ai.exceptions import AgentRunError
+from pydantic_ai.exceptions import (
+    AgentRunError,
+    ConcurrencyLimitExceeded,
+    ModelHTTPError,
+    UsageLimitExceeded,
+)
 
 from app.core.config import SESSION_COOKIE_NAME
 from app.core.dependencies import (
@@ -97,12 +102,33 @@ async def assistant_chat(
             status_code=403,
             detail="Assistant session belongs to another user",
         ) from e
+    except ModelHTTPError as e:
+        # Upstream said no. Keep its meaning: throttling stays throttling and an
+        # upstream outage stays an outage, both of which are worth retrying and
+        # both of which the client already has distinct messaging for. Only a
+        # provider 4xx we can't act on falls through to a generic failure.
+        logger.exception("Assistant model call failed upstream (%s)", e.status_code)
+        if e.status_code == 429:
+            raise HTTPException(
+                status_code=429, detail="The assistant is rate limited right now"
+            ) from e
+        if e.status_code >= 500:
+            raise HTTPException(
+                status_code=503, detail="The assistant's model provider is unavailable"
+            ) from e
+        raise HTTPException(
+            status_code=500, detail="The assistant could not complete that request"
+        ) from e
+    except (UsageLimitExceeded, ConcurrencyLimitExceeded) as e:
+        # A cap we set, not a broken run: retrying later is the right advice.
+        logger.exception("Assistant chat hit a usage or concurrency limit")
+        raise HTTPException(
+            status_code=429, detail="The assistant is at capacity right now"
+        ) from e
     except AgentRunError as e:
-        # pydantic-ai hangs every agent failure off AgentRunError, which is a
-        # RuntimeError -- so a single malformed tool call, a provider 4xx and a
-        # usage cap all used to land in the branch below and tell the user the
-        # assistant was down. It isn't: the run failed, nobody else is affected,
-        # and "try again later" is wrong because the same question fails again.
+        # What's left is the run itself going wrong -- a tool exhausting its
+        # retries, unparseable model output. One broken turn, not an outage, and
+        # not worth retrying: the same question fails the same way.
         logger.exception("Assistant chat run failed")
         raise HTTPException(
             status_code=500, detail="The assistant could not complete that request"

--- a/backend/api/app/api/v1/assistant.py
+++ b/backend/api/app/api/v1/assistant.py
@@ -23,7 +23,10 @@ from app.models.assistant import (
     SessionRestoreResponse,
 )
 from app.models.user_data import UserMeResponse
-from app.services.assistant_agent import AssistantTimeoutError
+from app.services.assistant_agent import (
+    AssistantTimeoutError,
+    AssistantUnavailableError,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -102,6 +105,14 @@ async def assistant_chat(
             status_code=403,
             detail="Assistant session belongs to another user",
         ) from e
+    except AssistantUnavailableError as e:
+        # The one case where "unavailable" is the truth. Narrowed from a bare
+        # RuntimeError catch, which also swallowed unrelated runtime bugs and
+        # returned their messages to the client.
+        logger.exception("Assistant chat unavailable (not configured)")
+        raise HTTPException(
+            status_code=503, detail="The analysis assistant is not configured"
+        ) from e
     except ModelHTTPError as e:
         # Upstream said no. Keep its meaning: throttling stays throttling and an
         # upstream outage stays an outage, both of which are worth retrying and
@@ -133,10 +144,6 @@ async def assistant_chat(
         raise HTTPException(
             status_code=500, detail="The assistant could not complete that request"
         ) from e
-    except RuntimeError as e:
-        # What's left is the deliberate one: the agent isn't configured.
-        logger.exception("Assistant chat unavailable (RuntimeError)")
-        raise HTTPException(status_code=503, detail=str(e)) from e
     except Exception as e:
         logger.exception("Assistant chat error")
         raise HTTPException(status_code=500, detail="Internal assistant error") from e

--- a/backend/api/app/services/assistant_agent.py
+++ b/backend/api/app/services/assistant_agent.py
@@ -109,6 +109,15 @@ class AssistantTimeoutError(RuntimeError):
     """Raised when the assistant run exceeds the server-side timeout."""
 
 
+class AssistantUnavailableError(RuntimeError):
+    """Raised when the agent isn't configured -- no API key, so no assistant.
+
+    Distinct from a run that failed: this is the one case where telling the user
+    the assistant is unavailable is true, so it's the only thing that should
+    reach a 503. An unrelated RuntimeError is a bug, not an outage.
+    """
+
+
 def _should_retry_agent_error(exc: BaseException) -> bool:
     return not isinstance(exc, AssistantTimeoutError)
 
@@ -975,7 +984,9 @@ class AssistantAgent:
         Creates a new session if session_id is None or not found.
         """
         if not self.is_available():
-            raise RuntimeError("Assistant agent is not available (check AI_API_KEY)")
+            raise AssistantUnavailableError(
+                "Assistant agent is not available (check AI_API_KEY)"
+            )
 
         # Get or create session
         state = None

--- a/backend/api/app/services/tools/catalog_query.py
+++ b/backend/api/app/services/tools/catalog_query.py
@@ -79,6 +79,10 @@ class EntitySchema:
         self.numeric_fields: set[str] = {
             f for f, t in self.fields.items() if t is FieldType.NUMERIC
         }
+        # GROUP BY on a list column buckets by whole-list equality, so only
+        # scalars can be faceted. Derived here with the rest so the tool schema,
+        # the validator and this declaration can't drift apart.
+        self.facetable_fields: set[str] = self.field_names - self.list_fields
         self.configured_columns: set[str] = self.field_names | set(self.display)
         # Fail at import on a misdeclared schema rather than late with malformed
         # SQL or an IndexError: a `list` always needs a projection, and every
@@ -265,6 +269,17 @@ class Op(str, Enum):
 
 Scalar = Union[str, int, float, bool]
 
+# Every field either entity can be grouped on, as a schema-level enum rather than
+# a bare string. A list field named here used to validate fine and then fail at
+# run time, and the model -- given no way to see the constraint -- reliably made
+# the same call on retry and killed the whole turn. Union across entities is
+# deliberate: the per-entity check below still catches an assembly field asked of
+# organisms, and it does so with a message naming the valid ones.
+FACETABLE_FIELDS: tuple[str, ...] = tuple(
+    sorted({f for s in ENTITY_SCHEMA.values() for f in s.facetable_fields})
+)
+FacetField = Literal[FACETABLE_FIELDS]  # type: ignore[valid-type]
+
 
 class Filter(BaseModel):
     field: str
@@ -286,7 +301,7 @@ class CatalogQuery(BaseModel):
     # Each facet column is a separate GROUP BY query in execute(); cap the count
     # so one call can't fan out into a burst of DB work. Realistic group-bys use
     # one or two columns — 4 is comfortable headroom.
-    facet_by: list[str] = Field(default_factory=list, max_length=4)
+    facet_by: list[FacetField] = Field(default_factory=list, max_length=4)
     # Bound the page to a small, fixed size so a `list` is always a short, fully
     # rendered table — never a corpus dump or a variable-length one. The cap is the
     # default (the model can't inflate it); over it we truncate and offer to narrow
@@ -320,9 +335,13 @@ class CatalogQuery(BaseModel):
         numeric_fields = schema.numeric_fields
         list_facets = sorted({c for c in self.facet_by if c in list_fields})
         if list_facets:
+            # Name the alternatives, as the unknown-field message above does. A
+            # retry that's only told "no" has nothing to go on and repeats the
+            # same call, which costs the whole turn rather than one tool call.
             raise ValueError(
-                f"cannot facet on list field(s) {list_facets}; "
-                "group-by needs a scalar field"
+                f"cannot facet on list field(s) {list_facets}; group-by needs a "
+                f"scalar field. Valid facet fields for entity "
+                f"{self.entity!r}: {sorted(schema.facetable_fields)}"
             )
         for f in self.filters:
             # Every op except the null checks needs a value; without this, a None

--- a/backend/api/app/services/tools/catalog_query.py
+++ b/backend/api/app/services/tools/catalog_query.py
@@ -278,7 +278,7 @@ Scalar = Union[str, int, float, bool]
 FACETABLE_FIELDS: tuple[str, ...] = tuple(
     sorted({f for s in ENTITY_SCHEMA.values() for f in s.facetable_fields})
 )
-FacetField = Literal[FACETABLE_FIELDS]  # type: ignore[valid-type]
+FacetField = Literal[*FACETABLE_FIELDS]  # type: ignore[valid-type]
 
 
 class Filter(BaseModel):

--- a/backend/api/app/services/tools/catalog_query.py
+++ b/backend/api/app/services/tools/catalog_query.py
@@ -318,31 +318,31 @@ class CatalogQuery(BaseModel):
             raise ValueError("operation 'facets' needs at least one facet_by field")
         schema = ENTITY_SCHEMA[self.entity]
         allowed = schema.field_names
-        referenced = (
-            [f.field for f in self.filters]
-            + list(self.facet_by)
-            + [s.field for s in self.sort]
+        # facet_by is checked first, and against this entity's facetable set
+        # rather than its full field list. The enum spans both entities, so an
+        # assembly-only scalar reaches here on an organism query; answering that
+        # with the generic "valid fields" list would offer taxonomicGroup, the
+        # model would take the suggestion, and the Literal would reject it on the
+        # retry -- the exact exhaustion this branch exists to stop. Every field
+        # named here is one that would actually work.
+        bad_facets = sorted(
+            {c for c in self.facet_by if c not in schema.facetable_fields}
         )
+        if bad_facets:
+            raise ValueError(
+                f"cannot facet on {bad_facets} for entity {self.entity!r}; "
+                f"group-by needs a scalar field of that entity. Valid facet "
+                f"fields: {sorted(schema.facetable_fields)}"
+            )
+        referenced = [f.field for f in self.filters] + [s.field for s in self.sort]
         unknown = sorted({f for f in referenced if f not in allowed})
         if unknown:
             raise ValueError(
                 f"unknown field(s) {unknown} for entity {self.entity!r}; "
                 f"valid fields: {sorted(allowed)}"
             )
-        # GROUP BY on a list column buckets by whole-list equality (and yields
-        # list-repr keys), not per-element counts — reject it rather than mislead.
         list_fields = schema.list_fields
         numeric_fields = schema.numeric_fields
-        list_facets = sorted({c for c in self.facet_by if c in list_fields})
-        if list_facets:
-            # Name the alternatives, as the unknown-field message above does. A
-            # retry that's only told "no" has nothing to go on and repeats the
-            # same call, which costs the whole turn rather than one tool call.
-            raise ValueError(
-                f"cannot facet on list field(s) {list_facets}; group-by needs a "
-                f"scalar field. Valid facet fields for entity "
-                f"{self.entity!r}: {sorted(schema.facetable_fields)}"
-            )
         for f in self.filters:
             # Every op except the null checks needs a value; without this, a None
             # compiles to a comparison against NULL that silently matches nothing.

--- a/backend/api/evals/results/2026-07-28-catalog_query-c629c980.md
+++ b/backend/api/evals/results/2026-07-28-catalog_query-c629c980.md
@@ -1,0 +1,29 @@
+# BRC Analytics evals
+
+- Generated: 2026-07-28T23:16:44Z
+- Commit: `c629c980`
+- Datasets: catalog_query
+- Models: MiniMax-M2.7
+
+## `catalog_query`
+
+| Model | QueryCatalogShape | n | duration |
+|---|---|---|---|
+| MiniMax-M2.7 | 9.0/10 (0.90) | 10 | 8.8s |
+
+<details><summary>Per-case detail (average across evaluators)</summary>
+
+| Case | MiniMax-M2.7 |
+|---|---|
+| count_chromosome_total | 1.00 |
+| count_clade_anopheles | 1.00 |
+| count_organisms_clade_anopheles | 1.00 |
+| empty_intersection_ref_and_complete | 1.00 |
+| facets_by_level | 1.00 |
+| facets_organisms_broad_fungi | 0.00 |
+| list_organisms_clade_anopheles | 1.00 |
+| list_species_and_level | 1.00 |
+| lookup_by_taxid | 1.00 |
+| reference_only_for_species | 1.00 |
+
+</details>

--- a/backend/api/evals/results/2026-07-28-catalog_query-c629c980.md
+++ b/backend/api/evals/results/2026-07-28-catalog_query-c629c980.md
@@ -7,23 +7,23 @@
 
 ## `catalog_query`
 
-| Model | QueryCatalogShape | n | duration |
-|---|---|---|---|
-| MiniMax-M2.7 | 9.0/10 (0.90) | 10 | 8.8s |
+| Model        | QueryCatalogShape | n   | duration |
+| ------------ | ----------------- | --- | -------- |
+| MiniMax-M2.7 | 9.0/10 (0.90)     | 10  | 8.8s     |
 
 <details><summary>Per-case detail (average across evaluators)</summary>
 
-| Case | MiniMax-M2.7 |
-|---|---|
-| count_chromosome_total | 1.00 |
-| count_clade_anopheles | 1.00 |
-| count_organisms_clade_anopheles | 1.00 |
-| empty_intersection_ref_and_complete | 1.00 |
-| facets_by_level | 1.00 |
-| facets_organisms_broad_fungi | 0.00 |
-| list_organisms_clade_anopheles | 1.00 |
-| list_species_and_level | 1.00 |
-| lookup_by_taxid | 1.00 |
-| reference_only_for_species | 1.00 |
+| Case                                | MiniMax-M2.7 |
+| ----------------------------------- | ------------ |
+| count_chromosome_total              | 1.00         |
+| count_clade_anopheles               | 1.00         |
+| count_organisms_clade_anopheles     | 1.00         |
+| empty_intersection_ref_and_complete | 1.00         |
+| facets_by_level                     | 1.00         |
+| facets_organisms_broad_fungi        | 0.00         |
+| list_organisms_clade_anopheles      | 1.00         |
+| list_species_and_level              | 1.00         |
+| lookup_by_taxid                     | 1.00         |
+| reference_only_for_species          | 1.00         |
 
 </details>

--- a/backend/api/tests/test_assistant_endpoints.py
+++ b/backend/api/tests/test_assistant_endpoints.py
@@ -267,6 +267,44 @@ class TestAnonymousSessionClaim:
         assert resp.status_code == 500
         assert "could not complete" in resp.json()["detail"]
 
+    def test_chat_preserves_upstream_throttling_as_429(
+        self, app_with_stubbed_agent, client
+    ):
+        # A provider 429 is transient and the client already words it properly.
+        # Flattening it to 500 would lose that for users and for alerting.
+        from pydantic_ai.exceptions import ModelHTTPError
+
+        agent = self._agent(app_with_stubbed_agent)
+        agent.chat = AsyncMock(
+            side_effect=ModelHTTPError(status_code=429, model_name="m", body=None)
+        )
+
+        resp = client.post("/api/v1/assistant/chat", json={"message": "hello"})
+
+        assert resp.status_code == 429
+
+    def test_chat_maps_an_upstream_outage_to_503(self, app_with_stubbed_agent, client):
+        from pydantic_ai.exceptions import ModelHTTPError
+
+        agent = self._agent(app_with_stubbed_agent)
+        agent.chat = AsyncMock(
+            side_effect=ModelHTTPError(status_code=529, model_name="m", body=None)
+        )
+
+        resp = client.post("/api/v1/assistant/chat", json={"message": "hello"})
+
+        assert resp.status_code == 503
+
+    def test_chat_maps_a_usage_cap_to_429(self, app_with_stubbed_agent, client):
+        from pydantic_ai.exceptions import UsageLimitExceeded
+
+        agent = self._agent(app_with_stubbed_agent)
+        agent.chat = AsyncMock(side_effect=UsageLimitExceeded("cap"))
+
+        resp = client.post("/api/v1/assistant/chat", json={"message": "hello"})
+
+        assert resp.status_code == 429
+
     def test_chat_still_maps_an_unconfigured_agent_to_503(
         self, app_with_stubbed_agent, client
     ):

--- a/backend/api/tests/test_assistant_endpoints.py
+++ b/backend/api/tests/test_assistant_endpoints.py
@@ -308,17 +308,28 @@ class TestAnonymousSessionClaim:
     def test_chat_still_maps_an_unconfigured_agent_to_503(
         self, app_with_stubbed_agent, client
     ):
-        # The one RuntimeError we raise on purpose does mean unavailable.
+        # The one error we raise on purpose does mean unavailable.
+        from app.services.assistant_agent import AssistantUnavailableError
+
         agent = self._agent(app_with_stubbed_agent)
-        agent.chat = AsyncMock(
-            side_effect=RuntimeError(
-                "Assistant agent is not available (check AI_API_KEY)"
-            )
-        )
+        agent.chat = AsyncMock(side_effect=AssistantUnavailableError("no key"))
 
         resp = client.post("/api/v1/assistant/chat", json={"message": "hello"})
 
         assert resp.status_code == 503
+
+    def test_chat_does_not_leak_an_unrelated_runtime_error(
+        self, app_with_stubbed_agent, client
+    ):
+        # A bare RuntimeError is a bug, not an outage, and its message can name
+        # internal config. It must not reach the client as a 503 with details.
+        agent = self._agent(app_with_stubbed_agent)
+        agent.chat = AsyncMock(side_effect=RuntimeError("REDIS_URL=redis://secret"))
+
+        resp = client.post("/api/v1/assistant/chat", json={"message": "hello"})
+
+        assert resp.status_code == 500
+        assert "secret" not in resp.text
 
     def test_chat_maps_permission_error_to_403(self, app_with_stubbed_agent, client):
         # An anonymous caller holding the session cookie but citing a session

--- a/backend/api/tests/test_assistant_endpoints.py
+++ b/backend/api/tests/test_assistant_endpoints.py
@@ -240,6 +240,48 @@ class TestAnonymousSessionClaim:
         assert resp.status_code == 403
         assert "another user" in resp.json()["detail"]
 
+    def _agent(self, app):
+        from app.core.dependencies import get_assistant_agent
+
+        return app.dependency_overrides[get_assistant_agent]()
+
+    def test_chat_maps_a_failed_agent_run_to_500_not_503(
+        self, app_with_stubbed_agent, client
+    ):
+        # pydantic-ai raises UnexpectedModelBehavior -- an AgentRunError, which
+        # subclasses RuntimeError -- when a tool exhausts its retries. That is one
+        # broken turn, not an outage, and 503 told every user the assistant was
+        # down and to come back later. Seen in production on a malformed
+        # query_catalog facet call.
+        from pydantic_ai.exceptions import UnexpectedModelBehavior
+
+        agent = self._agent(app_with_stubbed_agent)
+        agent.chat = AsyncMock(
+            side_effect=UnexpectedModelBehavior(
+                "Tool 'query_catalog' exceeded max retries count of 1"
+            )
+        )
+
+        resp = client.post("/api/v1/assistant/chat", json={"message": "hello"})
+
+        assert resp.status_code == 500
+        assert "could not complete" in resp.json()["detail"]
+
+    def test_chat_still_maps_an_unconfigured_agent_to_503(
+        self, app_with_stubbed_agent, client
+    ):
+        # The one RuntimeError we raise on purpose does mean unavailable.
+        agent = self._agent(app_with_stubbed_agent)
+        agent.chat = AsyncMock(
+            side_effect=RuntimeError(
+                "Assistant agent is not available (check AI_API_KEY)"
+            )
+        )
+
+        resp = client.post("/api/v1/assistant/chat", json={"message": "hello"})
+
+        assert resp.status_code == 503
+
     def test_chat_maps_permission_error_to_403(self, app_with_stubbed_agent, client):
         # An anonymous caller holding the session cookie but citing a session
         # owned by someone else skips the claim block and hits agent.chat(),

--- a/backend/api/tests/test_catalog_query.py
+++ b/backend/api/tests/test_catalog_query.py
@@ -48,7 +48,10 @@ def test_unknown_field_rejected():
 
 
 def test_unknown_facet_and_sort_fields_rejected():
-    with pytest.raises(ValueError, match="unknown field"):
+    # facet_by is an enum of the facetable fields, so an unknown name is refused
+    # by the schema before the per-entity check ever runs; sort is still a plain
+    # string and gets there.
+    with pytest.raises(ValueError):
         CatalogQuery(operation="facets", facet_by=["nope"])
     with pytest.raises(ValueError, match="unknown field"):
         CatalogQuery(sort=[Sort(field="nope")])
@@ -181,7 +184,10 @@ def test_compile_ne_and_not_in_are_null_safe():
 
 
 def test_facet_on_list_field_rejected():
-    with pytest.raises(ValueError, match="cannot facet on list field"):
+    # A list field is no longer offered in the facet_by enum at all, so the model
+    # cannot name one. The runtime "cannot facet on list field" check stays as a
+    # guard for a field that is scalar on one entity and a list on another.
+    with pytest.raises(ValueError):
         CatalogQuery(operation="facets", facet_by=["ploidy"])
 
 

--- a/backend/api/tests/test_catalog_query.py
+++ b/backend/api/tests/test_catalog_query.py
@@ -185,8 +185,8 @@ def test_compile_ne_and_not_in_are_null_safe():
 
 def test_facet_on_list_field_rejected():
     # A list field is no longer offered in the facet_by enum at all, so the model
-    # cannot name one. The runtime "cannot facet on list field" check stays as a
-    # guard for a field that is scalar on one entity and a list on another.
+    # cannot name one. A field that is scalar on one entity and a list on another
+    # would clear the enum and be caught by the per-entity facetable check.
     with pytest.raises(ValueError):
         CatalogQuery(operation="facets", facet_by=["ploidy"])
 

--- a/backend/api/tests/test_catalog_query_facets.py
+++ b/backend/api/tests/test_catalog_query_facets.py
@@ -39,12 +39,33 @@ def test_faceting_on_a_scalar_field_is_accepted():
     assert q.facet_by == ["taxonomicLevelKingdom"]
 
 
-def test_wrong_entity_facet_still_names_the_valid_fields():
-    """Cross-entity fields stay in the enum, so the per-entity check catches them
-    -- and has to say what would have worked, or a retry is blind."""
+def test_wrong_entity_facet_only_suggests_fields_that_would_work():
+    """The enum spans both entities, so an assembly scalar reaches the per-entity
+    check. Every field it suggests has to be facetable *for this entity* -- offer
+    a list field here and the model takes the suggestion, the Literal rejects it,
+    and the retry is gone. That is the exhaustion this whole change prevents."""
     with pytest.raises(pydantic.ValidationError) as exc:
         CatalogQuery(entity="organism", operation="facets", facet_by=["level"])
 
     message = str(exc.value)
-    assert "valid fields" in message
     assert "taxonomicLevelKingdom" in message
+    organism = ENTITY_SCHEMA["organism"]
+    for list_field in organism.list_fields:
+        assert list_field not in message, (
+            f"suggested {list_field}, which would fail on the retry"
+        )
+
+
+def test_every_suggested_facet_is_facetable_for_that_entity():
+    for name, schema in ENTITY_SCHEMA.items():
+        other = next(k for k in ENTITY_SCHEMA if k != name)
+        foreign = sorted(
+            ENTITY_SCHEMA[other].facetable_fields - schema.facetable_fields
+        )
+        if not foreign:
+            continue
+        with pytest.raises(pydantic.ValidationError) as exc:
+            CatalogQuery(entity=name, operation="facets", facet_by=[foreign[0]])
+        message = str(exc.value)
+        for bad in schema.list_fields:
+            assert bad not in message, f"{name} suggested un-facetable {bad}"

--- a/backend/api/tests/test_catalog_query_facets.py
+++ b/backend/api/tests/test_catalog_query_facets.py
@@ -1,0 +1,50 @@
+"""Guards for the facet-field contract.
+
+A live conversation died on `query_catalog(entity="organism",
+facet_by=["taxonomicGroup"])`: the field is a list, GROUP BY rejected it after
+validation, the model repeated the call on its single retry, and the run failed.
+"""
+
+import pydantic
+import pytest
+
+from app.services.tools.catalog_query import (
+    ENTITY_SCHEMA,
+    FACETABLE_FIELDS,
+    CatalogQuery,
+)
+
+
+def test_list_fields_are_not_offered_as_facets():
+    """The model picks from this enum, so a list field must not appear in it."""
+    for name, schema in ENTITY_SCHEMA.items():
+        offered = schema.list_fields & set(FACETABLE_FIELDS)
+        assert not offered, f"{name} offers un-facetable list field(s) {offered}"
+
+
+def test_facetable_fields_are_not_empty_and_include_a_real_grouping():
+    assert "taxonomicLevelKingdom" in FACETABLE_FIELDS
+    assert "taxonomicGroup" not in FACETABLE_FIELDS
+
+
+def test_faceting_on_a_list_field_is_rejected_by_the_schema():
+    with pytest.raises(pydantic.ValidationError):
+        CatalogQuery(entity="organism", operation="facets", facet_by=["taxonomicGroup"])
+
+
+def test_faceting_on_a_scalar_field_is_accepted():
+    q = CatalogQuery(
+        entity="organism", operation="facets", facet_by=["taxonomicLevelKingdom"]
+    )
+    assert q.facet_by == ["taxonomicLevelKingdom"]
+
+
+def test_wrong_entity_facet_still_names_the_valid_fields():
+    """Cross-entity fields stay in the enum, so the per-entity check catches them
+    -- and has to say what would have worked, or a retry is blind."""
+    with pytest.raises(pydantic.ValidationError) as exc:
+        CatalogQuery(entity="organism", operation="facets", facet_by=["level"])
+
+    message = str(exc.value)
+    assert "valid fields" in message
+    assert "taxonomicLevelKingdom" in message


### PR DESCRIPTION
Reported from the live site: after a reply about Plasmodium species, asking "What organisms do you have?" — one of our own suggestion chips — answered **"The analysis assistant is currently unavailable. Please try again later."**

Nothing was unavailable.

## What happened

The model called `query_catalog` grouping by `taxonomicGroup`, which is a `LIST` field. The validator rejected it *after* the call, pydantic-ai retried once, the model had no way to see the constraint so it made the same call, and the run died. Asked cold the same question works, because the model reaches for kingdom instead — so it only shows up mid-conversation.

Two things were wrong.

**The constraint wasn't in the schema.** `taxonomicGroup` is a perfectly good organism field and `facet_by` took any field name, so the model could only discover the rule by breaking it. `facet_by` is now an enum of the facetable fields, derived from the same declaration as `list_fields` so the two can't drift, and a list field simply isn't offered.

The enum spans both entities, which leaves one reachable case: an assembly-only scalar asked of organisms. That's caught per-entity, and the message now lists only fields that would actually work — the previous version answered with the entity's whole field list, `taxonomicGroup` included, so a model following the suggestion would exhaust its retry on exactly the failure this fixes.

**The error surface was misleading.** pydantic-ai hangs every agent failure off `AgentRunError`, which subclasses `RuntimeError`, so one malformed tool call, a provider 4xx and a usage cap all landed in the branch returning 503 — telling every user the assistant was down and to come back later. Now split by meaning:

| Failure | Status |
|---|---|
| Provider 429 | 429 |
| Provider 5xx | 503 |
| Usage / concurrency cap | 429 |
| Run failure (tool retries exhausted, unparseable output) | 500 |
| Agent not configured | 503 |

## Verification

Replayed the reported conversation against a real backend: **503 before, 200 after**, same session, answer grouped by phylum.

Backend suite 394 pass — the 8 `test_links` failures are pre-existing on `main` (they want a live catalog). New tests cover each status above, that no facet suggestion is ever a list field for the entity being queried, and that a list field is rejected at the schema level.

Evals against **MiniMax-M2.7** on the TACC Tejas endpoint, `catalog_query`, 3 repeats, before and after: **9.0/10 both, per-case identical across all ten**. No regression. Worth being straight about the limit: neither run ever provoked a list-field facet, so the eval demonstrates the change is harmless to model behavior, not that it fixes the bug. The replay and the unit tests are what demonstrate that. Result file committed under `evals/results/`.

## Notes for review

- Two existing tests changed assertions (`test_unknown_facet_and_sort_fields_rejected`, `test_facet_on_list_field_rejected`). Rejection now happens earlier, at the schema, so the old error strings no longer appear. That's the fix working, but it's a real behavior change rather than a cosmetic one.
- `ContentFilterError` subclasses `UnexpectedModelBehavior`, so a content-policy refusal now returns 500 rather than 503. Better than claiming an outage, still not the polite domain redirect #1298 wants — that issue stays open.
- Reproduced and fixed against local `gpt-oss-120b`; prod runs `claude-sonnet-4-6`. Same error surface and trigger, but if you want certainty prod hit this exact validation error, grep for `Assistant chat unavailable (RuntimeError)` — that line carries the traceback. The status-mapping half helps regardless of which `AgentRunError` prod hit.
