### PR TITLE
refactor: move workflows entity store/query/routes/types into @repo/shared (#1518)

### DIFF
--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/ReferenceAssemblyStep/components/AssemblyData/components/AssemblySelector/hooks/UseTable/hook.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/ReferenceAssemblyStep/components/AssemblyData/components/AssemblySelector/hooks/UseTable/hook.ts
@@ -1,4 +1,3 @@
-import { getEntities } from "@/services/workflows/query";
 import { FILTER_SORT } from "@databiosphere/findable-ui/lib/common/filters/sort/config/types";
 import { arrIncludesSome } from "@databiosphere/findable-ui/lib/components/Table/columnDef/columnFilters/filterFn";
 import { getFacetedUniqueValuesWithArrayValues } from "@databiosphere/findable-ui/lib/components/Table/common/utils";
@@ -7,6 +6,7 @@ import { ROW_POSITION } from "@databiosphere/findable-ui/lib/components/Table/fe
 import { ROW_PREVIEW } from "@databiosphere/findable-ui/lib/components/Table/features/RowPreview/constants";
 import { TABLE_DOWNLOAD } from "@databiosphere/findable-ui/lib/components/Table/features/TableDownload/constants";
 import type { Workflow } from "@repo/shared/apis/workflow";
+import { getEntities } from "@repo/shared/services/workflows/query";
 import {
   getCoreRowModel,
   getFacetedRowModel,

--- a/app/services/workflows/brc/entities.ts
+++ b/app/services/workflows/brc/entities.ts
@@ -1,0 +1,12 @@
+import type { Pangenome } from "@/apis/catalog/brc-analytics-catalog/common/pangenome";
+import { findEntity } from "@repo/shared/services/workflows/query";
+
+/**
+ * Gets the pangenome bundle for a species, or undefined when the species has no
+ * pangenome.
+ * @param speciesTaxonomyId - Species taxonomy ID.
+ * @returns Pangenome bundle, or undefined.
+ */
+export function getPangenome(speciesTaxonomyId: string): Pangenome | undefined {
+  return findEntity<Pangenome>("pangenomes", speciesTaxonomyId);
+}

--- a/app/services/workflows/brc/loader.ts
+++ b/app/services/workflows/brc/loader.ts
@@ -1,77 +1,30 @@
 import type { Pangenome } from "@/apis/catalog/brc-analytics-catalog/common/pangenome";
+import { API as BRC_API } from "@/services/workflows/brc/routes";
 import { formatTrsId } from "@/views/AnalyzeWorkflowsView/components/Main/utils";
 import { CUSTOM_WORKFLOW } from "@/views/AnalyzeWorkflowsView/custom/constants";
 import { DIFFERENTIAL_EXPRESSION_ANALYSIS } from "@/views/AnalyzeWorkflowsView/differentialExpressionAnalysis/constants";
 import { LEXICMAP } from "@/views/AnalyzeWorkflowsView/lexicmap/constants";
 import { LOGAN_SEARCH } from "@/views/AnalyzeWorkflowsView/loganSearch/constants";
-import { SiteConfig } from "@databiosphere/findable-ui/lib/config/entities";
 import type { Workflow, WorkflowCategory } from "@repo/shared/apis/workflow";
-import { API } from "./routes";
-import { getEntitiesById, setEntitiesById, setEntitiesByType } from "./store";
-import { EntityRoute } from "./types";
-
-/**
- * Fetches entities from the API.
- * @param url - URL.
- * @returns Entity list.
- */
-async function fetchEntities(url: string): Promise<unknown[]> {
-  const res = await fetch(url);
-
-  if (!res.ok) throw new Error(`Failed to fetch: ${url}`);
-
-  return (await res.json()) as unknown[];
-}
-
-/**
- * Checks if the route is an entity route.
- * @param route - Route.
- * @returns True if the route is an entity route; false otherwise.
- */
-function isEntityRoute(route: string): route is EntityRoute {
-  return route in API;
-}
-
-/**
- * Loads the entities store with entities from the API.
- * @param config - Site config.
- */
-export async function loadEntities(config: SiteConfig): Promise<void> {
-  for (const entity of config.entities) {
-    const { getId, route } = entity;
-
-    if (!isEntityRoute(route)) continue;
-
-    const apiRoute = API[route];
-
-    // Entities are already loaded; skip.
-    if (getEntitiesById().has(route)) continue;
-
-    // Get id function is not configured; entities are excluded from preloading.
-    if (!getId) continue;
-
-    // Fetch the entities.
-    const entities = await fetchEntities(apiRoute);
-
-    const entityById = new Map<string, unknown>();
-    for (const entity of entities) entityById.set(getId(entity), entity);
-
-    setEntitiesById(route, entityById);
-    setEntitiesByType(route, entities);
-  }
-}
+import { fetchEntities } from "@repo/shared/services/workflows/loader";
+import { API } from "@repo/shared/services/workflows/routes";
+import {
+  getEntitiesById,
+  setEntitiesById,
+  setEntitiesByType,
+} from "@repo/shared/services/workflows/store";
 
 /**
  * Loads the pangenomes store from the API, keyed by species taxonomy ID.
- * Pangenome data is optional (BRC-only and may be absent before its build
- * lands), so a missing or failed fetch is skipped rather than fatal.
+ * Pangenome data is optional (may be absent before its build lands), so a
+ * missing or failed fetch is skipped rather than fatal.
  */
 export async function loadPangenomes(): Promise<void> {
   if (getEntitiesById().has("pangenomes")) return;
 
   let pangenomes: Pangenome[];
   try {
-    pangenomes = (await fetchEntities(API.pangenomes)) as Pangenome[];
+    pangenomes = (await fetchEntities(BRC_API.pangenomes)) as Pangenome[];
   } catch (error) {
     // Optional data: stay non-fatal, but surface the error so a real
     // regression (vs. an intentionally-absent file) is debuggable.

--- a/app/services/workflows/brc/routes.ts
+++ b/app/services/workflows/brc/routes.ts
@@ -1,0 +1,3 @@
+export const API = {
+  pangenomes: "/api/pangenomes.json",
+} as const;

--- a/app/services/workflows/hooks/UseEntities/utils.ts
+++ b/app/services/workflows/hooks/UseEntities/utils.ts
@@ -1,9 +1,6 @@
-import {
-  loadEntities,
-  loadPangenomes,
-  loadWorkflows,
-} from "@/services/workflows/loader";
+import { loadPangenomes, loadWorkflows } from "@/services/workflows/brc/loader";
 import { SiteConfig } from "@databiosphere/findable-ui/lib/config/entities";
+import { loadEntities } from "@repo/shared/services/workflows/loader";
 
 let loadPromise: Promise<void> | null = null;
 

--- a/app/services/workflows/types.ts
+++ b/app/services/workflows/types.ts
@@ -1,3 +1,0 @@
-import { API } from "./routes";
-
-export type EntityRoute = keyof typeof API;

--- a/app/views/AnalyzeView/analyzeView.tsx
+++ b/app/views/AnalyzeView/analyzeView.tsx
@@ -1,9 +1,9 @@
-import { getEntity } from "@/services/workflows/query";
 import {
   BackPageContent,
   BackPageHero,
   BackPageView,
 } from "@databiosphere/findable-ui/lib/components/Layout/components/BackPage/backPageView.styles";
+import { getEntity } from "@repo/shared/services/workflows/query";
 import { JSX } from "react";
 import { Side } from "../EntityView/assembly/components/Side/side";
 import { Assembly } from "../WorkflowInputsView/types";

--- a/app/views/AnalyzeWorkflowsView/analyzeWorkflowsView.tsx
+++ b/app/views/AnalyzeWorkflowsView/analyzeWorkflowsView.tsx
@@ -1,9 +1,9 @@
-import { getEntity } from "@/services/workflows/query";
 import {
   BackPageContent,
   BackPageHero,
   BackPageView,
 } from "@databiosphere/findable-ui/lib/components/Layout/components/BackPage/backPageView.styles";
+import { getEntity } from "@repo/shared/services/workflows/query";
 import { JSX } from "react";
 import { Side } from "../EntityView/assembly/components/Side/side";
 import { Assembly } from "../WorkflowInputsView/types";

--- a/app/views/EntitiesView/utils.ts
+++ b/app/views/EntitiesView/utils.ts
@@ -1,6 +1,6 @@
 import type { EntitiesResponse } from "@/apis/catalog/brc-analytics-catalog/common/entities";
-import { getEntities } from "@/services/workflows/query";
-import type { EntityRoute } from "@/services/workflows/types";
+import { getEntities } from "@repo/shared/services/workflows/query";
+import type { EntityRoute } from "@repo/shared/services/workflows/types";
 
 /**
  * Build an explore-view data response from the client-loaded entity store.

--- a/app/views/OrganismView/components/Main/components/WorkflowsSection/workflowsSection.tsx
+++ b/app/views/OrganismView/components/Main/components/WorkflowsSection/workflowsSection.tsx
@@ -1,4 +1,3 @@
-import { getWorkflows } from "@/services/workflows/entities";
 import { Accordion } from "@/views/AnalyzeWorkflowsView/components/Main/components/Accordion/accordion";
 import { StyledSectionTitle } from "@/views/OrganismView/components/Main/main.styles";
 import { buildOrganismWorkflows } from "@/views/OrganismView/components/Main/utils";
@@ -6,6 +5,7 @@ import { useFeatureFlag } from "@databiosphere/findable-ui/lib/hooks/useFeatureF
 import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
 import { Stack } from "@mui/material";
 import { ROUTES } from "@repo/shared/routes/constants";
+import { getWorkflows } from "@repo/shared/services/workflows/entities";
 import { JSX } from "react";
 import { EmptyState } from "../EmptyState/emptyState";
 import { Props } from "./types";

--- a/app/views/OrganismView/hooks/UseShowPangenome/hook.ts
+++ b/app/views/OrganismView/hooks/UseShowPangenome/hook.ts
@@ -1,5 +1,5 @@
 import type { Pangenome } from "@/apis/catalog/brc-analytics-catalog/common/pangenome";
-import { getPangenome } from "@/services/workflows/entities";
+import { getPangenome } from "@/services/workflows/brc/entities";
 import { useFeatureFlag } from "@databiosphere/findable-ui/lib/hooks/useFeatureFlag/useFeatureFlag";
 
 /**

--- a/app/views/OrganismWorkflowInputsView/organismWorkflowInputsView.tsx
+++ b/app/views/OrganismWorkflowInputsView/organismWorkflowInputsView.tsx
@@ -8,14 +8,14 @@ import { Main } from "@/components/Entity/components/ConfigureWorkflowInputs/com
 import { SideColumn } from "@/components/Entity/components/ConfigureWorkflowInputs/components/SideColumn/sideColumn";
 import { WorkflowEntityContext } from "@/components/Entity/components/ConfigureWorkflowInputs/providers/WorkflowEntity/context";
 import { buildWorkflowEntityValue } from "@/components/Entity/components/ConfigureWorkflowInputs/providers/WorkflowEntity/utils";
-import { getWorkflow } from "@/services/workflows/entities";
-import { getEntity } from "@/services/workflows/query";
 import {
   BackPageContent,
   BackPageContentSideColumn,
   BackPageHero,
   BackPageView,
 } from "@databiosphere/findable-ui/lib/components/Layout/components/BackPage/backPageView.styles";
+import { getWorkflow } from "@repo/shared/services/workflows/entities";
+import { getEntity } from "@repo/shared/services/workflows/query";
 import { JSX, useMemo } from "react";
 import { useConfigureInputs } from "../WorkflowInputsView/hooks/UseConfigureInputs/useConfigureInputs";
 import { StyledBackPageContentMainColumn } from "../WorkflowInputsView/workflowInputsView.styles";

--- a/app/views/WorkflowInputsView/workflowInputsView.tsx
+++ b/app/views/WorkflowInputsView/workflowInputsView.tsx
@@ -11,13 +11,16 @@ import { WorkflowEntityContext } from "@/components/Entity/components/ConfigureW
 import { buildWorkflowEntityValue } from "@/components/Entity/components/ConfigureWorkflowInputs/providers/WorkflowEntity/utils";
 import { ENTITY_KEYS } from "@/providers/workflowHandoff/constants";
 import { HandoffStatusContext } from "@/providers/workflowHandoff/contexts/HandoffStatus/context";
-import { getAssembly, getWorkflow } from "@/services/workflows/entities";
 import {
   BackPageContent,
   BackPageContentSideColumn,
   BackPageHero,
   BackPageView,
 } from "@databiosphere/findable-ui/lib/components/Layout/components/BackPage/backPageView.styles";
+import {
+  getAssembly,
+  getWorkflow,
+} from "@repo/shared/services/workflows/entities";
 import { JSX, useMemo } from "react";
 import { useAssistantHandoff } from "./hooks/UseAssistantHandoff/useAssistantHandoff";
 import { useConfigureInputs } from "./hooks/UseConfigureInputs/useConfigureInputs";

--- a/app/views/WorkflowView/hooks/UseWorkflowEntities/utils.ts
+++ b/app/views/WorkflowView/hooks/UseWorkflowEntities/utils.ts
@@ -1,6 +1,5 @@
 import type { BRCDataCatalogOrganism } from "@/apis/catalog/brc-analytics-catalog/common/entities";
 import type { GA2OrganismEntity } from "@/apis/catalog/ga2/entities";
-import { findOrganism, getAssembly } from "@/services/workflows/entities";
 import type { Organism } from "@/views/OrganismView/types";
 import { mapOrganismEntityToOrganism } from "@/views/OrganismWorkflowInputsView/utils";
 import type { Assembly } from "@/views/WorkflowInputsView/types";
@@ -8,6 +7,10 @@ import { mapAssemblyToOrganism } from "@/views/WorkflowInputsView/utils";
 import { WORKFLOW_SCOPE } from "@repo/shared/apis/schema-types";
 import { sanitizeEntityId } from "@repo/shared/apis/utils";
 import type { Workflow } from "@repo/shared/apis/workflow";
+import {
+  findOrganism,
+  getAssembly,
+} from "@repo/shared/services/workflows/entities";
 
 /**
  * Resolves the reference-assembly genome, when one is configured.

--- a/app/views/WorkflowView/workflowView.tsx
+++ b/app/views/WorkflowView/workflowView.tsx
@@ -3,13 +3,13 @@ import { Main } from "@/components/Entity/components/ConfigureWorkflowInputs/com
 import { SideColumn } from "@/components/Entity/components/ConfigureWorkflowInputs/components/SideColumn/sideColumn";
 import { AssemblyContext } from "@/components/Entity/components/ConfigureWorkflowInputs/providers/Assembly/context";
 import { WorkflowEntityContext } from "@/components/Entity/components/ConfigureWorkflowInputs/providers/WorkflowEntity/context";
-import { getWorkflow } from "@/services/workflows/entities";
 import {
   BackPageContent,
   BackPageContentSideColumn,
   BackPageHero,
   BackPageView,
 } from "@databiosphere/findable-ui/lib/components/Layout/components/BackPage/backPageView.styles";
+import { getWorkflow } from "@repo/shared/services/workflows/entities";
 import { JSX } from "react";
 import { useConfigureInputs } from "../WorkflowInputsView/hooks/UseConfigureInputs/useConfigureInputs";
 import { Top } from "./components/Top/top";

--- a/app/views/WorkflowsView/workflowsView.tsx
+++ b/app/views/WorkflowsView/workflowsView.tsx
@@ -1,10 +1,10 @@
+import { useFeatureFlag } from "@databiosphere/findable-ui/lib/hooks/useFeatureFlag/useFeatureFlag";
+import type { WorkflowAssemblyMapping } from "@repo/shared/apis/workflow";
 import {
   getOrganisms,
   getWorkflows as getWorkflowCategories,
-} from "@/services/workflows/entities";
-import { API } from "@/services/workflows/routes";
-import { useFeatureFlag } from "@databiosphere/findable-ui/lib/hooks/useFeatureFlag/useFeatureFlag";
-import type { WorkflowAssemblyMapping } from "@repo/shared/apis/workflow";
+} from "@repo/shared/services/workflows/entities";
+import { API } from "@repo/shared/services/workflows/routes";
 import { JSX, useEffect, useMemo, useState } from "react";
 import { ExploreView } from "../ExploreView/exploreView";
 import { Workflows } from "./components/Workflows/workflows";

--- a/packages/shared/services/workflows/entities.ts
+++ b/packages/shared/services/workflows/entities.ts
@@ -1,10 +1,13 @@
-import type { Pangenome } from "@/apis/catalog/brc-analytics-catalog/common/pangenome";
 import type {
   AssemblyContract,
   OrganismContract,
 } from "@repo/shared/apis/types";
 import type { Workflow, WorkflowCategory } from "@repo/shared/apis/workflow";
-import { findEntity, getEntities, getEntity } from "./query";
+import {
+  findEntity,
+  getEntities,
+  getEntity,
+} from "@repo/shared/services/workflows/query";
 
 /**
  * Finds an organism by entity id, returning undefined when there is no match.
@@ -49,16 +52,6 @@ export function getOrganism<T extends OrganismContract>(entityId: string): T {
  */
 export function getOrganisms<T extends OrganismContract>(): T[] {
   return getEntities<T>("organisms");
-}
-
-/**
- * Gets the pangenome bundle for a species, or undefined when the species has no
- * pangenome.
- * @param speciesTaxonomyId - Species taxonomy ID.
- * @returns Pangenome bundle, or undefined.
- */
-export function getPangenome(speciesTaxonomyId: string): Pangenome | undefined {
-  return findEntity<Pangenome>("pangenomes", speciesTaxonomyId);
 }
 
 /**

--- a/packages/shared/services/workflows/entities.ts
+++ b/packages/shared/services/workflows/entities.ts
@@ -1,13 +1,6 @@
-import type {
-  AssemblyContract,
-  OrganismContract,
-} from "@repo/shared/apis/types";
-import type { Workflow, WorkflowCategory } from "@repo/shared/apis/workflow";
-import {
-  findEntity,
-  getEntities,
-  getEntity,
-} from "@repo/shared/services/workflows/query";
+import type { AssemblyContract, OrganismContract } from "../../apis/types";
+import type { Workflow, WorkflowCategory } from "../../apis/workflow";
+import { findEntity, getEntities, getEntity } from "./query";
 
 /**
  * Finds an organism by entity id, returning undefined when there is no match.

--- a/packages/shared/services/workflows/loader.ts
+++ b/packages/shared/services/workflows/loader.ts
@@ -1,0 +1,55 @@
+import { SiteConfig } from "@databiosphere/findable-ui/lib/config/entities";
+import { API } from "./routes";
+import { getEntitiesById, setEntitiesById, setEntitiesByType } from "./store";
+import type { EntityRoute } from "./types";
+
+/**
+ * Fetches entities from the API.
+ * @param url - URL.
+ * @returns Entity list.
+ */
+export async function fetchEntities(url: string): Promise<unknown[]> {
+  const res = await fetch(url);
+
+  if (!res.ok) throw new Error(`Failed to fetch: ${url}`);
+
+  return (await res.json()) as unknown[];
+}
+
+/**
+ * Checks if the route is an entity route.
+ * @param route - Route.
+ * @returns True if the route is an entity route; false otherwise.
+ */
+function isEntityRoute(route: string): route is EntityRoute {
+  return route in API;
+}
+
+/**
+ * Loads the entities store with entities from the API.
+ * @param config - Site config.
+ */
+export async function loadEntities(config: SiteConfig): Promise<void> {
+  for (const entity of config.entities) {
+    const { getId, route } = entity;
+
+    if (!isEntityRoute(route)) continue;
+
+    const apiRoute = API[route];
+
+    // Entities are already loaded; skip.
+    if (getEntitiesById().has(route)) continue;
+
+    // Get id function is not configured; entities are excluded from preloading.
+    if (!getId) continue;
+
+    // Fetch the entities.
+    const entities = await fetchEntities(apiRoute);
+
+    const entityById = new Map<string, unknown>();
+    for (const entity of entities) entityById.set(getId(entity), entity);
+
+    setEntitiesById(route, entityById);
+    setEntitiesByType(route, entities);
+  }
+}

--- a/packages/shared/services/workflows/loader.ts
+++ b/packages/shared/services/workflows/loader.ts
@@ -22,7 +22,7 @@ export async function fetchEntities(url: string): Promise<unknown[]> {
  * @returns True if the route is an entity route; false otherwise.
  */
 function isEntityRoute(route: string): route is EntityRoute {
-  return route in API;
+  return Object.hasOwn(API, route);
 }
 
 /**

--- a/packages/shared/services/workflows/query.ts
+++ b/packages/shared/services/workflows/query.ts
@@ -1,5 +1,5 @@
 import { getEntitiesById, getEntitiesByType } from "./store";
-import { EntityRoute } from "./types";
+import type { EntityRoute, EntityStoreKey } from "./types";
 
 /**
  * Finds an entity by entity list type and entity id, returning undefined when
@@ -9,7 +9,7 @@ import { EntityRoute } from "./types";
  * @returns Entity, or undefined when not found.
  */
 export function findEntity<T>(
-  entityListType: EntityRoute,
+  entityListType: EntityStoreKey,
   entityId: string
 ): T | undefined {
   return getEntitiesById().get(entityListType)?.get(entityId) as T | undefined;

--- a/packages/shared/services/workflows/routes.ts
+++ b/packages/shared/services/workflows/routes.ts
@@ -1,7 +1,6 @@
 export const API = {
   assemblies: "/api/assemblies.json",
   organisms: "/api/organisms.json",
-  pangenomes: "/api/pangenomes.json",
   workflowAssemblyMappings: "/api/workflow-assembly-mappings.json",
   workflows: "/api/workflows.json",
 } as const;

--- a/packages/shared/services/workflows/store.ts
+++ b/packages/shared/services/workflows/store.ts
@@ -1,25 +1,25 @@
-import { EntityRoute } from "./types";
+import type { EntityStoreKey } from "./types";
 
 // entityListType -> T[]
-const ENTITIES_BY_TYPE = new Map<EntityRoute, unknown[]>();
+const ENTITIES_BY_TYPE = new Map<EntityStoreKey, unknown[]>();
 
 // entityListType -> entityId -> T
-const ENTITIES_BY_ENTITY_ID = new Map<EntityRoute, Map<string, unknown>>();
+const ENTITIES_BY_ENTITY_ID = new Map<EntityStoreKey, Map<string, unknown>>();
 
 /**
  * Gets entities by entity id.
  * @returns Map of entity list types to entity id to entity.
  */
-export function getEntitiesById(): Map<EntityRoute, Map<string, unknown>> {
-  return ENTITIES_BY_ENTITY_ID as Map<EntityRoute, Map<string, unknown>>;
+export function getEntitiesById(): Map<EntityStoreKey, Map<string, unknown>> {
+  return ENTITIES_BY_ENTITY_ID as Map<EntityStoreKey, Map<string, unknown>>;
 }
 
 /**
  * Gets entities by entity list type.
  * @returns Map of entity list types to entities.
  */
-export function getEntitiesByType(): Map<EntityRoute, unknown[]> {
-  return ENTITIES_BY_TYPE as Map<EntityRoute, unknown[]>;
+export function getEntitiesByType(): Map<EntityStoreKey, unknown[]> {
+  return ENTITIES_BY_TYPE as Map<EntityStoreKey, unknown[]>;
 }
 
 /**
@@ -28,7 +28,7 @@ export function getEntitiesByType(): Map<EntityRoute, unknown[]> {
  * @param entitiesById - Map of entity id to entity.
  */
 export function setEntitiesById(
-  entityListType: EntityRoute,
+  entityListType: EntityStoreKey,
   entitiesById: Map<string, unknown>
 ): void {
   ENTITIES_BY_ENTITY_ID.set(entityListType, entitiesById);
@@ -40,7 +40,7 @@ export function setEntitiesById(
  * @param entities - Entities.
  */
 export function setEntitiesByType(
-  entityListType: EntityRoute,
+  entityListType: EntityStoreKey,
   entities: unknown[]
 ): void {
   ENTITIES_BY_TYPE.set(entityListType, entities);

--- a/packages/shared/services/workflows/store.ts
+++ b/packages/shared/services/workflows/store.ts
@@ -11,7 +11,7 @@ const ENTITIES_BY_ENTITY_ID = new Map<EntityStoreKey, Map<string, unknown>>();
  * @returns Map of entity list types to entity id to entity.
  */
 export function getEntitiesById(): Map<EntityStoreKey, Map<string, unknown>> {
-  return ENTITIES_BY_ENTITY_ID as Map<EntityStoreKey, Map<string, unknown>>;
+  return ENTITIES_BY_ENTITY_ID;
 }
 
 /**
@@ -19,7 +19,7 @@ export function getEntitiesById(): Map<EntityStoreKey, Map<string, unknown>> {
  * @returns Map of entity list types to entities.
  */
 export function getEntitiesByType(): Map<EntityStoreKey, unknown[]> {
-  return ENTITIES_BY_TYPE as Map<EntityStoreKey, unknown[]>;
+  return ENTITIES_BY_TYPE;
 }
 
 /**

--- a/packages/shared/services/workflows/types.ts
+++ b/packages/shared/services/workflows/types.ts
@@ -1,0 +1,8 @@
+import { API } from "./routes";
+
+export type EntityRoute = keyof typeof API;
+
+// Store key: the shared entity routes plus any site-specific keys a site's
+// loader stashes in the shared cache. `(string & {})` keeps EntityRoute
+// autocomplete while still admitting other string keys.
+export type EntityStoreKey = EntityRoute | (string & {});

--- a/pages/data/favorites.tsx
+++ b/pages/data/favorites.tsx
@@ -1,6 +1,5 @@
 import { SectionHero } from "@/components/Layout/components/AppLayout/components/Section/components/SectionHero/sectionHero";
 import { StyledPagesMain } from "@/components/Layout/components/Main/main.styles";
-import { getEntity } from "@/services/workflows/query";
 import { Assembly } from "@/views/WorkflowInputsView/types";
 import { Breadcrumb } from "@databiosphere/findable-ui/lib/components/common/Breadcrumbs/breadcrumbs";
 import {
@@ -14,6 +13,7 @@ import {
 import { sanitizeEntityId } from "@repo/shared/apis/utils";
 import { useAssemblyFavorites } from "@repo/shared/components/Favorites/hooks/UseAssemblyFavorites/hook";
 import { useAuth } from "@repo/shared/providers/authentication/provider";
+import { getEntity } from "@repo/shared/services/workflows/query";
 import Link from "next/link";
 import { JSX } from "react";
 

--- a/tests/services/workflows.loader.test.ts
+++ b/tests/services/workflows.loader.test.ts
@@ -1,11 +1,12 @@
-import {
-  loadEntities,
-  loadPangenomes,
-  loadWorkflows,
-} from "@/services/workflows/loader";
-import { API } from "@/services/workflows/routes";
-import { getEntitiesById, getEntitiesByType } from "@/services/workflows/store";
+import { loadPangenomes, loadWorkflows } from "@/services/workflows/brc/loader";
+import { API as BRC_API } from "@/services/workflows/brc/routes";
 import { SiteConfig } from "@databiosphere/findable-ui/lib/config/entities";
+import { loadEntities } from "@repo/shared/services/workflows/loader";
+import { API } from "@repo/shared/services/workflows/routes";
+import {
+  getEntitiesById,
+  getEntitiesByType,
+} from "@repo/shared/services/workflows/store";
 
 const CONFIG = {
   entities: [{ getId, route: "assemblies" }],
@@ -145,7 +146,7 @@ describe("workflows loader", () => {
 
       await loadPangenomes();
 
-      expect(fetchMock).toHaveBeenCalledWith(API.pangenomes);
+      expect(fetchMock).toHaveBeenCalledWith(BRC_API.pangenomes);
 
       const byId = getEntitiesById().get("pangenomes");
       const byType = getEntitiesByType().get("pangenomes");

--- a/tests/services/workflows.query.test.ts
+++ b/tests/services/workflows.query.test.ts
@@ -1,10 +1,10 @@
-import { getEntities, getEntity } from "@/services/workflows/query";
+import { getEntities, getEntity } from "@repo/shared/services/workflows/query";
 import {
   getEntitiesById,
   getEntitiesByType,
   setEntitiesById,
   setEntitiesByType,
-} from "@/services/workflows/store";
+} from "@repo/shared/services/workflows/store";
 
 describe("workflows query", () => {
   beforeEach(() => {

--- a/tests/services/workflows.store.test.ts
+++ b/tests/services/workflows.store.test.ts
@@ -3,7 +3,7 @@ import {
   getEntitiesByType,
   setEntitiesById,
   setEntitiesByType,
-} from "@/services/workflows/store";
+} from "@repo/shared/services/workflows/store";
 
 describe("workflows store", () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary

Moves the site-neutral workflows **data-service** into `@repo/shared/services/workflows` as part of the shared-package extraction:

- `routes.ts`, `types.ts`, `store.ts`, `query.ts`, `entities.ts`, and the loader's `fetchEntities` / `loadEntities` → `@repo/shared/services/workflows/`
- `types.ts` adds `EntityStoreKey` (`EntityRoute | (string & {})`) so the shared store/query stay a neutral cache while a site can stash extra keys (e.g. pangenomes) without leaking site-specific routes into the shared enum.

### Intentionally left staged in `app/services/workflows/brc/`

`loadWorkflows` and `loadPangenomes` remain app-side (in `brc/loader.ts`, with `getPangenome` in `brc/entities.ts` and the pangenomes route in `brc/routes.ts`) because they're still coupled to app/view code. Making `loadWorkflows` shared (by parameterizing it and giving `formatTrsId` a neutral workflow-domain home) is tracked in #1528 — please don't flag it here.

Consumers across views/pages and the workflows service tests are repointed to the shared paths.

Closes #1518

🤖 Generated with [Claude Code](https://claude.com/claude-code)