### PR TITLE
refactor: make loadworkflows shared and establish a generic workflow-domain folder (#1528)

### DIFF
--- a/app/apis/catalog/brc-analytics-catalog/common/utils.ts
+++ b/app/apis/catalog/brc-analytics-catalog/common/utils.ts
@@ -1,9 +1,9 @@
-import { formatTrsId } from "@/views/AnalyzeWorkflowsView/components/Main/utils";
 import {
   ORGANISM_PLOIDY,
   WORKFLOW_PLOIDY,
 } from "@repo/shared/apis/schema-types";
 import { sanitizeEntityId } from "@repo/shared/apis/utils";
+import { formatTrsId } from "@repo/shared/workflow/utils";
 import { WorkflowEntity } from "@site-config/brc-analytics/local/index/workflow/types";
 import { BRCDataCatalogGenome, BRCDataCatalogOrganism } from "./entities";
 

--- a/app/apis/catalog/ga2/utils.ts
+++ b/app/apis/catalog/ga2/utils.ts
@@ -1,5 +1,5 @@
-import { formatTrsId } from "@/views/AnalyzeWorkflowsView/components/Main/utils";
 import { sanitizeEntityId } from "@repo/shared/apis/utils";
+import { formatTrsId } from "@repo/shared/workflow/utils";
 import { WorkflowEntity } from "@site-config/ga2/local/index/workflow/types";
 import { GA2AssemblyEntity, GA2OrganismEntity } from "./entities";
 

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/hooks/UseLaunchGalaxy/useLaunchGalaxy.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/hooks/UseLaunchGalaxy/useLaunchGalaxy.ts
@@ -4,14 +4,14 @@ import {
   getLMLSLandingUrl,
   getWorkflowLandingUrl,
 } from "@/utils/galaxy-api/galaxy-api";
-import { CUSTOM_WORKFLOW } from "@/views/AnalyzeWorkflowsView/custom/constants";
-import { DIFFERENTIAL_EXPRESSION_ANALYSIS } from "@/views/AnalyzeWorkflowsView/differentialExpressionAnalysis/constants";
-import { LEXICMAP } from "@/views/AnalyzeWorkflowsView/lexicmap/constants";
-import { LOGAN_SEARCH } from "@/views/AnalyzeWorkflowsView/loganSearch/constants";
 import { useAsync } from "@databiosphere/findable-ui/lib/hooks/useAsync";
 import { useConfig } from "@databiosphere/findable-ui/lib/hooks/useConfig";
 import type { Workflow } from "@repo/shared/apis/workflow";
 import { apiClient } from "@repo/shared/services/api-client/api-client";
+import { CUSTOM_WORKFLOW } from "@repo/shared/workflow/custom";
+import { DIFFERENTIAL_EXPRESSION_ANALYSIS } from "@repo/shared/workflow/differentialExpressionAnalysis";
+import { LEXICMAP } from "@repo/shared/workflow/lexicmap";
+import { LOGAN_SEARCH } from "@repo/shared/workflow/loganSearch";
 import { useRouter } from "next/router";
 import { useCallback } from "react";
 import {

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/hooks/UseLaunchGalaxy/utils.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/hooks/UseLaunchGalaxy/utils.ts
@@ -1,4 +1,3 @@
-import { DIFFERENTIAL_EXPRESSION_ANALYSIS } from "@/views/AnalyzeWorkflowsView/differentialExpressionAnalysis/constants";
 import { ConfiguredInput } from "@/views/WorkflowInputsView/hooks/UseConfigureInputs/types";
 import {
   ANCHOR_TARGET,
@@ -7,6 +6,7 @@ import {
 import { WORKFLOW_PARAMETER_VARIABLE } from "@repo/shared/apis/schema-types";
 import type { Workflow } from "@repo/shared/apis/workflow";
 import type { WorkflowRunCreateRequest } from "@repo/shared/services/api-client/types";
+import { DIFFERENTIAL_EXPRESSION_ANALYSIS } from "@repo/shared/workflow/differentialExpressionAnalysis";
 import {
   ConfiguredValue,
   isAssemblyConfiguredValue,

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/steps/utils.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/steps/utils.ts
@@ -1,11 +1,11 @@
-import { CUSTOM_WORKFLOW } from "@/views/AnalyzeWorkflowsView/custom/constants";
-import { DIFFERENTIAL_EXPRESSION_ANALYSIS } from "@/views/AnalyzeWorkflowsView/differentialExpressionAnalysis/constants";
 import { ConfiguredInput } from "@/views/WorkflowInputsView/hooks/UseConfigureInputs/types";
 import {
   WORKFLOW_PARAMETER_VARIABLE,
   WORKFLOW_SCOPE,
 } from "@repo/shared/apis/schema-types";
 import type { Workflow } from "@repo/shared/apis/workflow";
+import { CUSTOM_WORKFLOW } from "@repo/shared/workflow/custom";
+import { DIFFERENTIAL_EXPRESSION_ANALYSIS } from "@repo/shared/workflow/differentialExpressionAnalysis";
 import { StepConfig } from "../components/Step/types";
 import { STEP } from "./constants";
 

--- a/app/services/workflows/brc/loader.ts
+++ b/app/services/workflows/brc/loader.ts
@@ -1,13 +1,6 @@
 import type { Pangenome } from "@/apis/catalog/brc-analytics-catalog/common/pangenome";
 import { API as BRC_API } from "@/services/workflows/brc/routes";
-import { formatTrsId } from "@/views/AnalyzeWorkflowsView/components/Main/utils";
-import { CUSTOM_WORKFLOW } from "@/views/AnalyzeWorkflowsView/custom/constants";
-import { DIFFERENTIAL_EXPRESSION_ANALYSIS } from "@/views/AnalyzeWorkflowsView/differentialExpressionAnalysis/constants";
-import { LEXICMAP } from "@/views/AnalyzeWorkflowsView/lexicmap/constants";
-import { LOGAN_SEARCH } from "@/views/AnalyzeWorkflowsView/loganSearch/constants";
-import type { Workflow, WorkflowCategory } from "@repo/shared/apis/workflow";
 import { fetchEntities } from "@repo/shared/services/workflows/loader";
-import { API } from "@repo/shared/services/workflows/routes";
 import {
   getEntitiesById,
   setEntitiesById,
@@ -43,39 +36,4 @@ export async function loadPangenomes(): Promise<void> {
 
   setEntitiesById("pangenomes", pangenomeBySpeciesTaxonomyId);
   setEntitiesByType("pangenomes", pangenomes);
-}
-
-/**
- * Loads the workflows store with workflows from the API.
- */
-export async function loadWorkflows(): Promise<void> {
-  if (getEntitiesById().has("workflows")) return;
-
-  const workflowCategories = (await fetchEntities(
-    API.workflows
-  )) as WorkflowCategory[];
-
-  const workflows = workflowCategories.flatMap((w) => w.workflows);
-
-  const workflowById = new Map<string, Workflow>();
-
-  for (const workflow of workflows) {
-    workflowById.set(formatTrsId(workflow.trsId), workflow);
-  }
-
-  // Add custom workflow.
-  workflowById.set(CUSTOM_WORKFLOW.trsId, CUSTOM_WORKFLOW);
-
-  // Add differential expression analysis.
-  workflowById.set(
-    DIFFERENTIAL_EXPRESSION_ANALYSIS.trsId,
-    DIFFERENTIAL_EXPRESSION_ANALYSIS
-  );
-
-  // Add LMLS workflows (Logan Search and Lexicmap).
-  workflowById.set(LOGAN_SEARCH.trsId, LOGAN_SEARCH);
-  workflowById.set(LEXICMAP.trsId, LEXICMAP);
-
-  setEntitiesById("workflows", workflowById);
-  setEntitiesByType("workflows", workflowCategories);
 }

--- a/app/services/workflows/hooks/UseEntities/utils.ts
+++ b/app/services/workflows/hooks/UseEntities/utils.ts
@@ -1,6 +1,13 @@
-import { loadPangenomes, loadWorkflows } from "@/services/workflows/brc/loader";
+import { loadPangenomes } from "@/services/workflows/brc/loader";
 import { SiteConfig } from "@databiosphere/findable-ui/lib/config/entities";
-import { loadEntities } from "@repo/shared/services/workflows/loader";
+import {
+  loadEntities,
+  loadWorkflows,
+} from "@repo/shared/services/workflows/loader";
+import { CUSTOM_WORKFLOW } from "@repo/shared/workflow/custom";
+import { DIFFERENTIAL_EXPRESSION_ANALYSIS } from "@repo/shared/workflow/differentialExpressionAnalysis";
+import { LEXICMAP } from "@repo/shared/workflow/lexicmap";
+import { LOGAN_SEARCH } from "@repo/shared/workflow/loganSearch";
 
 let loadPromise: Promise<void> | null = null;
 
@@ -16,7 +23,12 @@ export function ensureEntitiesLoaded(config: SiteConfig): Promise<void> {
     // Load in parallel so the optional pangenome fetch adds no serial latency
     // to the core workflows/entities load that every data page depends on.
     await Promise.all([
-      loadWorkflows(),
+      loadWorkflows([
+        CUSTOM_WORKFLOW,
+        DIFFERENTIAL_EXPRESSION_ANALYSIS,
+        LOGAN_SEARCH,
+        LEXICMAP,
+      ]),
       loadPangenomes(),
       loadEntities(config),
     ]);

--- a/app/views/AnalyzeWorkflowsView/components/Main/components/Accordion/components/Workflow/workflow.tsx
+++ b/app/views/AnalyzeWorkflowsView/components/Main/components/Accordion/components/Workflow/workflow.tsx
@@ -1,5 +1,4 @@
 import { TYPOGRAPHY_PROPS as COMPONENT_TYPOGRAPHY_PROPS } from "@/views/AnalyzeWorkflowsView/components/Main/components/Accordion/constants";
-import { formatTrsId } from "@/views/AnalyzeWorkflowsView/components/Main/utils";
 import { REL_ATTRIBUTE } from "@databiosphere/findable-ui/lib/components/Links/common/entities";
 import { Link as DXLink } from "@databiosphere/findable-ui/lib/components/Links/components/Link/link";
 import { BUTTON_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/button";
@@ -7,6 +6,7 @@ import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/m
 import { replaceParameters } from "@databiosphere/findable-ui/lib/utils/replaceParameters";
 import { Button, Grid, Typography } from "@mui/material";
 import { ROUTES } from "@repo/shared/routes/constants";
+import { formatTrsId } from "@repo/shared/workflow/utils";
 import Link from "next/link";
 import { Fragment, JSX } from "react";
 import { GRID_PROPS } from "./constants";

--- a/app/views/AnalyzeWorkflowsView/components/Main/utils.ts
+++ b/app/views/AnalyzeWorkflowsView/components/Main/utils.ts
@@ -1,11 +1,11 @@
 import { workflowPloidyMatchesOrganismPloidy } from "@/apis/catalog/brc-analytics-catalog/common/utils";
-import { DIFFERENTIAL_EXPRESSION_ANALYSIS } from "@/views/AnalyzeWorkflowsView/differentialExpressionAnalysis/constants";
 import {
   WORKFLOW_PARAMETER_VARIABLE,
   WORKFLOW_SCOPE,
 } from "@repo/shared/apis/schema-types";
 import type { AssemblyContract } from "@repo/shared/apis/types";
 import type { Workflow, WorkflowCategory } from "@repo/shared/apis/workflow";
+import { DIFFERENTIAL_EXPRESSION_ANALYSIS } from "@repo/shared/workflow/differentialExpressionAnalysis";
 import { WorkflowCategoryId } from "../../../../../catalog/schema/generated/schema";
 
 /**
@@ -57,16 +57,6 @@ export function buildAssemblyWorkflows(
 
   // Sort workflow categories (coming soon categories last).
   return workflowCategories.sort(sortWorkflowCategories);
-}
-
-/**
- * Formats a trsId for use in URLs by removing the hash character if it begins with one
- * and replacing any special characters with hyphens.
- * @param trsId - The trsId to format.
- * @returns The formatted trsId.
- */
-export function formatTrsId(trsId: string): string {
-  return trsId.replace(/^#/, "").replace(/[^a-zA-Z0-9]/g, "-");
 }
 
 /**

--- a/app/views/WorkflowsView/utils.ts
+++ b/app/views/WorkflowsView/utils.ts
@@ -4,10 +4,10 @@ import type {
   WorkflowAssemblyMapping,
   WorkflowCategory,
 } from "@repo/shared/apis/workflow";
+import { DIFFERENTIAL_EXPRESSION_ANALYSIS } from "@repo/shared/workflow/differentialExpressionAnalysis";
+import { LEXICMAP } from "@repo/shared/workflow/lexicmap";
+import { LOGAN_SEARCH } from "@repo/shared/workflow/loganSearch";
 import { WorkflowCategoryId } from "../../../catalog/schema/generated/schema";
-import { DIFFERENTIAL_EXPRESSION_ANALYSIS } from "../AnalyzeWorkflowsView/differentialExpressionAnalysis/constants";
-import { LEXICMAP } from "../AnalyzeWorkflowsView/lexicmap/constants";
-import { LOGAN_SEARCH } from "../AnalyzeWorkflowsView/loganSearch/constants";
 import type { Assembly } from "../WorkflowInputsView/types";
 import type { Organism, WorkflowAssembly, WorkflowEntity } from "./types";
 

--- a/packages/shared/services/workflows/loader.ts
+++ b/packages/shared/services/workflows/loader.ts
@@ -1,4 +1,6 @@
 import { SiteConfig } from "@databiosphere/findable-ui/lib/config/entities";
+import type { Workflow, WorkflowCategory } from "../../apis/workflow";
+import { formatTrsId } from "../../workflow/utils";
 import { API } from "./routes";
 import { getEntitiesById, setEntitiesById, setEntitiesByType } from "./store";
 import type { EntityRoute } from "./types";
@@ -52,4 +54,34 @@ export async function loadEntities(config: SiteConfig): Promise<void> {
     setEntitiesById(route, entityById);
     setEntitiesByType(route, entities);
   }
+}
+
+/**
+ * Loads the workflows store with workflows from the API, plus any additional
+ * workflows supplied by the caller.
+ * @param extraWorkflows - Additional workflows to add to the store, keyed by their trsId.
+ */
+export async function loadWorkflows(
+  extraWorkflows: Workflow[] = []
+): Promise<void> {
+  if (getEntitiesById().has("workflows")) return;
+
+  const workflowCategories = (await fetchEntities(
+    API.workflows
+  )) as WorkflowCategory[];
+
+  const workflows = workflowCategories.flatMap((w) => w.workflows);
+
+  const workflowById = new Map<string, Workflow>();
+
+  for (const workflow of workflows) {
+    workflowById.set(formatTrsId(workflow.trsId), workflow);
+  }
+
+  for (const workflow of extraWorkflows) {
+    workflowById.set(workflow.trsId, workflow);
+  }
+
+  setEntitiesById("workflows", workflowById);
+  setEntitiesByType("workflows", workflowCategories);
 }

--- a/packages/shared/workflow/custom.ts
+++ b/packages/shared/workflow/custom.ts
@@ -2,8 +2,8 @@ import {
   WORKFLOW_PARAMETER_VARIABLE,
   WORKFLOW_PLOIDY,
   WORKFLOW_SCOPE,
-} from "@repo/shared/apis/schema-types";
-import type { Workflow } from "@repo/shared/apis/workflow";
+} from "../apis/schema-types";
+import type { Workflow } from "../apis/workflow";
 
 export const CUSTOM_WORKFLOW: Workflow = {
   assemblyCountMax: 1,

--- a/packages/shared/workflow/differentialExpressionAnalysis.ts
+++ b/packages/shared/workflow/differentialExpressionAnalysis.ts
@@ -1,8 +1,5 @@
-import {
-  WORKFLOW_PLOIDY,
-  WORKFLOW_SCOPE,
-} from "@repo/shared/apis/schema-types";
-import type { Workflow } from "@repo/shared/apis/workflow";
+import { WORKFLOW_PLOIDY, WORKFLOW_SCOPE } from "../apis/schema-types";
+import type { Workflow } from "../apis/workflow";
 
 export const DIFFERENTIAL_EXPRESSION_ANALYSIS: Workflow = {
   assemblyCountMax: 1,

--- a/packages/shared/workflow/lexicmap.ts
+++ b/packages/shared/workflow/lexicmap.ts
@@ -1,8 +1,5 @@
-import {
-  WORKFLOW_PLOIDY,
-  WORKFLOW_SCOPE,
-} from "@repo/shared/apis/schema-types";
-import type { Workflow } from "@repo/shared/apis/workflow";
+import { WORKFLOW_PLOIDY, WORKFLOW_SCOPE } from "../apis/schema-types";
+import type { Workflow } from "../apis/workflow";
 
 export const LEXICMAP: Workflow = {
   assemblyCountMax: 0,

--- a/packages/shared/workflow/loganSearch.ts
+++ b/packages/shared/workflow/loganSearch.ts
@@ -1,8 +1,5 @@
-import {
-  WORKFLOW_PLOIDY,
-  WORKFLOW_SCOPE,
-} from "@repo/shared/apis/schema-types";
-import type { Workflow } from "@repo/shared/apis/workflow";
+import { WORKFLOW_PLOIDY, WORKFLOW_SCOPE } from "../apis/schema-types";
+import type { Workflow } from "../apis/workflow";
 
 export const LOGAN_SEARCH: Workflow = {
   assemblyCountMax: 0,

--- a/packages/shared/workflow/utils.ts
+++ b/packages/shared/workflow/utils.ts
@@ -1,0 +1,9 @@
+/**
+ * Formats a trsId for use in URLs by removing the hash character if it begins with one
+ * and replacing any special characters with hyphens.
+ * @param trsId - The trsId to format.
+ * @returns The formatted trsId.
+ */
+export function formatTrsId(trsId: string): string {
+  return trsId.replace(/^#/, "").replace(/[^a-zA-Z0-9]/g, "-");
+}

--- a/pages/data/[entityListType]/[entityId]/analyze/custom.tsx
+++ b/pages/data/[entityListType]/[entityId]/analyze/custom.tsx
@@ -2,9 +2,9 @@ import { getPageMeta } from "@/common/meta/utils";
 import { config } from "@/config/config";
 import { getEntities } from "@/utils/entityUtils";
 import { seedDatabase } from "@/utils/seedDatabase";
-import { CUSTOM_WORKFLOW } from "@/views/AnalyzeWorkflowsView/custom/constants";
 import { WorkflowInputsView } from "@/views/WorkflowInputsView/workflowInputsView";
 import { EntityDataGate } from "@repo/shared/components/EntityDataGate/entityDataGate";
+import { CUSTOM_WORKFLOW } from "@repo/shared/workflow/custom";
 import {
   GetStaticPaths,
   GetStaticPathsResult,

--- a/pages/data/workflows/[trsId]/index.tsx
+++ b/pages/data/workflows/[trsId]/index.tsx
@@ -1,11 +1,11 @@
 import { getPageMeta } from "@/common/meta/utils";
 import { config } from "@/config/config";
-import { formatTrsId } from "@/views/AnalyzeWorkflowsView/components/Main/utils";
-import { DIFFERENTIAL_EXPRESSION_ANALYSIS } from "@/views/AnalyzeWorkflowsView/differentialExpressionAnalysis/constants";
-import { LEXICMAP } from "@/views/AnalyzeWorkflowsView/lexicmap/constants";
-import { LOGAN_SEARCH } from "@/views/AnalyzeWorkflowsView/loganSearch/constants";
 import { WorkflowView } from "@/views/WorkflowView/workflowView";
 import { EntityDataGate } from "@repo/shared/components/EntityDataGate/entityDataGate";
+import { DIFFERENTIAL_EXPRESSION_ANALYSIS } from "@repo/shared/workflow/differentialExpressionAnalysis";
+import { LEXICMAP } from "@repo/shared/workflow/lexicmap";
+import { LOGAN_SEARCH } from "@repo/shared/workflow/loganSearch";
+import { formatTrsId } from "@repo/shared/workflow/utils";
 import { GetStaticPaths, GetStaticProps, GetStaticPropsContext } from "next";
 import { ParsedUrlQuery } from "querystring";
 import { JSX } from "react";

--- a/tests/analysisMethodCatalogs.utils.test.ts
+++ b/tests/analysisMethodCatalogs.utils.test.ts
@@ -4,9 +4,9 @@ import {
   WORKFLOW_SCOPE,
 } from "@repo/shared/apis/schema-types";
 import type { WorkflowCategory } from "@repo/shared/apis/workflow";
+import { DIFFERENTIAL_EXPRESSION_ANALYSIS } from "@repo/shared/workflow/differentialExpressionAnalysis";
 import type { BRCDataCatalogGenome } from "../app/apis/catalog/brc-analytics-catalog/common/entities";
 import { buildAssemblyWorkflows } from "../app/views/AnalyzeWorkflowsView/components/Main/utils";
-import { DIFFERENTIAL_EXPRESSION_ANALYSIS } from "../app/views/AnalyzeWorkflowsView/differentialExpressionAnalysis/constants";
 import { WorkflowCategoryId } from "../catalog/schema/generated/schema";
 
 describe("buildAssemblyWorkflows", () => {

--- a/tests/components/configureWorkflowInputs/getConfiguredValues.scope.test.ts
+++ b/tests/components/configureWorkflowInputs/getConfiguredValues.scope.test.ts
@@ -8,25 +8,19 @@ import {
 import type { Workflow } from "@repo/shared/apis/workflow";
 
 // Mock workflow constants to avoid pulling in unneeded modules
-jest.mock(
-  "../../../app/views/AnalyzeWorkflowsView/differentialExpressionAnalysis/constants",
-  () => ({
-    DIFFERENTIAL_EXPRESSION_ANALYSIS: {
-      trsId: "differential-expression-analysis",
-    },
-  })
-);
+jest.mock("@repo/shared/workflow/differentialExpressionAnalysis", () => ({
+  DIFFERENTIAL_EXPRESSION_ANALYSIS: {
+    trsId: "differential-expression-analysis",
+  },
+}));
 
-jest.mock(
-  "../../../app/views/AnalyzeWorkflowsView/loganSearch/constants",
-  () => ({
-    LOGAN_SEARCH: {
-      trsId: "logan-search",
-    },
-  })
-);
+jest.mock("@repo/shared/workflow/loganSearch", () => ({
+  LOGAN_SEARCH: {
+    trsId: "logan-search",
+  },
+}));
 
-jest.mock("../../../app/views/AnalyzeWorkflowsView/lexicmap/constants", () => ({
+jest.mock("@repo/shared/workflow/lexicmap", () => ({
   LEXICMAP: {
     trsId: "lexicmap",
   },

--- a/tests/services/workflows.loader.test.ts
+++ b/tests/services/workflows.loader.test.ts
@@ -1,7 +1,11 @@
-import { loadPangenomes, loadWorkflows } from "@/services/workflows/brc/loader";
+import { loadPangenomes } from "@/services/workflows/brc/loader";
 import { API as BRC_API } from "@/services/workflows/brc/routes";
 import { SiteConfig } from "@databiosphere/findable-ui/lib/config/entities";
-import { loadEntities } from "@repo/shared/services/workflows/loader";
+import type { Workflow } from "@repo/shared/apis/workflow";
+import {
+  loadEntities,
+  loadWorkflows,
+} from "@repo/shared/services/workflows/loader";
 import { API } from "@repo/shared/services/workflows/routes";
 import {
   getEntitiesById,
@@ -11,14 +15,6 @@ import {
 const CONFIG = {
   entities: [{ getId, route: "assemblies" }],
 } as SiteConfig;
-
-jest.mock("../../app/views/AnalyzeWorkflowsView/components/Main/utils", () => ({
-  formatTrsId: (trsId: string): string => trsId,
-}));
-
-jest.mock("../../app/views/AnalyzeWorkflowsView/custom/constants", () => ({
-  CUSTOM_WORKFLOW: { trsId: "custom-workflow" },
-}));
 
 describe("workflows loader", () => {
   let fetchMock: jest.MockedFunction<typeof fetch>;
@@ -105,10 +101,11 @@ describe("workflows loader", () => {
   describe("loadWorkflows", () => {
     test("loads workflow categories, flattens workflows, and populates store", async () => {
       const categories = [{ workflows: [{ trsId: "trs-1" }] }];
+      const extraWorkflows = [{ trsId: "custom-workflow" } as Workflow];
 
       fetchMock.mockResolvedValue(mockFetchResponse(categories));
 
-      await loadWorkflows();
+      await loadWorkflows(extraWorkflows);
 
       expect(fetchMock).toHaveBeenCalledWith(API.workflows);
 

--- a/tests/views/analyzeWorkflowsView/buildAssemblyWorkflows.scope.test.ts
+++ b/tests/views/analyzeWorkflowsView/buildAssemblyWorkflows.scope.test.ts
@@ -1,12 +1,12 @@
 import type { BRCDataCatalogGenome } from "@/apis/catalog/brc-analytics-catalog/common/entities";
 import { buildAssemblyWorkflows } from "@/views/AnalyzeWorkflowsView/components/Main/utils";
-import { DIFFERENTIAL_EXPRESSION_ANALYSIS } from "@/views/AnalyzeWorkflowsView/differentialExpressionAnalysis/constants";
 import {
   ORGANISM_PLOIDY,
   WORKFLOW_PLOIDY,
   WORKFLOW_SCOPE,
 } from "@repo/shared/apis/schema-types";
 import type { WorkflowCategory } from "@repo/shared/apis/workflow";
+import { DIFFERENTIAL_EXPRESSION_ANALYSIS } from "@repo/shared/workflow/differentialExpressionAnalysis";
 import { WorkflowCategoryId } from "../../../catalog/schema/generated/schema";
 
 describe("buildAssemblyWorkflows - scope filtering", () => {

--- a/tests/views/workflowsView/getWorkflows.scope.test.ts
+++ b/tests/views/workflowsView/getWorkflows.scope.test.ts
@@ -9,23 +9,20 @@ import type {
   WorkflowCategory,
 } from "@repo/shared/apis/workflow";
 
-jest.mock(
-  "../../../app/views/AnalyzeWorkflowsView/differentialExpressionAnalysis/constants",
-  () => ({
-    DIFFERENTIAL_EXPRESSION_ANALYSIS: {
-      assemblyCountMax: 1,
-      assemblyCountMin: 1,
-      iwcId: "iwc-deseq2",
-      parameters: [],
-      ploidy: "ANY",
-      scope: "ASSEMBLY",
-      taxonomyId: null,
-      trsId: "differential-expression-analysis",
-      workflowDescription: "DESeq2 workflow",
-      workflowName: "Differential Expression Analysis",
-    },
-  })
-);
+jest.mock("@repo/shared/workflow/differentialExpressionAnalysis", () => ({
+  DIFFERENTIAL_EXPRESSION_ANALYSIS: {
+    assemblyCountMax: 1,
+    assemblyCountMin: 1,
+    iwcId: "iwc-deseq2",
+    parameters: [],
+    ploidy: "ANY",
+    scope: "ASSEMBLY",
+    taxonomyId: null,
+    trsId: "differential-expression-analysis",
+    workflowDescription: "DESeq2 workflow",
+    workflowName: "Differential Expression Analysis",
+  },
+}));
 
 describe("getWorkflows - scope handling", () => {
   const ORGANISMS: Organism[] = [];


### PR DESCRIPTION
## Summary

Follow-on from #1518. Makes `loadWorkflows` a shared, site-neutral loader and establishes `packages/shared/workflow/` as the home for all-things-workflow (distinct from the `services/workflows/` data-service and the `apis/workflow.ts` types).

### Changes

- **`packages/shared/workflow/`** (new domain folder):
  - `utils.ts` — `formatTrsId` (moved out of `AnalyzeWorkflowsView/.../Main/utils.ts`; it's a pure, both-site helper).
  - `custom.ts`, `differentialExpressionAnalysis.ts`, `lexicmap.ts`, `loganSearch.ts` — the synthetic workflow defs, moved from `app/views/AnalyzeWorkflowsView/<tool>/constants.ts`. They're consumed only by shared components/pages that both sites render, so they belong in shared.
- **`packages/shared/services/workflows/loader.ts`** — `loadWorkflows(extraWorkflows: Workflow[] = [])` now lives here: base fetch/flatten/key/store, then appends the caller-supplied extras. No longer hardcodes the synthetic defs.
- **`app/services/workflows/hooks/UseEntities/utils.ts`** — the orchestrator injects the 4 synthetic defs via the new parameter. Post-split, each site's orchestrator decides what to inject.
- **`app/services/workflows/brc/loader.ts`** — trimmed to just `loadPangenomes`.
- Consumers (both catalog utils, stepper launch/steps, AnalyzeWorkflowsView, WorkflowsView, pages, tests) repointed to `@repo/shared/workflow/*`.

Shared package stays pure (no `@/` or `@site-config` imports in the new/changed shared files).

Closes #1528

> Stacked on #1529 (#1518). Base will retarget to `main` once #1529 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)