### PR TITLE
fix: stop deploys wiping live assistant sessions and harden restore

### DIFF
--- a/app/hooks/useAssistantChat.ts
+++ b/app/hooks/useAssistantChat.ts
@@ -94,9 +94,26 @@ export const useAssistantChat = ({
         setIsComplete(restored.is_complete);
         setHandoffUrl(restored.handoff_url);
       })
-      .catch(() => {
+      .catch((error: unknown) => {
         if (cancelled) return;
-        if (!initialSessionId) localStorage.removeItem(SESSION_KEY);
+        const status =
+          error instanceof HTTPError ? error.response.status : undefined;
+        if (status === 404) {
+          // The session reached the end of its life -- aged out on the server's
+          // TTL, or dropped. Nothing is broken. A pointer we kept in
+          // localStorage is just stale, so bin it and start fresh without
+          // alarming anyone; a session id that came in on the URL was asked for
+          // by name, so say it's gone rather than showing a blank page.
+          if (!initialSessionId) {
+            localStorage.removeItem(SESSION_KEY);
+            return;
+          }
+          setError("That conversation is no longer available.");
+          return;
+        }
+        // Anything else may well be transient with the session still alive on
+        // the server, so hold on to the pointer -- dropping it here would turn
+        // a blip into permanent loss of the conversation.
         setError("Failed to restore the previous conversation.");
       })
       .finally(() => {

--- a/app/hooks/useAssistantChat.ts
+++ b/app/hooks/useAssistantChat.ts
@@ -5,7 +5,6 @@ import type {
   AssistantChatResponse,
   SuggestionChip,
 } from "@repo/shared/services/api-client/types";
-import { HTTPError } from "ky";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 const SESSION_KEY = "brc-assistant-session-id";
@@ -79,6 +78,11 @@ export const useAssistantChat = ({
     if (!sourceId) return;
 
     let cancelled = false;
+    // Adopt the id before the round trip. Keeping a pointer through a failed
+    // restore is pointless if the next message ignores it -- an unset ref sends
+    // session_id: undefined, the server opens a fresh session, and success
+    // overwrites the pointer we were trying to protect.
+    sessionIdRef.current = sourceId;
     // eslint-disable-next-line react-hooks/set-state-in-effect -- react-hooks v7 anti-pattern (setState in effect)
     setIsRestoring(true);
 
@@ -96,19 +100,19 @@ export const useAssistantChat = ({
       })
       .catch((error: unknown) => {
         if (cancelled) return;
-        const status =
-          error instanceof HTTPError ? error.response.status : undefined;
+        const status = httpStatus(error);
         if (status === 404) {
           // The session reached the end of its life -- aged out on the server's
-          // TTL, or dropped. Nothing is broken. A pointer we kept in
-          // localStorage is just stale, so bin it and start fresh without
-          // alarming anyone; a session id that came in on the URL was asked for
-          // by name, so say it's gone rather than showing a blank page.
-          if (!initialSessionId) {
-            localStorage.removeItem(SESSION_KEY);
-            return;
+          // TTL, or dropped. Nothing is broken, and there's nothing to go back
+          // to, so drop the id and let the next message open a fresh session.
+          sessionIdRef.current = null;
+          localStorage.removeItem(SESSION_KEY);
+          // A localStorage pointer going stale is unremarkable, so say nothing.
+          // An id that arrived on the URL was asked for by name -- that one
+          // deserves an answer rather than a blank page.
+          if (initialSessionId) {
+            setError("That conversation is no longer available.");
           }
-          setError("That conversation is no longer available.");
           return;
         }
         // Anything else may well be transient with the session still alive on
@@ -236,9 +240,25 @@ export const useAssistantChat = ({
  * @param error - The caught error
  * @returns A user-facing error string
  */
+/**
+ * Pull the HTTP status off a thrown request error, if it carries one.
+ *
+ * Duck-typed rather than `instanceof HTTPError`: class identity is one
+ * duplicated ky copy or bundling quirk away from failing silently, and the
+ * consequence here is a mis-classified restore. Anything without a numeric
+ * status -- a network failure, an aborted request -- reports undefined, which
+ * every caller treats as the transient case.
+ * @param error - The thrown value from a failed request
+ * @returns The HTTP status, or undefined if the error doesn't carry one
+ */
+function httpStatus(error: unknown): number | undefined {
+  const response = (error as { response?: { status?: unknown } } | null)
+    ?.response;
+  return typeof response?.status === "number" ? response.status : undefined;
+}
+
 function handleChatError(error: unknown): string {
-  const status =
-    error instanceof HTTPError ? error.response?.status : undefined;
+  const status = httpStatus(error);
   const name = (error as { name?: string }).name;
   if (name === "TimeoutError" || status === 504) {
     return "The assistant took too long to respond. Please try again.";

--- a/app/hooks/useAssistantChat.ts
+++ b/app/hooks/useAssistantChat.ts
@@ -5,6 +5,7 @@ import type {
   AssistantChatResponse,
   SuggestionChip,
 } from "@repo/shared/services/api-client/types";
+import { useRouter } from "next/router";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 const SESSION_KEY = "brc-assistant-session-id";
@@ -61,6 +62,7 @@ export const useAssistantChat = ({
   const [saveMessage, setSaveMessage] = useState<string | null>(null);
   const sessionIdRef = useRef<string | null>(initialSessionId ?? null);
   const sendingRef = useRef(false);
+  const router = useRouter();
 
   // Hydrate from either an explicit initialSessionId (URL param, set by the
   // saved-analysis restore flow) or a localStorage-stored session. URL wins.
@@ -108,7 +110,11 @@ export const useAssistantChat = ({
         // 404 it's gone, 403 the signing cookie no longer matches it. Drop the
         // id so the next message opens a fresh session instead of re-failing.
         sessionIdRef.current = null;
-        localStorage.removeItem(SESSION_KEY);
+        // Only clear the pointer if it's still the one that failed -- a newer
+        // session may have replaced it while this request was in flight.
+        if (localStorage.getItem(SESSION_KEY) === sourceId) {
+          localStorage.removeItem(SESSION_KEY);
+        }
         // Only worth mentioning if the id came from the URL; a stale
         // localStorage pointer going bad is routine.
         if (initialSessionId) {
@@ -182,6 +188,20 @@ export const useAssistantChat = ({
     }
     sessionIdRef.current = null;
     localStorage.removeItem(SESSION_KEY);
+    // Drop ?sessionId= as well. It outranks localStorage on mount, so leaving it
+    // means a reload restores the conversation we just walked away from and
+    // orphans whatever replaced it.
+    if (router.query.sessionId) {
+      const query = { ...router.query };
+      delete query.sessionId;
+      router
+        .replace({ pathname: router.pathname, query }, undefined, {
+          shallow: true,
+        })
+        .catch(() => {
+          // Cosmetic: the session is already reset either way.
+        });
+    }
     setMessages([]);
     setSchema(null);
     setSuggestions([]);
@@ -190,7 +210,7 @@ export const useAssistantChat = ({
     setError(null);
     setLastFailedMessage(null);
     setSaveMessage(null);
-  }, []);
+  }, [router]);
 
   const saveAnalysis = useCallback(async (): Promise<void> => {
     if (!sessionIdRef.current) {

--- a/app/hooks/useAssistantChat.ts
+++ b/app/hooks/useAssistantChat.ts
@@ -62,13 +62,6 @@ export const useAssistantChat = ({
   const sessionIdRef = useRef<string | null>(initialSessionId ?? null);
   const sendingRef = useRef(false);
 
-  // Sync the session ref when caller swaps initialSessionId.
-  useEffect(() => {
-    if (initialSessionId !== undefined) {
-      sessionIdRef.current = initialSessionId;
-    }
-  }, [initialSessionId]);
-
   // Hydrate from either an explicit initialSessionId (URL param, set by the
   // saved-analysis restore flow) or a localStorage-stored session. URL wins.
   // Either way we call the restore endpoint so we get computed handoff state
@@ -78,10 +71,8 @@ export const useAssistantChat = ({
     if (!sourceId) return;
 
     let cancelled = false;
-    // Adopt the id before the round trip. Keeping a pointer through a failed
-    // restore is pointless if the next message ignores it -- an unset ref sends
-    // session_id: undefined, the server opens a fresh session, and success
-    // overwrites the pointer we were trying to protect.
+    // Adopt before the round trip: an unset ref sends session_id: undefined, so
+    // a failed restore would open a new session and overwrite the kept pointer.
     sessionIdRef.current = sourceId;
     // eslint-disable-next-line react-hooks/set-state-in-effect -- react-hooks v7 anti-pattern (setState in effect)
     setIsRestoring(true);
@@ -101,24 +92,28 @@ export const useAssistantChat = ({
       .catch((error: unknown) => {
         if (cancelled) return;
         const status = httpStatus(error);
-        if (status === 404) {
-          // The session reached the end of its life -- aged out on the server's
-          // TTL, or dropped. Nothing is broken, and there's nothing to go back
-          // to, so drop the id and let the next message open a fresh session.
-          sessionIdRef.current = null;
-          localStorage.removeItem(SESSION_KEY);
-          // A localStorage pointer going stale is unremarkable, so say nothing.
-          // An id that arrived on the URL was asked for by name -- that one
-          // deserves an answer rather than a blank page.
-          if (initialSessionId) {
-            setError("That conversation is no longer available.");
-          }
+        // No response, a server error, or a throttle: the session is probably
+        // still there, so keep the pointer and let a reload pick it up. Dropping
+        // it here would turn a blip into permanent loss.
+        if (
+          status === undefined ||
+          status >= 500 ||
+          status === 408 ||
+          status === 429
+        ) {
+          setError("Failed to restore the previous conversation.");
           return;
         }
-        // Anything else may well be transient with the session still alive on
-        // the server, so hold on to the pointer -- dropping it here would turn
-        // a blip into permanent loss of the conversation.
-        setError("Failed to restore the previous conversation.");
+        // Any other 4xx and this browser is never getting that session back --
+        // 404 it's gone, 403 the signing cookie no longer matches it. Drop the
+        // id so the next message opens a fresh session instead of re-failing.
+        sessionIdRef.current = null;
+        localStorage.removeItem(SESSION_KEY);
+        // Only worth mentioning if the id came from the URL; a stale
+        // localStorage pointer going bad is routine.
+        if (initialSessionId) {
+          setError("That conversation is no longer available.");
+        }
       })
       .finally(() => {
         if (!cancelled) setIsRestoring(false);
@@ -236,18 +231,10 @@ export const useAssistantChat = ({
 };
 
 /**
- * Map API errors to user-friendly messages.
- * @param error - The caught error
- * @returns A user-facing error string
- */
-/**
  * Pull the HTTP status off a thrown request error, if it carries one.
  *
- * Duck-typed rather than `instanceof HTTPError`: class identity is one
- * duplicated ky copy or bundling quirk away from failing silently, and the
- * consequence here is a mis-classified restore. Anything without a numeric
- * status -- a network failure, an aborted request -- reports undefined, which
- * every caller treats as the transient case.
+ * Duck-typed rather than `instanceof HTTPError` -- a duplicated ky copy would
+ * silently mis-classify a restore. No status reads as the transient case.
  * @param error - The thrown value from a failed request
  * @returns The HTTP status, or undefined if the error doesn't carry one
  */
@@ -257,6 +244,11 @@ function httpStatus(error: unknown): number | undefined {
   return typeof response?.status === "number" ? response.status : undefined;
 }
 
+/**
+ * Map API errors to user-friendly messages.
+ * @param error - The caught error
+ * @returns A user-facing error string
+ */
 function handleChatError(error: unknown): string {
   const status = httpStatus(error);
   const name = (error as { name?: string }).name;

--- a/app/services/assistant-api-client.ts
+++ b/app/services/assistant-api-client.ts
@@ -77,6 +77,12 @@ export const assistantAPIClient = {
   assistantRestore: async (
     sessionId: string
   ): Promise<SessionRestoreResponse> => {
-    return httpClient.get(`assistant/session/${sessionId}`).json();
+    // One attempt only. A Redis outage now surfaces as 500, which is in the
+    // shared retry list, so the default would spend three tries plus any
+    // Retry-After the proxy asks for -- all with a person watching a spinner.
+    // Failing fast is fine here: the pointer is kept and a reload retries.
+    return httpClient
+      .get(`assistant/session/${sessionId}`, { retry: { limit: 0 } })
+      .json();
   },
 };

--- a/app/views/AssistantView/assistantView.tsx
+++ b/app/views/AssistantView/assistantView.tsx
@@ -60,7 +60,10 @@ export const AssistantView = ({ initialSessionId }: Props): JSX.Element => {
 
   if (!isAssistantEnabled) return <Error statusCode={404} />;
 
-  const showReset = messages.length > 0 || schema !== null;
+  // Also show it on an error: a session that can't be restored leaves no
+  // messages and no schema, so without this the one control that clears the bad
+  // id is hidden exactly when it's needed and the only way out is editing the URL.
+  const showReset = messages.length > 0 || schema !== null || error !== null;
   const modelLabel = formatModelLabel(info);
 
   return (

--- a/app/views/AssistantView/assistantView.tsx
+++ b/app/views/AssistantView/assistantView.tsx
@@ -60,9 +60,8 @@ export const AssistantView = ({ initialSessionId }: Props): JSX.Element => {
 
   if (!isAssistantEnabled) return <Error statusCode={404} />;
 
-  // Also show it on an error: a session that can't be restored leaves no
-  // messages and no schema, so without this the one control that clears the bad
-  // id is hidden exactly when it's needed and the only way out is editing the URL.
+  // On error there are no messages and no schema, which would hide Reset
+  // exactly when it's the only way to clear a bad session id.
   const showReset = messages.length > 0 || schema !== null || error !== null;
   const modelLabel = formatModelLabel(info);
 

--- a/backend/api/app/core/cache.py
+++ b/backend/api/app/core/cache.py
@@ -7,6 +7,14 @@ import redis.asyncio as redis
 
 logger = logging.getLogger(__name__)
 
+# Key namespaces holding cached upstream responses, safe to drop on deploy.
+# Everything else in the database is live state -- assistant sessions
+# (assistant:session:*), auth sessions and in-flight PKCE (auth:*), rate-limit
+# counters (ratelimit:*) -- and has to survive a restart. New cache namespaces
+# belong here; missing one only means it ages out via its TTL instead of being
+# dropped at boot, which is the safe direction to be wrong in.
+CACHE_KEY_PATTERNS = ("ena:*", "v1:*")
+
 
 class CacheService:
     """Redis-based cache service with TTL support and key management"""
@@ -71,8 +79,28 @@ class CacheService:
             logger.error(f"Cache clear pattern error for {pattern}: {e}")
             return 0
 
+    async def clear_caches(self) -> int:
+        """Drop cached upstream responses, leaving live state intact.
+
+        Scoped to CACHE_KEY_PATTERNS rather than flushing the database, because
+        the same Redis holds sessions and rate-limit counters. Scans rather than
+        KEYS so a large keyspace doesn't block the server.
+        """
+        cleared = 0
+        try:
+            for pattern in CACHE_KEY_PATTERNS:
+                keys = [key async for key in self.redis.scan_iter(match=pattern)]
+                if keys:
+                    cleared += await self.redis.delete(*keys)
+        except redis.RedisError as e:
+            logger.error(f"Cache clear error: {e}")
+        return cleared
+
     async def flush_all(self) -> bool:
-        """Flush all keys from the current database"""
+        """Flush every key in the database, live state included.
+
+        Destructive -- clear_caches() is the deploy-safe version.
+        """
         try:
             await self.redis.flushdb()
             logger.info("Cache flushed successfully")

--- a/backend/api/app/core/cache.py
+++ b/backend/api/app/core/cache.py
@@ -7,17 +7,14 @@ import redis.asyncio as redis
 
 logger = logging.getLogger(__name__)
 
-# Key namespaces holding cached upstream responses, safe to drop on deploy.
-# Everything else in the database is live state -- assistant sessions
-# (assistant:session:*), auth sessions and in-flight PKCE (auth:*), rate-limit
-# counters (ratelimit:*) -- and has to survive a restart. New cache namespaces
-# belong here; missing one only means it ages out via its TTL instead of being
-# dropped at boot, which is the safe direction to be wrong in.
+# Cached upstream responses, safe to drop on deploy. Everything else in this
+# database is live state -- assistant and auth sessions, in-flight PKCE,
+# rate-limit counters -- and has to survive a restart. Add new cache namespaces
+# here; missing one only means it ages out on its TTL, the safe way to be wrong.
 CACHE_KEY_PATTERNS = ("ena:*", "v1:*")
 
-# Deletes go out in batches so neither the DELETE argument list nor our own key
-# buffer grows with the size of the namespace -- this Redis also serves live
-# session and rate-limit traffic on the same event loop.
+# Bounds both the DELETE argument list and our own key buffer, so neither grows
+# with the size of the namespace.
 CLEAR_BATCH_SIZE = 500
 
 
@@ -28,13 +25,10 @@ class CacheService:
         self.redis = redis.from_url(redis_url, decode_responses=True)
 
     async def get(self, key: str) -> Optional[Any]:
-        """Get a value from cache by key"""
+        """Get a value from cache by key, or None if it can't be read"""
         try:
-            value = await self.redis.get(key)
-            if value:
-                return json.loads(value)
-            return None
-        except (redis.RedisError, json.JSONDecodeError) as e:
+            return await self.get_strict(key)
+        except redis.RedisError as e:
             logger.error(f"Cache get error for key {key}: {e}")
             return None
 
@@ -48,11 +42,7 @@ class CacheService:
         the difference. A genuine miss, or a value that won't decode, is still
         None -- there's nothing to recover in either case.
         """
-        try:
-            value = await self.redis.get(key)
-        except redis.RedisError:
-            logger.exception(f"Cache read failed for key {key}")
-            raise
+        value = await self.redis.get(key)
         if not value:
             return None
         try:
@@ -97,50 +87,42 @@ class CacheService:
             return -2
 
     async def clear_pattern(self, pattern: str) -> int:
-        """Clear all keys matching a pattern"""
+        """Clear all keys matching a pattern.
+
+        Scans rather than using KEYS, and deletes in batches, so neither the
+        server nor this process is held up in proportion to the keyspace.
+        """
+        cleared = 0
         try:
-            keys = await self.redis.keys(pattern)
-            if keys:
-                return await self.redis.delete(*keys)
-            return 0
+            batch: list[str] = []
+            # MATCH filters server-side but still walks the whole keyspace, and
+            # SCAN's default COUNT of 10 would make that thousands of round
+            # trips on a warm cache. Ask for the batch size we're going to
+            # delete anyway.
+            async for key in self.redis.scan_iter(
+                match=pattern, count=CLEAR_BATCH_SIZE
+            ):
+                batch.append(key)
+                if len(batch) >= CLEAR_BATCH_SIZE:
+                    cleared += await self.redis.delete(*batch)
+                    batch.clear()
+            if batch:
+                cleared += await self.redis.delete(*batch)
         except redis.RedisError as e:
             logger.error(f"Cache clear pattern error for {pattern}: {e}")
-            return 0
+        return cleared
 
     async def clear_caches(self) -> int:
         """Drop cached upstream responses, leaving live state intact.
 
-        Scoped to CACHE_KEY_PATTERNS rather than flushing the database, because
-        the same Redis holds sessions and rate-limit counters. Scans rather than
-        KEYS so a large keyspace doesn't block the server.
+        Scoped to CACHE_KEY_PATTERNS rather than flushing the database: the same
+        Redis holds sessions and rate-limit counters, and a deploy must not take
+        those with it.
         """
         cleared = 0
-        try:
-            for pattern in CACHE_KEY_PATTERNS:
-                batch: list[str] = []
-                async for key in self.redis.scan_iter(match=pattern):
-                    batch.append(key)
-                    if len(batch) >= CLEAR_BATCH_SIZE:
-                        cleared += await self.redis.delete(*batch)
-                        batch.clear()
-                if batch:
-                    cleared += await self.redis.delete(*batch)
-        except redis.RedisError as e:
-            logger.error(f"Cache clear error: {e}")
+        for pattern in CACHE_KEY_PATTERNS:
+            cleared += await self.clear_pattern(pattern)
         return cleared
-
-    async def flush_all(self) -> bool:
-        """Flush every key in the database, live state included.
-
-        Destructive -- clear_caches() is the deploy-safe version.
-        """
-        try:
-            await self.redis.flushdb()
-            logger.info("Cache flushed successfully")
-            return True
-        except redis.RedisError as e:
-            logger.error(f"Cache flush error: {e}")
-            return False
 
     async def get_stats(self) -> Dict[str, Any]:
         """Get cache statistics"""

--- a/backend/api/app/core/cache.py
+++ b/backend/api/app/core/cache.py
@@ -15,6 +15,11 @@ logger = logging.getLogger(__name__)
 # dropped at boot, which is the safe direction to be wrong in.
 CACHE_KEY_PATTERNS = ("ena:*", "v1:*")
 
+# Deletes go out in batches so neither the DELETE argument list nor our own key
+# buffer grows with the size of the namespace -- this Redis also serves live
+# session and rate-limit traffic on the same event loop.
+CLEAR_BATCH_SIZE = 500
+
 
 class CacheService:
     """Redis-based cache service with TTL support and key management"""
@@ -31,6 +36,29 @@ class CacheService:
             return None
         except (redis.RedisError, json.JSONDecodeError) as e:
             logger.error(f"Cache get error for key {key}: {e}")
+            return None
+
+    async def get_strict(self, key: str) -> Optional[Any]:
+        """Read a key, telling "absent" apart from "Redis unavailable".
+
+        get() answers None to both, which is the right call for a cache and the
+        wrong one for state that merely lives in one: a Redis blip would be
+        indistinguishable from an expired session, and the caller would tell the
+        user their conversation is gone. Raises RedisError so callers can tell
+        the difference. A genuine miss, or a value that won't decode, is still
+        None -- there's nothing to recover in either case.
+        """
+        try:
+            value = await self.redis.get(key)
+        except redis.RedisError:
+            logger.exception(f"Cache read failed for key {key}")
+            raise
+        if not value:
+            return None
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError as e:
+            logger.error(f"Cache value for key {key} is not valid JSON: {e}")
             return None
 
     async def set(self, key: str, value: Any, ttl: int = 3600) -> bool:
@@ -89,9 +117,14 @@ class CacheService:
         cleared = 0
         try:
             for pattern in CACHE_KEY_PATTERNS:
-                keys = [key async for key in self.redis.scan_iter(match=pattern)]
-                if keys:
-                    cleared += await self.redis.delete(*keys)
+                batch: list[str] = []
+                async for key in self.redis.scan_iter(match=pattern):
+                    batch.append(key)
+                    if len(batch) >= CLEAR_BATCH_SIZE:
+                        cleared += await self.redis.delete(*batch)
+                        batch.clear()
+                if batch:
+                    cleared += await self.redis.delete(*batch)
         except redis.RedisError as e:
             logger.error(f"Cache clear error: {e}")
         return cleared

--- a/backend/api/app/main.py
+++ b/backend/api/app/main.py
@@ -60,8 +60,8 @@ def create_app() -> FastAPI:
     async def lifespan(app: FastAPI):
         async with mcp_app.lifespan(app):
             cache_service = get_cache_service()
-            await cache_service.flush_all()
-            logger.info("Cache cleared on startup")
+            cleared = await cache_service.clear_caches()
+            logger.info("Cleared %d cached response keys on startup", cleared)
 
             await init_db()
 

--- a/backend/api/app/services/session_service.py
+++ b/backend/api/app/services/session_service.py
@@ -42,7 +42,10 @@ class SessionService:
         return state
 
     async def get_session(self, session_id: str) -> Optional[SessionState]:
-        raw = await self.cache.get(self._key(session_id))
+        # Strict read: a Redis outage has to surface as an error rather than as
+        # None. get() fails open, which would report a live conversation as
+        # expired and prompt the client to discard its only reference to it.
+        raw = await self.cache.get_strict(self._key(session_id))
         if raw is None:
             return None
         try:

--- a/backend/api/evals/tasks.py
+++ b/backend/api/evals/tasks.py
@@ -119,6 +119,11 @@ class _InMemoryCache:
     async def get(self, key: str) -> Optional[Any]:
         return self._store.get(key)
 
+    async def get_strict(self, key: str) -> Optional[Any]:
+        # SessionService reads through this one. A dict has no backend to fail,
+        # so there's nothing to raise -- a miss is just a miss.
+        return self._store.get(key)
+
     async def set(self, key: str, value: Any, ttl: int = 3600) -> bool:  # noqa: ARG002
         self._store[key] = value
         return True

--- a/backend/api/tests/test_assistant_endpoints.py
+++ b/backend/api/tests/test_assistant_endpoints.py
@@ -29,7 +29,7 @@ def app_with_stubbed_agent(tmp_path, monkeypatch):
     monkeypatch.setenv("AI_API_KEY", "stub")
 
     fake_cache = MagicMock()
-    fake_cache.flush_all = AsyncMock()
+    fake_cache.clear_caches = AsyncMock(return_value=0)
     fake_cache.close = AsyncMock()
     fake_auth = MagicMock()
     fake_auth.close = AsyncMock()

--- a/backend/api/tests/test_cache_clear.py
+++ b/backend/api/tests/test_cache_clear.py
@@ -1,0 +1,62 @@
+import fnmatch
+from typing import AsyncIterator
+
+import pytest
+
+from app.core.cache import CacheService
+
+
+class FakeRedis:
+    """Minimal stand-in supporting the scan/delete pair clear_caches uses."""
+
+    def __init__(self, keys: dict[str, str]):
+        self.values = dict(keys)
+
+    async def scan_iter(self, match: str) -> AsyncIterator[str]:
+        for key in list(self.values):
+            if fnmatch.fnmatch(key, match):
+                yield key
+
+    async def delete(self, *keys: str) -> int:
+        return sum(self.values.pop(key, None) is not None for key in keys)
+
+
+def _service(keys: dict[str, str]) -> CacheService:
+    service = CacheService.__new__(CacheService)
+    service.redis = FakeRedis(keys)
+    return service
+
+
+@pytest.mark.asyncio
+async def test_clear_caches_drops_cached_responses_and_keeps_live_state():
+    """A deploy must drop stale upstream caches without logging anyone out."""
+    service = _service(
+        {
+            "ena:taxonomy:5833:limit:10": "cached",
+            "ena:study:PRJEB1234": "cached",
+            "v1:assemblies:links": "cached",
+            "v1:organisms:links:5833": "cached",
+            "assistant:session:abc123": "live conversation",
+            "auth:session:def456": "logged-in user",
+            "auth:pkce:state789": "in-flight login",
+            "ratelimit:203.0.113.5": "7",
+        }
+    )
+
+    cleared = await service.clear_caches()
+
+    assert cleared == 4
+    assert sorted(service.redis.values) == [
+        "assistant:session:abc123",
+        "auth:pkce:state789",
+        "auth:session:def456",
+        "ratelimit:203.0.113.5",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_clear_caches_is_a_noop_when_only_state_is_present():
+    service = _service({"assistant:session:abc123": "live conversation"})
+
+    assert await service.clear_caches() == 0
+    assert "assistant:session:abc123" in service.redis.values

--- a/backend/api/tests/test_cache_clear.py
+++ b/backend/api/tests/test_cache_clear.py
@@ -13,8 +13,12 @@ class FakeRedis:
     def __init__(self, keys: dict[str, str]):
         self.values = dict(keys)
         self.delete_batch_sizes: list[int] = []
+        self.scan_counts: list[int | None] = []
 
-    async def scan_iter(self, match: str) -> AsyncIterator[str]:
+    async def scan_iter(
+        self, match: str, count: int | None = None
+    ) -> AsyncIterator[str]:
+        self.scan_counts.append(count)
         # Snapshot the key list the way a real cursor scan does not: this fake
         # can't model concurrent mutation, so tests here cover selection and
         # batching only.
@@ -79,13 +83,20 @@ async def test_clear_caches_batches_its_deletes():
     assert cleared == 1200
     assert service.redis.values == {}
     assert max(service.redis.delete_batch_sizes) <= CLEAR_BATCH_SIZE
+    # SCAN's default COUNT of 10 would be thousands of round trips on a warm
+    # cache, all on the connection live traffic is using.
+    assert service.redis.scan_counts == [CLEAR_BATCH_SIZE] * len(
+        service.redis.scan_counts
+    )
 
 
-def test_startup_uses_the_scoped_clear_and_not_a_full_flush():
-    """The bug was the lifespan calling flush_all(). Assert on the source so a
-    future edit can't quietly reintroduce it -- exercising the real lifespan
-    needs Redis, a DB and the MCP app, which is why this regressed unnoticed."""
+def test_startup_clears_caches_rather_than_flushing_the_database():
+    """#1523 was the lifespan calling flush_all(), which took live sessions with
+    it. Asserted against the source because main.py binds get_cache_service at
+    import time, so a fixture can't substitute the cache the lifespan actually
+    uses -- which is also why no existing test caught the original bug."""
     source = (Path(__file__).resolve().parents[1] / "app" / "main.py").read_text()
 
     assert "clear_caches()" in source
-    assert "flush_all()" not in source
+    assert "flushdb" not in source
+    assert "flush_all" not in source

--- a/backend/api/tests/test_cache_clear.py
+++ b/backend/api/tests/test_cache_clear.py
@@ -1,9 +1,10 @@
 import fnmatch
+from pathlib import Path
 from typing import AsyncIterator
 
 import pytest
 
-from app.core.cache import CacheService
+from app.core.cache import CLEAR_BATCH_SIZE, CacheService
 
 
 class FakeRedis:
@@ -11,13 +12,18 @@ class FakeRedis:
 
     def __init__(self, keys: dict[str, str]):
         self.values = dict(keys)
+        self.delete_batch_sizes: list[int] = []
 
     async def scan_iter(self, match: str) -> AsyncIterator[str]:
+        # Snapshot the key list the way a real cursor scan does not: this fake
+        # can't model concurrent mutation, so tests here cover selection and
+        # batching only.
         for key in list(self.values):
             if fnmatch.fnmatch(key, match):
                 yield key
 
     async def delete(self, *keys: str) -> int:
+        self.delete_batch_sizes.append(len(keys))
         return sum(self.values.pop(key, None) is not None for key in keys)
 
 
@@ -60,3 +66,26 @@ async def test_clear_caches_is_a_noop_when_only_state_is_present():
 
     assert await service.clear_caches() == 0
     assert "assistant:session:abc123" in service.redis.values
+
+
+@pytest.mark.asyncio
+async def test_clear_caches_batches_its_deletes():
+    """One unbounded DELETE would scale with the namespace, on a Redis that is
+    also serving live session and rate-limit traffic."""
+    service = _service({f"ena:key{i}": "cached" for i in range(1200)})
+
+    cleared = await service.clear_caches()
+
+    assert cleared == 1200
+    assert service.redis.values == {}
+    assert max(service.redis.delete_batch_sizes) <= CLEAR_BATCH_SIZE
+
+
+def test_startup_uses_the_scoped_clear_and_not_a_full_flush():
+    """The bug was the lifespan calling flush_all(). Assert on the source so a
+    future edit can't quietly reintroduce it -- exercising the real lifespan
+    needs Redis, a DB and the MCP app, which is why this regressed unnoticed."""
+    source = (Path(__file__).resolve().parents[1] / "app" / "main.py").read_text()
+
+    assert "clear_caches()" in source
+    assert "flush_all()" not in source

--- a/backend/api/tests/test_mcp.py
+++ b/backend/api/tests/test_mcp.py
@@ -35,7 +35,7 @@ def _make_app(tmp_path, monkeypatch, sra_mirror_path=None):
         monkeypatch.setenv("SRA_MIRROR_PATH", sra_mirror_path)
 
     fake_cache = MagicMock()
-    fake_cache.flush_all = AsyncMock()
+    fake_cache.clear_caches = AsyncMock(return_value=0)
     fake_cache.close = AsyncMock()
     fake_auth = MagicMock()
     fake_auth.close = AsyncMock()

--- a/backend/api/tests/test_session_service.py
+++ b/backend/api/tests/test_session_service.py
@@ -116,3 +116,24 @@ async def test_get_session_still_returns_none_for_a_genuine_miss():
     service = SessionService(cache)
 
     assert await service.get_session("never-existed") is None
+
+
+@pytest.mark.asyncio
+async def test_eval_harness_cache_double_satisfies_session_service():
+    """The evals run SessionService against their own dict-backed cache.
+
+    It's duck-typed, so adding a read method to CacheService breaks it at
+    runtime with nothing at import time to catch it -- get_strict already did
+    once. Round-trip a session through it so the next one fails here instead.
+    """
+    from evals.tasks import _InMemoryCache
+
+    service = SessionService(_InMemoryCache())
+    state = await service.create_session(
+        messages=[ChatMessage(role=MessageRole.USER, content="hello")],
+    )
+
+    loaded = await service.get_session(state.session_id)
+
+    assert loaded is not None
+    assert loaded.messages[0].content == "hello"

--- a/backend/api/tests/test_session_service.py
+++ b/backend/api/tests/test_session_service.py
@@ -1,17 +1,24 @@
 import pytest
+import redis.asyncio as redis
 
 from app.models.assistant import AnalysisSchema, ChatMessage, MessageRole
 from app.services.session_service import SessionService
 
 
 class FakeCache:
-    def __init__(self):
+    def __init__(self, fail_reads: bool = False):
         self.values: dict[str, dict] = {}
+        self.fail_reads = fail_reads
 
     async def delete(self, key: str) -> bool:
         return self.values.pop(key, None) is not None
 
     async def get(self, key: str):
+        return self.values.get(key)
+
+    async def get_strict(self, key: str):
+        if self.fail_reads:
+            raise redis.RedisError("redis is unreachable")
         return self.values.get(key)
 
     async def set(self, key: str, value, ttl: int = 3600) -> bool:
@@ -81,3 +88,31 @@ async def test_claim_session_raises_keyerror_for_missing_session():
 
     with pytest.raises(KeyError):
         await service.claim_session("does-not-exist", "user-a")
+
+
+@pytest.mark.asyncio
+async def test_get_session_surfaces_redis_failure_instead_of_reporting_a_miss():
+    """A Redis outage must not be indistinguishable from an expired session.
+
+    If it returns None the endpoint answers 404, and the client takes that as
+    "this conversation is gone" and discards its only pointer to a session that
+    is still very much alive.
+    """
+    cache = FakeCache()
+    service = SessionService(cache)
+    state = await service.create_session(
+        messages=[ChatMessage(role=MessageRole.USER, content="hello")],
+    )
+
+    cache.fail_reads = True
+
+    with pytest.raises(redis.RedisError):
+        await service.get_session(state.session_id)
+
+
+@pytest.mark.asyncio
+async def test_get_session_still_returns_none_for_a_genuine_miss():
+    cache = FakeCache()
+    service = SessionService(cache)
+
+    assert await service.get_session("never-existed") is None

--- a/backend/api/tests/test_user_persistence_api.py
+++ b/backend/api/tests/test_user_persistence_api.py
@@ -98,7 +98,7 @@ def persistence_app(tmp_path, monkeypatch):
     dependencies.reset_all_services()
 
     fake_cache = MagicMock()
-    fake_cache.flush_all = AsyncMock()
+    fake_cache.clear_caches = AsyncMock(return_value=0)
     fake_cache.close = AsyncMock()
     fake_auth = MagicMock()
     fake_auth.close = AsyncMock()

--- a/backend/api/tests/test_workflow_runs_api.py
+++ b/backend/api/tests/test_workflow_runs_api.py
@@ -40,7 +40,7 @@ def workflow_runs_client(tmp_path, monkeypatch):
     dependencies.reset_all_services()
 
     fake_cache = MagicMock()
-    fake_cache.flush_all = AsyncMock()
+    fake_cache.clear_caches = AsyncMock(return_value=0)
     fake_cache.close = AsyncMock()
     fake_auth = MagicMock()
     fake_auth.close = AsyncMock()

--- a/tests/hooks/useAssistantChat.restore.test.ts
+++ b/tests/hooks/useAssistantChat.restore.test.ts
@@ -1,0 +1,95 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useAssistantChat } from "../../app/hooks/useAssistantChat";
+import { assistantAPIClient } from "../../app/services/assistant-api-client";
+
+jest.mock("../../app/services/assistant-api-client", () => ({
+  assistantAPIClient: {
+    assistantChat: jest.fn(),
+    assistantRestore: jest.fn(),
+  },
+}));
+// Keeps ESM-only ky out of the jest module graph, which it enters through the
+// shared client the hook imports for saved analyses.
+jest.mock("@repo/shared/services/api-client/api-client", () => ({
+  apiClient: { saveAnalysis: jest.fn() },
+}));
+
+const mockClient = assistantAPIClient as jest.Mocked<typeof assistantAPIClient>;
+
+const SESSION_KEY = "brc-assistant-session-id";
+const STORED_ID = "stored1111222233334444555566667777";
+
+/**
+ * Shaped like the ky HTTPError the client throws -- the hook reads `.response.status`.
+ * @param status - HTTP status to attach
+ * @returns An error carrying that status
+ */
+function httpError(status: number): Error & { response: { status: number } } {
+  return Object.assign(new Error(`${status}`), { response: { status } });
+}
+
+describe("useAssistantChat restore", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  test("a 404 on a stored session clears the pointer without alarming the user", async () => {
+    localStorage.setItem(SESSION_KEY, STORED_ID);
+    mockClient.assistantRestore.mockRejectedValue(httpError(404));
+
+    const { result } = renderHook(() => useAssistantChat({}));
+
+    await waitFor(() => expect(result.current.isRestoring).toBe(false));
+    expect(localStorage.getItem(SESSION_KEY)).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  test("a 404 on a session named in the URL says so rather than rendering blank", async () => {
+    mockClient.assistantRestore.mockRejectedValue(httpError(404));
+
+    const { result } = renderHook(() =>
+      useAssistantChat({ initialSessionId: STORED_ID })
+    );
+
+    await waitFor(() => expect(result.current.isRestoring).toBe(false));
+    expect(result.current.error).toMatch(/no longer available/i);
+  });
+
+  test("a 5xx keeps the pointer -- the session is probably still alive", async () => {
+    localStorage.setItem(SESSION_KEY, STORED_ID);
+    mockClient.assistantRestore.mockRejectedValue(httpError(503));
+
+    const { result } = renderHook(() => useAssistantChat({}));
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(localStorage.getItem(SESSION_KEY)).toBe(STORED_ID);
+  });
+
+  test("after a 5xx the next message continues the kept session, not a new one", async () => {
+    // Preserving the pointer is pointless if the next send ignores it: an
+    // unadopted id sends session_id undefined, the server opens a fresh session
+    // and success overwrites the very pointer we kept.
+    localStorage.setItem(SESSION_KEY, STORED_ID);
+    mockClient.assistantRestore.mockRejectedValue(httpError(503));
+    mockClient.assistantChat.mockResolvedValue({
+      handoff_url: null,
+      is_complete: false,
+      reply: "ok",
+      schema_state: null,
+      session_id: STORED_ID,
+      suggestions: [],
+    } as unknown as Awaited<ReturnType<typeof mockClient.assistantChat>>);
+
+    const { result } = renderHook(() => useAssistantChat({}));
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+
+    await act(async () => {
+      await result.current.sendMessage("still there?");
+    });
+
+    expect(mockClient.assistantChat).toHaveBeenCalledWith(
+      expect.objectContaining({ session_id: STORED_ID })
+    );
+  });
+});

--- a/tests/hooks/useAssistantChat.restore.test.ts
+++ b/tests/hooks/useAssistantChat.restore.test.ts
@@ -5,8 +5,22 @@ import { assistantAPIClient } from "../../app/services/assistant-api-client";
 jest.mock("../../app/services/assistant-api-client", () => ({
   assistantAPIClient: {
     assistantChat: jest.fn(),
+    assistantDeleteSession: jest.fn().mockResolvedValue(undefined),
     assistantRestore: jest.fn(),
   },
+}));
+const mockReplace = jest.fn().mockResolvedValue(true);
+let mockQuery: Record<string, string> = {};
+jest.mock("next/router", () => ({
+  useRouter: (): {
+    pathname: string;
+    query: Record<string, string>;
+    replace: jest.Mock;
+  } => ({
+    pathname: "/assistant",
+    query: mockQuery,
+    replace: mockReplace,
+  }),
 }));
 // Keeps ESM-only ky out of the jest module graph, which it enters through the
 // shared client the hook imports for saved analyses.
@@ -32,6 +46,7 @@ describe("useAssistantChat restore", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     localStorage.clear();
+    mockQuery = {};
   });
 
   test("a 404 on a stored session clears the pointer without alarming the user", async () => {
@@ -112,6 +127,27 @@ describe("useAssistantChat restore", () => {
 
     expect(mockClient.assistantChat).toHaveBeenCalledWith(
       expect.objectContaining({ session_id: STORED_ID })
+    );
+  });
+
+  test("reset strips ?sessionId= so a reload can't resurrect the old session", async () => {
+    // initialSessionId outranks localStorage on mount. Leaving the query param
+    // behind means reloading restores the conversation the user just left and
+    // orphans whatever they started instead.
+    mockQuery = { sessionId: STORED_ID };
+    mockClient.assistantRestore.mockRejectedValue(httpError(503));
+
+    const { result } = renderHook(() =>
+      useAssistantChat({ initialSessionId: STORED_ID })
+    );
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+
+    act(() => result.current.resetSession());
+
+    expect(mockReplace).toHaveBeenCalledWith(
+      expect.objectContaining({ query: {} }),
+      undefined,
+      { shallow: true }
     );
   });
 });

--- a/tests/hooks/useAssistantChat.restore.test.ts
+++ b/tests/hooks/useAssistantChat.restore.test.ts
@@ -56,6 +56,28 @@ describe("useAssistantChat restore", () => {
     expect(result.current.error).toMatch(/no longer available/i);
   });
 
+  test("a 403 drops the pointer -- this browser can never restore that session", async () => {
+    // The signing cookie no longer matches the id, which is permanent. Keeping
+    // it would re-send the same id on every message and wedge the chat.
+    localStorage.setItem(SESSION_KEY, STORED_ID);
+    mockClient.assistantRestore.mockRejectedValue(httpError(403));
+
+    const { result } = renderHook(() => useAssistantChat({}));
+
+    await waitFor(() => expect(result.current.isRestoring).toBe(false));
+    expect(localStorage.getItem(SESSION_KEY)).toBeNull();
+  });
+
+  test("a 429 keeps the pointer -- throttling is transient", async () => {
+    localStorage.setItem(SESSION_KEY, STORED_ID);
+    mockClient.assistantRestore.mockRejectedValue(httpError(429));
+
+    const { result } = renderHook(() => useAssistantChat({}));
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(localStorage.getItem(SESSION_KEY)).toBe(STORED_ID);
+  });
+
   test("a 5xx keeps the pointer -- the session is probably still alive", async () => {
     localStorage.setItem(SESSION_KEY, STORED_ID);
     mockClient.assistantRestore.mockRejectedValue(httpError(503));


### PR DESCRIPTION
Closes #1523 and #1524. Both surfaced while smoke-testing the assistant ahead of dropping the feature flag; independent of that branch and mergeable on its own.

## Deploys were wiping live sessions (#1523)

The lifespan called `cache_service.flush_all()`, which is a bare `redis.flushdb()`. Assistant sessions live in that same database under `assistant:session:*`, so **every restart destroyed every in-flight conversation** — in prod, every deploy boots everyone mid-chat. Auth sessions, in-flight PKCE and rate-limit counters went with it.

I confirmed this the hard way: I accidentally started the old build against the same Redis mid-testing and took `dbsize` to 0, including eight `celery-task-meta-*` keys belonging to an unrelated app sharing the instance.

Replaced with `clear_caches()`, scoped to the namespaces holding cached upstream responses (`ena:*`, `v1:*`). Allowlist rather than denylist deliberately: forget to add a new *cache* prefix and it ages out on its TTL; forget to exclude a new *state* prefix and you silently delete live data. `clear_pattern()` gained the scan-and-batch loop and `clear_caches()` calls it, so there's one implementation of "delete by pattern" rather than a good one sitting beside a blocking one. `SCAN` asks for `COUNT` instead of defaulting to 10 — on a warm cache that's tens of round trips instead of thousands. `flush_all()` is deleted: callerless, and the exact footgun that caused this.

## Restore couldn't tell "expired" from "broken" (#1524)

Two problems, inverses of each other. A 404 is the ordinary end of a session's life, but produced an error banner on a freshly-loaded page. A 5xx is the real failure, and was the one case where dropping the localStorage pointer was actively harmful — the session is very likely still alive, so it turned a blip into permanent loss.

Now split on meaning: no response, 5xx, 408 or 429 keeps the pointer and shows a retryable error; any other 4xx drops it. That matters for **403** specifically — the signing cookie no longer matching is permanent, and treating it as transient would have re-sent the same id on every message and wedged the chat.

Three supporting fixes, each of which the split needs to be worth anything:

- **A Redis outage now surfaces as an error, not a 404.** `CacheService.get()` fails open and returned `None`, which the endpoint reported as "session not found" — so the exact failure this branch exists to survive was telling the client its conversation was gone. Sessions read through `get_strict()`, which propagates `RedisError`.
- **The session id is adopted before the request.** It was only set after a *successful* restore, so after a failure the next message went out with no id, the server opened a fresh session, and success overwrote the pointer we'd just protected.
- **Reset is reachable and complete.** "New Conversation" now shows on error (a failed restore leaves no messages and no schema, which is exactly what used to hide it), and reset strips `?sessionId=` — that param outranks localStorage on mount, so reloading after a reset resurrected the abandoned session and orphaned the new one.

## Verification

End to end against real Redis and a real browser: seeded session + cache keys, restarted the API — session, auth, rate-limit and the unrelated app's keys all survived, only `ena:*`/`v1:*` cleared, restore returned 200 and the conversation rendered. Stale id → no banner, pointer cleared. Backend stopped mid-restore → error shown, pointer **kept**, reset visible; backend back + reload → conversation recovered.

Backend 390 pass (8 `test_links` pre-existing on `main`), frontend 588 pass, tsc and ESLint clean. New tests cover the cache allowlist and batching, that a Redis failure is distinguishable from a miss, and the restore state machine across 404/403/429/5xx for both stored and URL sessions.

## Notes for review

- Adding `get_strict()` broke the evals harness, whose dict-backed cache double is duck-typed against `CacheService`. Fixed, plus a test that round-trips a session through it so the next method addition fails in CI rather than at eval time.
- Status extraction is duck-typed rather than `instanceof HTTPError` — class identity is one duplicated ky copy away from silently mis-classifying, and ky is ESM-only so `instanceof` can't be unit-tested without changing shared jest config. This also removed a duplicated check.
- `assistantRestore` opts out of the shared ky retry policy. Converting a Redis outage to a 500 quietly opted it into three attempts plus any `Retry-After`, with a person watching a spinner.
- **Deliberately out of scope:** `SessionService._save()` is still fail-open, so a Redis blip can silently drop a turn — the same bug on the write side, and arguably the more damaging half. Also worth a follow-up: moving sessions off `CacheService` onto their own Redis client, the way `AuthService` already does.
