### PR TITLE
feat: remove the assistant feature flag and add a Feedback button

### DIFF
--- a/app/views/AssistantView/assistantView.styles.ts
+++ b/app/views/AssistantView/assistantView.styles.ts
@@ -15,6 +15,13 @@ export const SectionContent = styled(Stack)`
   width: calc(100% - 32px);
 `;
 
+export const ActionsRow = styled(Box)({
+  alignItems: "center",
+  display: "flex",
+  justifyContent: "space-between",
+  paddingBottom: "8px",
+});
+
 export const TwoPanelLayout = styled(Box)({
   "@media (min-width: 960px)": {
     flexDirection: "row",

--- a/app/views/AssistantView/assistantView.tsx
+++ b/app/views/AssistantView/assistantView.tsx
@@ -1,13 +1,14 @@
 import { ChatPanel, SchemaPanel } from "@/components/Assistant";
+import { config } from "@/config/config";
 import { useAssistantChat } from "@/hooks/useAssistantChat";
 import { assistantAPIClient } from "@/services/assistant-api-client";
-import { useFeatureFlag } from "@databiosphere/findable-ui/lib/hooks/useFeatureFlag/useFeatureFlag";
+import FeedbackOutlinedIcon from "@mui/icons-material/FeedbackOutlined";
 import RestartAltIcon from "@mui/icons-material/RestartAlt";
 import { Button } from "@mui/material";
 import type { AssistantInfoResponse } from "@repo/shared/services/api-client/types";
-import Error from "next/error";
 import { type JSX, useEffect, useState } from "react";
 import {
+  ActionsRow,
   AssistantDisclaimer,
   ChatColumn,
   SchemaColumn,
@@ -22,7 +23,6 @@ interface Props {
 }
 
 export const AssistantView = ({ initialSessionId }: Props): JSX.Element => {
-  const isAssistantEnabled = useFeatureFlag("assistant");
   const {
     error,
     handoffUrl,
@@ -41,9 +41,11 @@ export const AssistantView = ({ initialSessionId }: Props): JSX.Element => {
     initialSessionId,
   });
   const [info, setInfo] = useState<AssistantInfoResponse | null>(null);
+  // Read per-site rather than importing one site's config, so the button can
+  // never point at another tenant's form.
+  const { supportUrl } = config();
 
   useEffect(() => {
-    if (!isAssistantEnabled) return;
     let cancelled = false;
     assistantAPIClient
       .assistantInfo()
@@ -56,9 +58,7 @@ export const AssistantView = ({ initialSessionId }: Props): JSX.Element => {
     return (): void => {
       cancelled = true;
     };
-  }, [isAssistantEnabled]);
-
-  if (!isAssistantEnabled) return <Error statusCode={404} />;
+  }, []);
 
   // On error there are no messages and no schema, which would hide Reset
   // exactly when it's the only way to clear a bad session id.
@@ -69,15 +69,31 @@ export const AssistantView = ({ initialSessionId }: Props): JSX.Element => {
     <StyledSection>
       <SectionContent>
         <Headline />
-        <Button
-          onClick={resetSession}
-          size="small"
-          startIcon={<RestartAltIcon />}
-          sx={{ visibility: showReset ? "visible" : "hidden" }}
-          variant="text"
-        >
-          New Conversation
-        </Button>
+        <ActionsRow>
+          <Button
+            onClick={resetSession}
+            size="small"
+            startIcon={<RestartAltIcon />}
+            sx={{ visibility: showReset ? "visible" : "hidden" }}
+            variant="text"
+          >
+            New Conversation
+          </Button>
+          {supportUrl && (
+            <Button
+              aria-label="Give feedback on the Analysis Assistant (opens in a new tab)"
+              component="a"
+              href={supportUrl}
+              rel="noopener noreferrer"
+              size="small"
+              startIcon={<FeedbackOutlinedIcon />}
+              target="_blank"
+              variant="outlined"
+            >
+              Feedback
+            </Button>
+          )}
+        </ActionsRow>
         <TwoPanelLayout>
           <ChatColumn>
             <ChatPanel
@@ -98,8 +114,10 @@ export const AssistantView = ({ initialSessionId }: Props): JSX.Element => {
           </SchemaColumn>
         </TwoPanelLayout>
         <AssistantDisclaimer>
-          AI assistant — {modelLabel}. Responses can be inaccurate; verify
-          anything important before relying on it.
+          AI assistant — {modelLabel}. Your messages are sent to the model
+          provider to generate a response, so avoid sharing sensitive or
+          identifying information. Responses can be inaccurate; verify anything
+          important before relying on it.
         </AssistantDisclaimer>
       </SectionContent>
     </StyledSection>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -12,7 +12,6 @@ import { Floating } from "@databiosphere/findable-ui/lib/components/Layout/compo
 import { Header as DXHeader } from "@databiosphere/findable-ui/lib/components/Layout/components/Header/header";
 import { Main as DXMain } from "@databiosphere/findable-ui/lib/components/Layout/components/Main/main";
 import { setFeatureFlags } from "@databiosphere/findable-ui/lib/hooks/useFeatureFlag/common/utils";
-import { useFeatureFlag } from "@databiosphere/findable-ui/lib/hooks/useFeatureFlag/useFeatureFlag";
 import { ConfigProvider as DXConfigProvider } from "@databiosphere/findable-ui/lib/providers/config";
 import { ExploreStateProvider } from "@databiosphere/findable-ui/lib/providers/exploreState";
 import { LayoutDimensionsProvider } from "@databiosphere/findable-ui/lib/providers/layoutDimensions/provider";
@@ -27,11 +26,10 @@ import { OgMeta } from "@repo/shared/components/OgMeta/ogMeta";
 import { AuthProvider } from "@repo/shared/providers/authentication/provider";
 import { EntitiesLoadedProvider } from "@repo/shared/providers/entitiesLoaded/provider";
 import { WorkflowHandoffProvider } from "@repo/shared/providers/workflowHandoff/provider";
-import { ROUTES } from "@routes/constants";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { type NextPage } from "next";
 import type { AppProps } from "next/app";
-import { type JSX, useMemo } from "react";
+import { type JSX } from "react";
 
 const DEFAULT_ENTITY_LIST_TYPE = "organisms";
 
@@ -50,13 +48,7 @@ export type AppPropsWithComponent = AppProps & {
   pageProps: PageProps;
 };
 
-setFeatureFlags([
-  "assembly-workflows",
-  "assistant",
-  "hyphy",
-  "lmls",
-  "pangenome",
-]);
+setFeatureFlags(["assembly-workflows", "hyphy", "lmls", "pangenome"]);
 
 const queryClient = new QueryClient();
 
@@ -82,19 +74,6 @@ function MyApp(props: AppPropsWithComponent): JSX.Element {
   const appTheme = mergeAppTheme(baseThemeOptions, themeOptions);
   const AppLayout = Component.AppLayout || DXAppLayout;
   const Main = Component.Main || DXMain;
-  const isAssistantEnabled = useFeatureFlag("assistant");
-  const filteredHeader = useMemo(() => {
-    if (!header) return header;
-    if (isAssistantEnabled) return header;
-    const { navigation, ...rest } = header;
-    if (!navigation) return header;
-    return {
-      ...rest,
-      navigation: navigation.map((group) =>
-        group?.filter((item) => item.url !== ROUTES.ASSISTANT)
-      ) as typeof navigation,
-    };
-  }, [header, isAssistantEnabled]);
 
   return (
     <AppCacheProvider {...props}>
@@ -116,7 +95,7 @@ function MyApp(props: AppPropsWithComponent): JSX.Element {
                   <AuthProvider loginEnabled={appConfig.loginEnabled}>
                     <LayoutDimensionsProvider>
                       <AppLayout>
-                        <DXHeader {...filteredHeader} />
+                        <DXHeader {...header} />
                         <ExploreStateProvider entityListType={entityListType}>
                           <WorkflowHandoffProvider>
                             <Main>

--- a/pages/assistant/index.tsx
+++ b/pages/assistant/index.tsx
@@ -1,6 +1,8 @@
 import { BRC_PAGE_META } from "@/common/meta/brc/constants";
+import { config } from "@/config/config";
 import { AssistantView } from "@/views/AssistantView/assistantView";
 import { StyledPagesMain } from "@repo/shared/components/layout/Main/main.styles";
+import { ROUTES } from "@routes/constants";
 import { type GetStaticProps } from "next";
 import { useRouter } from "next/router";
 import { type JSX } from "react";
@@ -14,6 +16,13 @@ export const Assistant = (): JSX.Element => {
 };
 
 export const getStaticProps: GetStaticProps = async () => {
+  const { allowedPaths } = config();
+
+  // Only build on sites where /assistant is an allowed path.
+  if (allowedPaths && !allowedPaths.includes(ROUTES.ASSISTANT)) {
+    return { notFound: true };
+  }
+
   return {
     props: {
       ...BRC_PAGE_META.ASSISTANT,

--- a/pages/assistant/saved.tsx
+++ b/pages/assistant/saved.tsx
@@ -1,3 +1,4 @@
+import { config } from "@/config/config";
 import { type Breadcrumb } from "@databiosphere/findable-ui/lib/components/common/Breadcrumbs/breadcrumbs";
 import {
   Alert,
@@ -12,6 +13,8 @@ import { SectionHero } from "@repo/shared/components/layout/SectionHero/sectionH
 import { useAuth } from "@repo/shared/providers/authentication/provider";
 import { apiClient } from "@repo/shared/services/api-client/api-client";
 import type { SavedAnalysisSummary } from "@repo/shared/services/api-client/types";
+import { ROUTES } from "@routes/constants";
+import { type GetStaticProps } from "next";
 import { useRouter } from "next/router";
 import { type JSX, useEffect, useState } from "react";
 
@@ -198,5 +201,17 @@ export default function SavedAnalysesPage(): JSX.Element {
     </>
   );
 }
+
+export const getStaticProps: GetStaticProps = async () => {
+  const { allowedPaths } = config();
+
+  // Guarded on the assistant route, not its own: everything under /assistant
+  // belongs to the same feature, and this page is only reachable from it.
+  if (allowedPaths && !allowedPaths.includes(ROUTES.ASSISTANT)) {
+    return { notFound: true };
+  }
+
+  return { props: {} };
+};
 
 SavedAnalysesPage.Main = StyledPagesMain;

--- a/site-config/brc-analytics/local/config.ts
+++ b/site-config/brc-analytics/local/config.ts
@@ -17,6 +17,7 @@ import { APP_KEYS } from "@site-config/common/constants";
 import { type AppSiteConfig } from "@site-config/common/entities";
 import data from "catalog/output/ncbi-taxa-tree.json";
 import { createElement } from "react";
+import { SUPPORT_URL } from "./constants";
 import { floating } from "./floating/floating";
 import { genomeEntityConfig } from "./index/genomeEntityConfig";
 import { organismEntityConfig } from "./index/organismEntityConfig";
@@ -122,6 +123,7 @@ export function makeConfig(
     loginEnabled,
     maxReadRunsForBrowseAll: 80000,
     redirectRootToPath: "/",
+    supportUrl: SUPPORT_URL,
     taxTree: taxTreeData,
     themeOptions: THEME_OPTIONS,
   };

--- a/site-config/brc-analytics/local/constants.ts
+++ b/site-config/brc-analytics/local/constants.ts
@@ -1,0 +1,5 @@
+// Destination for both the floating help icon and the assistant's Feedback
+// button -- one form, so responses land in a single place regardless of entry
+// point.
+export const SUPPORT_URL =
+  "https://docs.google.com/forms/d/e/1FAIpQLSd8f5hrd1-ECgPUbS5dL9njoU1nvCSN5ukykKk9mF6WAyTh6A/viewform?usp=sf_link";

--- a/site-config/brc-analytics/local/floating/floating.ts
+++ b/site-config/brc-analytics/local/floating/floating.ts
@@ -3,13 +3,14 @@ import {
   type ComponentConfig,
   type FloatingConfig,
 } from "@databiosphere/findable-ui/lib/config/entities";
+import { SUPPORT_URL } from "@site-config/brc-analytics/local/constants";
 
 export const floating: FloatingConfig = {
   components: [
     {
       component: StyledViewSupport,
       props: {
-        url: "https://docs.google.com/forms/d/e/1FAIpQLSd8f5hrd1-ECgPUbS5dL9njoU1nvCSN5ukykKk9mF6WAyTh6A/viewform?usp=sf_link",
+        url: SUPPORT_URL,
       },
     } as ComponentConfig<typeof StyledViewSupport>,
   ],

--- a/site-config/common/entities.ts
+++ b/site-config/common/entities.ts
@@ -32,5 +32,8 @@ export interface AppSiteConfig extends BaseSiteConfig {
   appKey?: (typeof APP_KEYS)[keyof typeof APP_KEYS];
   loginEnabled?: boolean;
   maxReadRunsForBrowseAll: number;
+  // Where this site's help and feedback go. Resolved per site so app code can
+  // link it without naming one site's config directly.
+  supportUrl?: string;
   taxTree?: TaxonomyNode;
 }

--- a/site-config/ga2/local/config.ts
+++ b/site-config/ga2/local/config.ts
@@ -12,6 +12,7 @@ import { ROUTES as SITE_ROUTES } from "@routes/constants";
 import { APP_KEYS } from "@site-config/common/constants";
 import { type AppSiteConfig } from "@site-config/common/entities";
 import data from "catalog/ga2/output/ncbi-taxa-tree.json";
+import { SUPPORT_URL } from "./constants";
 import { floating } from "./floating/floating";
 import { genomeEntityConfig } from "./index/genome/genomeEntityConfig";
 import { organismEntityConfig } from "./index/organism/organismEntityConfig";
@@ -103,6 +104,7 @@ export function makeConfig(
     },
     maxReadRunsForBrowseAll: 80000,
     redirectRootToPath: "/",
+    supportUrl: SUPPORT_URL,
     taxTree: taxTreeData,
     themeOptions: THEME_OPTIONS,
   };

--- a/site-config/ga2/local/constants.ts
+++ b/site-config/ga2/local/constants.ts
@@ -1,0 +1,4 @@
+// Destination for the floating help icon on GA2. Kept beside the site's other
+// config so app code reads it through config() rather than importing a
+// particular site's file.
+export const SUPPORT_URL = "https://forms.gle/6sqBCiKPCPTg6q1k9";

--- a/site-config/ga2/local/floating/floating.ts
+++ b/site-config/ga2/local/floating/floating.ts
@@ -3,13 +3,14 @@ import {
   type FloatingConfig,
 } from "@databiosphere/findable-ui/lib/config/entities";
 import { StyledViewSupport } from "@ga2/components/layout/ViewSupport/viewSupport.styles";
+import { SUPPORT_URL } from "@site-config/ga2/local/constants";
 
 export const floating: FloatingConfig = {
   components: [
     {
       component: StyledViewSupport,
       props: {
-        url: "https://forms.gle/6sqBCiKPCPTg6q1k9",
+        url: SUPPORT_URL,
       },
     } as ComponentConfig<typeof StyledViewSupport>,
   ],

--- a/sites/brc-analytics/docs/learn/assistant.mdx
+++ b/sites/brc-analytics/docs/learn/assistant.mdx
@@ -14,7 +14,7 @@ title: "About the Assistant"
 
 The Analysis Assistant is a chat interface that helps you set up a genomic analysis on BRC Analytics without hunting through the catalog yourself. You describe what you want to do in plain language, and the assistant helps you pick an organism, a genome assembly, and a compatible workflow from the BRC catalog. Once your setup is complete, it hands off to the workflow stepper so you can review the configuration and launch the analysis in Galaxy.
 
-The assistant is in **beta**. Like any AI tool, it can make mistakes -- double-check anything important before relying on it, and use the feedback link on the assistant page to tell us what's working and what isn't.
+The assistant is in **beta**. Like any AI tool, it can make mistakes -- double-check anything important before relying on it, and use the **Feedback** button on the assistant page to tell us what's working and what isn't.
 
 ## How to use it
 
@@ -23,7 +23,7 @@ The assistant is in **beta**. Like any AI tool, it can make mistakes -- double-c
 3. **Configure your analysis.** As you answer, the assistant fills in the pieces it needs: the reference assembly, the workflow, and details about your data.
 4. **Hand off to the workflow stepper.** When the setup is ready, the assistant hands you off to the workflow stepper with your selections pre-filled. From there you can review everything and launch in Galaxy.
 
-If the assistant doesn't have what you're looking for -- for example, an organism or assembly that isn't in the catalog -- it will say so. You can browse the [catalog](/data/organisms) directly, or [open an issue](https://github.com/galaxyproject/brc-analytics/issues) to request that we add it.
+If the assistant doesn't have what you're looking for -- for example, an organism or assembly that isn't in the catalog -- it will say so. You can browse the [catalog](/data/organisms) directly, or ask us to add it on the [community forum](https://help.brc-analytics.org) or by [opening an issue](https://github.com/galaxyproject/brc-analytics/issues). Those are the same places the assistant will point you when it hits a gap.
 
 ## What it can't do (yet)
 
@@ -34,4 +34,17 @@ The assistant is focused on the catalog-to-Galaxy setup flow described above. It
 - Interpret your results, write or summarize papers, or answer general research questions.
 - Browse external resources (like UCSC Genome Browser tracks) on your behalf.
 
-If you need something it can't do, [open an issue](https://github.com/galaxyproject/brc-analytics/issues) and let us know -- it helps us prioritize.
+If you need something it can't do, let us know on the [community forum](https://help.brc-analytics.org) or by [opening an issue](https://github.com/galaxyproject/brc-analytics/issues) -- it helps us prioritize.
+
+## Feedback and getting help
+
+Two different things, and they go to two different places:
+
+- **How the assistant itself did** -- the **Feedback** button on the assistant page. It opens a short form and needs no account. Use it when a reply was wrong, confusing, or unhelpful. During the beta this is the signal we're watching most closely, so it's worth a sentence even when something only felt slightly off.
+- **Help with an analysis, or something missing from the catalog** -- the [community forum](https://help.brc-analytics.org) or [GitHub issues](https://github.com/galaxyproject/brc-analytics/issues). Both are public, so the next person with the same question finds the answer. Email [help@brc-analytics.org](mailto:help@brc-analytics.org) instead if you'd rather not post in the open.
+
+## What happens to your messages
+
+The assistant runs on a large language model hosted by a third-party provider. The model in use is named at the bottom of the assistant page. To generate a reply, what you type is sent to that provider along with the catalog context the assistant looked up on your behalf -- so please don't enter sensitive, confidential, or personally identifying information.
+
+Your conversation is held in short-lived server-side storage so you can pick up where you left off. It expires on its own about two hours after your last message, so an active conversation keeps going and an abandoned one clears itself. If you're signed in and save an analysis, a copy of the conversation is kept with your account until you delete it -- for a long chat that copy covers the most recent hundred messages rather than the whole thing.

--- a/sites/brc-analytics/docs/learn/faq.mdx
+++ b/sites/brc-analytics/docs/learn/faq.mdx
@@ -36,9 +36,10 @@ Many users launch a workflow from BRC Analytics and then continue custom analyse
 
 ## What features are coming next?
 
+The **[Analysis Assistant](/learn/assistant)** has since shipped and is in beta. Its own page covers what it can do, which model is answering you, and what happens to your messages.
+
 We are actively developing support for:
 
-- **AI Chat Assistant**: An intelligent interface powered by open-source LLMs hosted at TACC. It will assist with site navigation, identifying supported organisms, selecting appropriate workflows for your analysis goals, and searching external databases (like NCBI) to help you find the best reference assemblies and public datasets.
 - **Comparative Genomics & Pangenomics**: Analyze variation across multiple strains or species.
 - **Host-Pathogen Interactions**: Integrated workflows for dual-organism analysis.
 - **Genome Assembly**: De novo assembly pipelines for various sequencing technologies.

--- a/sites/brc-analytics/views/LearnView/learnView.tsx
+++ b/sites/brc-analytics/views/LearnView/learnView.tsx
@@ -5,9 +5,8 @@ import { type JSX } from "react";
 import { getFilteredCards } from "./utils";
 
 export const LearnView = (): JSX.Element => {
-  const isAssistantEnabled = useFeatureFlag("assistant");
   const isLmlsEnabled = useFeatureFlag("lmls");
-  const cards = getFilteredCards(isAssistantEnabled, isLmlsEnabled);
+  const cards = getFilteredCards(isLmlsEnabled);
   return (
     <ContentIndexView
       slotProps={{

--- a/sites/brc-analytics/views/LearnView/utils.ts
+++ b/sites/brc-analytics/views/LearnView/utils.ts
@@ -4,17 +4,13 @@ import { CARDS } from "./constants";
 
 /**
  * Filters the cards based on the provided feature flags.
- * @param isAssistantEnabled - A boolean indicating if the assistant feature is enabled.
  * @param isLmlsEnabled - A boolean indicating if the LMLS feature is enabled.
  * @returns An array of filtered cards based on the feature flags.
  */
 export function getFilteredCards(
-  isAssistantEnabled: boolean,
   isLmlsEnabled: boolean
 ): ComponentProps<typeof SectionContentCard>[] {
   return CARDS.filter(
-    (card) =>
-      (card.href !== "/learn/sequence-search-workflows" || isLmlsEnabled) &&
-      (card.href !== "/learn/assistant" || isAssistantEnabled)
+    (card) => card.href !== "/learn/sequence-search-workflows" || isLmlsEnabled
   );
 }

--- a/sites/brc-analytics/views/RoadmapView/content/sectionRoadmap.mdx
+++ b/sites/brc-analytics/views/RoadmapView/content/sectionRoadmap.mdx
@@ -24,7 +24,7 @@
             #### In beta / feature-flagged
 
             - **Comparative genomics workflows** — HyPhy-powered analyses behind feature flag; unblocked by new per-organism workflow support that lets users select two or more assemblies as inputs.
-            - **Natural language analysis assistant** — a purpose-built BRC MCP server and analysis assistant agent currently in testing, enabling natural language interaction with BRC Analytics data and Galaxy.
+            - **Natural language analysis assistant** — a purpose-built BRC MCP server and analysis assistant agent, now in beta, enabling natural language interaction with BRC Analytics data and Galaxy.
             - **Logan and LexicMap sequence-driven SRA search workflows** — sequences as first-class entry points, behind feature flag.
             - **Assembly building workflows** — IWC-curated pipelines surfaced through new per-organism workflow UI; these take no assembly input, as users provide their own data to build from.
             - **Flu subtyping workflows** — respiratory pathogen subtyping nearing release; takes no assembly input, using a curated reference FASTA set instead.


### PR DESCRIPTION
Drops the `assistant` feature flag so the Analysis Assistant is live for everyone as a beta — Phase 1 of #1288 — and gives beta users an obvious way to say how it's going. Closes #1290.

**Merge last.** #1525 fixes a live 503 and #1526 stops deploys wiping sessions; both are worth having in before this turns the feature on for everyone. #1526 also touches `assistantView.tsx` and will conflict textually with this on the `showReset` line — trivial to resolve.

## Removing the flag

The gate comes out entirely rather than getting defaulted to on: `useFeatureFlag` reads localStorage client-side, so a default-on gate would still flash a 404 on first render before hydration. Three gates went — the nav item filter in `_app.tsx`, the 404 in `AssistantView`, and the Learn card filter — along with the flag registration. No `useFeatureFlag("assistant")` consumers remain.

## Feedback button

A labeled "Feedback" button in an actions row under the headline, opposite "New Conversation" — visually part of the assistant, and it can't collide with the chat input or scroll away mid-conversation. It points at the same support form the floating help icon already uses rather than a new destination, opens in a new tab, and says so in its accessible name. That URL is now a `SUPPORT_URL` constant both the floating config and the button import, so the two entry points can't drift.

## Keeping it off GA2

This is the part worth reviewing hardest. Both sites build from one `pages/` tree and the static export ships every page, so **the feature flag was the only thing keeping the assistant off Genome Ark**. Removing it would have put a BRC-branded assistant, BRC metadata and the BRC feedback form on GA2.

Three routes needed guarding, using the `allowedPaths` idiom `/calendar` and the `/about` pages already use:

- `/assistant` — direct guard.
- `/assistant/saved` — its own page, easy to miss. GA2 served the Saved Analyses UI, breadcrumbed to a 404 and stuck on a spinner because auth isn't configured there.
- `/learn/assistant` — `pages/learn/[...slug]` generates a page per file under `app/docs/learn`, so hiding the Learn card wasn't enough; the doc stayed directly reachable. Dropped from the generated paths, with the same check in `getStaticProps` behind it.

Verified on a real GA2 dev server: all three 404 there while `/data/organisms` still renders; on BRC all three still render.

## Copy

Adds a third-party-model disclosure to the chat disclaimer and a "What happens to your messages" section in `assistant.mdx` — the beta readiness review called this the one disclosure to fix before un-flagging, and until now the only disclaimer was "responses can be inaccurate".

Also reconciles the two feedback channels, which previously didn't know about each other: the Feedback button goes to the support form (quick, private, no account — the beta signal), while the forum and GitHub handle help and catalog gaps, which is already what the agent's own replies tell people. And retires stale copy — the FAQ still listed the assistant as a future feature "powered by open-source LLMs hosted at TACC" that searches NCBI, contradicting both the new disclosure and the documented inability to browse external resources; the roadmap still said "currently in testing".

## Verification

581 frontend tests pass, tsc and ESLint clean. Checked in a dev server that the nav item appears, `/assistant` renders instead of 404ing, the Learn card is back, the docs render, and the Feedback button points at the right form with `target="_blank"` and `rel="noopener noreferrer"`.

## Still open

- **#1290 also wants the Google Form renamed to "Help and Feedback."** Google-side, not code — and it matters more now that the docs describe that form as the feedback channel specifically.
- **Remaining Phase 1 issues:** #1293, #1299, #1318, #1320.
- **Worth knowing before this merges:** there's still no durable record of assistant conversations. #1294 is closed and the decision was durable-to-Postgres, but only the `saved_analyses` path landed, which needs an authenticated user who explicitly saves. Everything else lives in Redis for 2h and evaporates. So as it stands the beta can't answer "what are people asking it," which #1288 wanted in place first. Doesn't block this PR, but it does undercut the point of the beta.
