### PR TITLE
chore: enforce import convention via eslint and normalize self-imports (#1573)

### DIFF
--- a/app/apis/catalog/brc-analytics-catalog/common/schema-entities.ts
+++ b/app/apis/catalog/brc-analytics-catalog/common/schema-entities.ts
@@ -1,4 +1,4 @@
 export {
   OutbreakPriority as OUTBREAK_PRIORITY,
   OutbreakResourceType as OUTBREAK_RESOURCE_TYPE,
-} from "../../../../../catalog/schema/generated/schema";
+} from "@catalog/schema/generated/schema";

--- a/app/components/Assistant/ChatPanel/chatPanel.tsx
+++ b/app/components/Assistant/ChatPanel/chatPanel.tsx
@@ -1,3 +1,5 @@
+import { ChatMessage } from "@/components/Assistant/ChatMessage/chatMessage";
+import { SuggestionChips } from "@/components/Assistant/SuggestionChips/suggestionChips";
 import {
   Alert,
   Box,
@@ -9,8 +11,6 @@ import {
 import { useAuth } from "@repo/shared/providers/authentication/provider";
 import type { SuggestionChip } from "@repo/shared/services/api-client/types";
 import { JSX, useEffect, useRef, useState } from "react";
-import { ChatMessage } from "../ChatMessage/chatMessage";
-import { SuggestionChips } from "../SuggestionChips/suggestionChips";
 import { ChatContainer, InputRow, MessagesContainer } from "./chatPanel.styles";
 
 interface ChatMessageDisplay {

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/AccessionCountStep/accessionCountStep.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/AccessionCountStep/accessionCountStep.tsx
@@ -1,3 +1,4 @@
+import { StepProps } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/types";
 import { StepContent } from "@databiosphere/findable-ui/lib/components/Stepper/components/Step/components/StepContent/stepContent";
 import { Optional } from "@databiosphere/findable-ui/lib/components/Stepper/components/Step/components/StepLabel/components/Optional/optional";
 import { StepLabel } from "@databiosphere/findable-ui/lib/components/Stepper/components/Step/components/StepLabel/stepLabel";
@@ -5,7 +6,6 @@ import { Step } from "@databiosphere/findable-ui/lib/components/Stepper/componen
 import { BUTTON_PROPS } from "@databiosphere/findable-ui/lib/components/common/Button/constants";
 import { Button, OutlinedInput } from "@mui/material";
 import { Fragment, JSX } from "react";
-import { StepProps } from "../types";
 import { StyledStack } from "./accessionCountStep.styles";
 import { useAccessionCount } from "./hooks/UseAccessionCount/hook";
 

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/AccessionCountStep/step.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/AccessionCountStep/step.ts
@@ -1,4 +1,4 @@
-import { StepConfig } from "../types";
+import { StepConfig } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/types";
 import { AccessionCountStep } from "./accessionCountStep";
 
 export const STEP = {

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/DESeq2FormulaStep/deSeq2FormulaStep.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/DESeq2FormulaStep/deSeq2FormulaStep.tsx
@@ -1,3 +1,5 @@
+import { StyledStack } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/step.styles";
+import { StepProps } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/types";
 import { BUTTON_PROPS } from "@databiosphere/findable-ui/lib/components/common/Button/constants";
 import { Optional } from "@databiosphere/findable-ui/lib/components/Stepper/components/Step/components/StepLabel/components/Optional/optional";
 import { StepLabel } from "@databiosphere/findable-ui/lib/components/Stepper/components/Step/components/StepLabel/stepLabel";
@@ -5,8 +7,6 @@ import { Step } from "@databiosphere/findable-ui/lib/components/Stepper/componen
 import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
 import { Button, Typography } from "@mui/material";
 import { Fragment, JSX } from "react";
-import { StyledStack } from "../step.styles";
-import { StepProps } from "../types";
 import { Alert } from "./components/Alert/alert";
 import { Table } from "./components/Table/table";
 import { StyledStepContent } from "./deSeq2FormulaStep.styles";

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/DESeq2FormulaStep/step.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/DESeq2FormulaStep/step.ts
@@ -1,4 +1,4 @@
-import { StepConfig } from "../types";
+import { StepConfig } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/types";
 import { DESeq2FormulaStep } from "./deSeq2FormulaStep";
 
 export const STEP = {

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/GTFStep/gtfStep.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/GTFStep/gtfStep.tsx
@@ -1,3 +1,9 @@
+import { StepWarning } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/components/StepWarning/stepWarning";
+import { StepProps } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/types";
+import {
+  getButtonDisabledState,
+  getStepActiveState,
+} from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/utils/stepUtils";
 import { useAssembly } from "@/components/Entity/components/ConfigureWorkflowInputs/providers/Assembly/hook";
 import { BUTTON_PROPS } from "@databiosphere/findable-ui/lib/components/common/Button/constants";
 import { RadioCheckedIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/RadioCheckedIcon/radioCheckedIcon";
@@ -21,9 +27,6 @@ import {
   Typography,
 } from "@mui/material";
 import { Fragment, JSX, useEffect } from "react";
-import { StepWarning } from "../components/StepWarning/stepWarning";
-import { StepProps } from "../types";
-import { getButtonDisabledState, getStepActiveState } from "../utils/stepUtils";
 import { StyledGrid } from "./gtfStep.styles";
 import { useRadioGroup } from "./hooks/UseRadioGroup/hook";
 import { useQuery } from "./query/hook";

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/GTFStep/query/options/queryFn.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/GTFStep/query/options/queryFn.ts
@@ -1,6 +1,6 @@
+import { QueryKey } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/GTFStep/query/types";
 import { QueryFunctionContext } from "@tanstack/react-query";
 import ky from "ky";
-import { QueryKey } from "../types";
 import { UCSC_FILES_ENDPOINT } from "./constants";
 
 /**

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/GTFStep/step.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/GTFStep/step.ts
@@ -1,5 +1,5 @@
+import { StepConfig } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/types";
 import { LABEL } from "@databiosphere/findable-ui/lib/apis/azul/common/entities";
-import { StepConfig } from "../types";
 import { GTFStep } from "./gtfStep";
 import { getGeneModelLabel } from "./utils";
 

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/GTFStep/utils.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/GTFStep/utils.ts
@@ -1,5 +1,5 @@
+import { UseRadioGroup } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/hooks/UseRadioGroup/types";
 import { OnConfigure } from "@/views/WorkflowInputsView/hooks/UseConfigureInputs/types";
-import { UseRadioGroup } from "../hooks/UseRadioGroup/types";
 import { STEP } from "./step";
 
 /**

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PrimaryContrastsStep/hooks/UseBaselineContrasts/utils.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PrimaryContrastsStep/hooks/UseBaselineContrasts/utils.ts
@@ -1,5 +1,5 @@
+import { CONTRAST_MODE } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PrimaryContrastsStep/hooks/UseRadioGroup/types";
 import { BaselineContrasts } from "@/views/WorkflowInputsView/hooks/UseConfigureInputs/types";
-import { CONTRAST_MODE } from "../UseRadioGroup/types";
 
 /**
  * Builds the primary contrasts for BASELINE mode.

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PrimaryContrastsStep/hooks/UseExplicitContrasts/utils.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PrimaryContrastsStep/hooks/UseExplicitContrasts/utils.ts
@@ -1,5 +1,5 @@
+import { CONTRAST_MODE } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PrimaryContrastsStep/hooks/UseRadioGroup/types";
 import { ExplicitContrasts } from "@/views/WorkflowInputsView/hooks/UseConfigureInputs/types";
-import { CONTRAST_MODE } from "../UseRadioGroup/types";
 import { ContrastPair, ContrastPairs } from "./types";
 
 /**

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PrimaryContrastsStep/hooks/UsePrimaryContrasts/hook.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PrimaryContrastsStep/hooks/UsePrimaryContrasts/hook.ts
@@ -1,7 +1,7 @@
+import { UseBaselineContrasts } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PrimaryContrastsStep/hooks/UseBaselineContrasts/types";
+import { UseExplicitContrasts } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PrimaryContrastsStep/hooks/UseExplicitContrasts/types";
+import { CONTRAST_MODE } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PrimaryContrastsStep/hooks/UseRadioGroup/types";
 import { useMemo } from "react";
-import { UseBaselineContrasts } from "../UseBaselineContrasts/types";
-import { UseExplicitContrasts } from "../UseExplicitContrasts/types";
-import { CONTRAST_MODE } from "../UseRadioGroup/types";
 import { UsePrimaryContrasts } from "./types";
 import { getPrimaryContrasts, isDisabled } from "./utils";
 

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PrimaryContrastsStep/hooks/UsePrimaryContrasts/utils.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PrimaryContrastsStep/hooks/UsePrimaryContrasts/utils.ts
@@ -1,10 +1,10 @@
+import { CONTRAST_MODE } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PrimaryContrastsStep/hooks/UseRadioGroup/types";
 import {
   AllVAllContrasts,
   BaselineContrasts,
   ExplicitContrasts,
   PrimaryContrasts,
 } from "@/views/WorkflowInputsView/hooks/UseConfigureInputs/types";
-import { CONTRAST_MODE } from "../UseRadioGroup/types";
 
 /**
  * Builds the primary contrasts configuration based on mode.

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PrimaryContrastsStep/primaryContrastsStep.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PrimaryContrastsStep/primaryContrastsStep.tsx
@@ -1,11 +1,11 @@
+import { useRadioGroup } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/hooks/UseRadioGroup/hook";
+import { StyledStack as CommonStyledStack } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/step.styles";
+import { StepProps } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/types";
 import { StepLabel } from "@databiosphere/findable-ui/lib/components/Stepper/components/Step/components/StepLabel/stepLabel";
 import { Step } from "@databiosphere/findable-ui/lib/components/Stepper/components/Step/step";
 import { BUTTON_PROPS } from "@databiosphere/findable-ui/lib/components/common/Button/constants";
 import { Button, Divider } from "@mui/material";
 import { JSX, useMemo } from "react";
-import { useRadioGroup } from "../hooks/UseRadioGroup/hook";
-import { StyledStack as CommonStyledStack } from "../step.styles";
-import { StepProps } from "../types";
 import { Alert } from "./components/Alert/alert";
 import { CompareBaseline } from "./components/CompareBaseline/compareBaseline";
 import { ExplicitPairs } from "./components/ExplicitPairs/explicitPairs";

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PrimaryContrastsStep/step.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PrimaryContrastsStep/step.ts
@@ -1,4 +1,4 @@
-import { StepConfig } from "../types";
+import { StepConfig } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/types";
 import { PrimaryContrastsStep } from "./primaryContrastsStep";
 
 export const STEP = {

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/ReferenceAssemblyStep/components/AssemblyData/components/AssemblySummary/types.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/ReferenceAssemblyStep/components/AssemblyData/components/AssemblySummary/types.ts
@@ -1,6 +1,6 @@
+import { Assembly } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/ReferenceAssemblyStep/components/AssemblyData/components/AssemblySelector/hooks/UseTable/types";
 import { StepProps } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/types";
 import { Table } from "@tanstack/react-table";
-import { Assembly } from "../AssemblySelector/hooks/UseTable/types";
 
 export interface Props extends Pick<StepProps, "configuredInput"> {
   onEdit: () => void;

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/ReferenceAssemblyStep/referenceAssemblyStep.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/ReferenceAssemblyStep/referenceAssemblyStep.tsx
@@ -1,3 +1,4 @@
+import { StepProps } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/types";
 import { useAssembly } from "@/components/Entity/components/ConfigureWorkflowInputs/providers/Assembly/hook";
 import { BUTTON_PROPS } from "@databiosphere/findable-ui/lib/components/common/Button/constants";
 import { StepContent } from "@databiosphere/findable-ui/lib/components/Stepper/components/Step/components/StepContent/stepContent";
@@ -6,7 +7,6 @@ import { StepLabel } from "@databiosphere/findable-ui/lib/components/Stepper/com
 import { Step } from "@databiosphere/findable-ui/lib/components/Stepper/components/Step/step";
 import { Button } from "@mui/material";
 import { Fragment, JSX, useEffect, useMemo } from "react";
-import { StepProps } from "../types";
 import { AssemblyData } from "./components/AssemblyData/assemblyData";
 import { useTable } from "./components/AssemblyData/components/AssemblySelector/hooks/UseTable/hook";
 import { StepContext } from "./provider/context";

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/ReferenceAssemblyStep/step.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/ReferenceAssemblyStep/step.ts
@@ -1,4 +1,4 @@
-import { StepConfig } from "../types";
+import { StepConfig } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/types";
 import { ReferenceAssemblyStep } from "./referenceAssemblyStep";
 
 export const STEP = {

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/RelatedTracksStep/relatedTracksStep.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/RelatedTracksStep/relatedTracksStep.tsx
@@ -1,3 +1,6 @@
+import { ToggleButtonGroup } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/components/ToggleButtonGroup/toggleButtonGroup";
+import { useToggleButtonGroup } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/hooks/UseToggleButtonGroup/useToggleButtonGroup";
+import { StepProps } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/types";
 import { useAssembly } from "@/components/Entity/components/ConfigureWorkflowInputs/providers/Assembly/hook";
 import { BUTTON_PROPS } from "@databiosphere/findable-ui/lib/components/common/Button/constants";
 import { StepContent } from "@databiosphere/findable-ui/lib/components/Stepper/components/Step/components/StepContent/stepContent";
@@ -6,9 +9,6 @@ import { StepLabel } from "@databiosphere/findable-ui/lib/components/Stepper/com
 import { Step } from "@databiosphere/findable-ui/lib/components/Stepper/components/Step/step";
 import { Button } from "@mui/material";
 import { Fragment, JSX } from "react";
-import { ToggleButtonGroup } from "../components/ToggleButtonGroup/toggleButtonGroup";
-import { useToggleButtonGroup } from "../hooks/UseToggleButtonGroup/useToggleButtonGroup";
-import { StepProps } from "../types";
 import { useTable } from "./components/GenomeBrowser/components/TracksSelector/hooks/UseTable/hook";
 import { getTracksData } from "./components/GenomeBrowser/components/TracksSelector/utils";
 import { GenomeBrowser } from "./components/GenomeBrowser/genomeBrowser";

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/RelatedTracksStep/step.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/RelatedTracksStep/step.ts
@@ -1,4 +1,4 @@
-import { StepConfig } from "../types";
+import { StepConfig } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/types";
 import { RelatedTracksStep } from "./relatedTracksStep";
 import { renderValue } from "./utils";
 

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SampleSheetClassificationStep/sampleSheetClassificationStep.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SampleSheetClassificationStep/sampleSheetClassificationStep.tsx
@@ -1,11 +1,11 @@
+import { StyledStack } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/step.styles";
+import { StepProps } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/types";
 import { BUTTON_PROPS } from "@databiosphere/findable-ui/lib/components/common/Button/constants";
 import { StepLabel } from "@databiosphere/findable-ui/lib/components/Stepper/components/Step/components/StepLabel/stepLabel";
 import { Step } from "@databiosphere/findable-ui/lib/components/Stepper/components/Step/step";
 import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
 import { Button, Typography } from "@mui/material";
 import { Fragment, JSX } from "react";
-import { StyledStack } from "../step.styles";
-import { StepProps } from "../types";
 import { ClassificationTable } from "./components/ClassificationTable/classificationTable";
 import { ClassificationValidation } from "./components/ClassificationValidation/classificationValidation";
 import { useColumnClassification } from "./hooks/UseColumnClassification/hook";

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SampleSheetClassificationStep/step.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SampleSheetClassificationStep/step.ts
@@ -1,4 +1,4 @@
-import { StepConfig } from "../types";
+import { StepConfig } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/types";
 import { SampleSheetClassificationStep } from "./sampleSheetClassificationStep";
 
 export const STEP = {

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SampleSheetStep/sampleSheetStep.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SampleSheetStep/sampleSheetStep.tsx
@@ -1,3 +1,5 @@
+import { useFilePicker } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/hooks/UseFilePicker/hook";
+import { StepProps } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/types";
 import { StepContent } from "@databiosphere/findable-ui/lib/components/Stepper/components/Step/components/StepContent/stepContent";
 import { Optional } from "@databiosphere/findable-ui/lib/components/Stepper/components/Step/components/StepLabel/components/Optional/optional";
 import { StepLabel } from "@databiosphere/findable-ui/lib/components/Stepper/components/Step/components/StepLabel/stepLabel";
@@ -5,8 +7,6 @@ import { Step } from "@databiosphere/findable-ui/lib/components/Stepper/componen
 import { BUTTON_PROPS } from "@databiosphere/findable-ui/lib/components/common/Button/constants";
 import { Button } from "@mui/material";
 import { Fragment, JSX } from "react";
-import { useFilePicker } from "../hooks/UseFilePicker/hook";
-import { StepProps } from "../types";
 import { Dropzone } from "./components/Dropzone/dropzone";
 import { UploadedFile } from "./components/UploadedFile/uploadedFile";
 import { INPUT_PROPS } from "./constants";

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SampleSheetStep/step.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SampleSheetStep/step.ts
@@ -1,4 +1,4 @@
-import { StepConfig } from "../types";
+import { StepConfig } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/types";
 import { SampleSheetStep } from "./sampleSheetStep";
 
 export const STEP = {

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequenceStep/sequenceStep.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequenceStep/sequenceStep.tsx
@@ -1,3 +1,6 @@
+import { UploadedFile } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SampleSheetStep/components/UploadedFile/uploadedFile";
+import { useFilePicker } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/hooks/UseFilePicker/hook";
+import { StepProps } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/types";
 import { StepContent } from "@databiosphere/findable-ui/lib/components/Stepper/components/Step/components/StepContent/stepContent";
 import { Optional } from "@databiosphere/findable-ui/lib/components/Stepper/components/Step/components/StepLabel/components/Optional/optional";
 import { StepLabel } from "@databiosphere/findable-ui/lib/components/Stepper/components/Step/components/StepLabel/stepLabel";
@@ -5,9 +8,6 @@ import { Step } from "@databiosphere/findable-ui/lib/components/Stepper/componen
 import { BUTTON_PROPS } from "@databiosphere/findable-ui/lib/components/common/Button/constants";
 import { Button } from "@mui/material";
 import { Fragment, JSX, useCallback } from "react";
-import { UploadedFile } from "../SampleSheetStep/components/UploadedFile/uploadedFile";
-import { useFilePicker } from "../hooks/UseFilePicker/hook";
-import { StepProps } from "../types";
 import { Dropzone } from "./components/Dropzone/dropzone";
 import { INPUT_PROPS } from "./constants";
 import { readFastaFile } from "./hooks/UseFilePicker/utils";

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequenceStep/step.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequenceStep/step.ts
@@ -1,4 +1,4 @@
-import { StepConfig } from "../types";
+import { StepConfig } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/types";
 import { SequenceStep } from "./sequenceStep";
 
 export const STEP = {

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/CollectionSelector/hooks/UseColumnFilters/utils.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/CollectionSelector/hooks/UseColumnFilters/utils.ts
@@ -1,4 +1,5 @@
 import { WORKFLOW_PARAMETER_BY_STEP_KEY } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/CollectionSelector/constants";
+import { CATEGORY_CONFIGS } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/CollectionSelector/hooks/UseTable/categoryConfigs";
 import {
   SEQUENCING_DATA_FILE_TYPE,
   SEQUENCING_DATA_TYPE,
@@ -7,7 +8,6 @@ import {
 import { StepProps } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/types";
 import type { Workflow, WorkflowParameter } from "@repo/shared/apis/workflow";
 import { ColumnFiltersState } from "@tanstack/react-table";
-import { CATEGORY_CONFIGS } from "../UseTable/categoryConfigs";
 import { isSequencingDataType } from "./typeGuards";
 
 /**

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/query/hook.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/query/hook.ts
@@ -1,8 +1,11 @@
+import {
+  BaseReadRun,
+  ENAReadRunsQuery,
+} from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/types";
 import { useWorkflowEntity } from "@/components/Entity/components/ConfigureWorkflowInputs/providers/WorkflowEntity/hook";
 import { useConfig } from "@databiosphere/findable-ui/lib/hooks/useConfig";
 import { AppSiteConfig } from "@site-config/common/entities";
 import { DefaultError, useQuery as useReactQuery } from "@tanstack/react-query";
-import { BaseReadRun, ENAReadRunsQuery } from "../types";
 import { countQueryFn } from "./options/countQueryFn";
 import { queryFn } from "./options/queryFn";
 import { CountQueryKey, QueryKey } from "./types";

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/query/options/countQueryFn.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/query/options/countQueryFn.ts
@@ -1,7 +1,7 @@
 import { ENA_PORTAL_API_BASE_URL } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/constants";
+import { CountQueryKey } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/query/types";
 import { QueryFunctionContext } from "@tanstack/react-query";
 import ky from "ky";
-import { CountQueryKey } from "../types";
 
 /**
  * Fetches the ENA read-run count for the given taxonomy ID via ENA's dedicated

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/query/options/queryFn.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/query/options/queryFn.ts
@@ -1,8 +1,8 @@
 import { ENA_PORTAL_API_BASE_URL } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/constants";
 import { ENA_FIELDS } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/hooks/UseENADataByAccession/constants";
+import { QueryKey } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/query/types";
 import { QueryFunctionContext } from "@tanstack/react-query";
 import ky from "ky";
-import { QueryKey } from "../types";
 
 /**
  * Fetches ENA sequencing data based on the provided taxonomy ID using React Query.

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/sequencingStep.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/sequencingStep.tsx
@@ -1,3 +1,7 @@
+import { ToggleButtonGroup } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/components/ToggleButtonGroup/toggleButtonGroup";
+import { useToggleButtonGroup } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/hooks/UseToggleButtonGroup/useToggleButtonGroup";
+import { StepProps } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/types";
+import { getStepActiveState } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/utils/stepUtils";
 import {
   Loading,
   LOADING_PANEL_STYLE,
@@ -7,10 +11,6 @@ import { StepLabel } from "@databiosphere/findable-ui/lib/components/Stepper/com
 import { Step } from "@databiosphere/findable-ui/lib/components/Stepper/components/Step/step";
 import { HandoffStatusContext } from "@repo/shared/providers/workflowHandoff/contexts/HandoffStatus/context";
 import { JSX, useCallback, useContext } from "react";
-import { ToggleButtonGroup } from "../components/ToggleButtonGroup/toggleButtonGroup";
-import { useToggleButtonGroup } from "../hooks/UseToggleButtonGroup/useToggleButtonGroup";
-import { StepProps } from "../types";
-import { getStepActiveState } from "../utils/stepUtils";
 import { useColumnFilters } from "./components/ENASequencingData/components/CollectionSelector/hooks/UseColumnFilters/hook";
 import { useRowSelection } from "./components/ENASequencingData/components/CollectionSelector/hooks/UseRowSelection/hook";
 import { useTable } from "./components/ENASequencingData/components/CollectionSelector/hooks/UseTable/hook";

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/step.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/step.ts
@@ -1,5 +1,5 @@
+import { StepConfig } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/types";
 import { LABEL } from "@databiosphere/findable-ui/lib/apis/azul/common/entities";
-import { StepConfig } from "../types";
 import { SequencingStep } from "./sequencingStep";
 
 export const ANY_END_STEP = {

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/StrandednessStep/step.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/StrandednessStep/step.ts
@@ -1,4 +1,4 @@
-import { StepConfig } from "../types";
+import { StepConfig } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/types";
 import { StrandednessStep } from "./strandednessStep";
 import { getStepLabel } from "./utils";
 

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/StrandednessStep/strandednessStep.tsx
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/StrandednessStep/strandednessStep.tsx
@@ -1,3 +1,5 @@
+import { useRadioGroup } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/hooks/UseRadioGroup/hook";
+import { StepProps } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/types";
 import { BUTTON_PROPS } from "@databiosphere/findable-ui/lib/components/common/Button/constants";
 import { RadioCheckedIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/RadioCheckedIcon/radioCheckedIcon";
 import { RadioUncheckedIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/RadioUncheckedIcon/radioUncheckedIcon";
@@ -15,8 +17,6 @@ import {
   Typography,
 } from "@mui/material";
 import { Fragment, JSX } from "react";
-import { useRadioGroup } from "../hooks/UseRadioGroup/hook";
-import { StepProps } from "../types";
 import { CONTROLS } from "./constants";
 import { StyledStepContent } from "./strandednessStep.styles";
 import { getStepLabel } from "./utils";

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/steps/constants.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/steps/constants.ts
@@ -1,22 +1,22 @@
-import { WORKFLOW_PARAMETER_VARIABLE } from "@repo/shared/apis/schema-types";
-import { STEP as ACCESSION_COUNT_STEP } from "../components/Step/AccessionCountStep/step";
-import { STEP as DESEQ2_FORMULA_STEP } from "../components/Step/DESeq2FormulaStep/step";
-import { STEP as GTF_STEP } from "../components/Step/GTFStep/step";
-import { STEP as PRIMARY_CONTRASTS_STEP } from "../components/Step/PrimaryContrastsStep/step";
-import { STEP as REFERENCE_ASSEMBLY_STEP } from "../components/Step/ReferenceAssemblyStep/step";
-import { RELATED_TRACKS_STEP } from "../components/Step/RelatedTracksStep/step";
-import { STEP as SAMPLE_SHEET_CLASSIFICATION_STEP } from "../components/Step/SampleSheetClassificationStep/step";
-import { STEP as SAMPLE_SHEET_STEP } from "../components/Step/SampleSheetStep/step";
-import { STEP as SEQUENCE_STEP } from "../components/Step/SequenceStep/step";
+import { STEP as ACCESSION_COUNT_STEP } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/AccessionCountStep/step";
+import { STEP as DESEQ2_FORMULA_STEP } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/DESeq2FormulaStep/step";
+import { STEP as GTF_STEP } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/GTFStep/step";
+import { STEP as PRIMARY_CONTRASTS_STEP } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/PrimaryContrastsStep/step";
+import { STEP as REFERENCE_ASSEMBLY_STEP } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/ReferenceAssemblyStep/step";
+import { RELATED_TRACKS_STEP } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/RelatedTracksStep/step";
+import { STEP as SAMPLE_SHEET_CLASSIFICATION_STEP } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SampleSheetClassificationStep/step";
+import { STEP as SAMPLE_SHEET_STEP } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SampleSheetStep/step";
+import { STEP as SEQUENCE_STEP } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequenceStep/step";
 import {
   ANY_END_STEP,
   PAIRED_END_STEP,
   PAIRED_FILE_STEP,
   SINGLE_END_STEP,
   SINGLE_FILE_STEP,
-} from "../components/Step/SequencingStep/step";
-import { STEP as STRANDEDNESS_STEP } from "../components/Step/StrandednessStep/step";
-import { StepConfig } from "../components/Step/types";
+} from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/step";
+import { STEP as STRANDEDNESS_STEP } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/StrandednessStep/step";
+import { StepConfig } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/types";
+import { WORKFLOW_PARAMETER_VARIABLE } from "@repo/shared/apis/schema-types";
 
 export const SEQUENCING_STEPS: Record<string, StepConfig> = {
   readRunPairedFile: PAIRED_FILE_STEP,

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/steps/types.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/steps/types.ts
@@ -1,4 +1,4 @@
-import { StepConfig } from "../components/Step/types";
+import { StepConfig } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/types";
 
 export interface UseConfiguredSteps {
   configuredSteps: StepConfig[];

--- a/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/steps/utils.ts
+++ b/app/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/steps/utils.ts
@@ -1,3 +1,4 @@
+import { StepConfig } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/types";
 import { ConfiguredInput } from "@/views/WorkflowInputsView/hooks/UseConfigureInputs/types";
 import {
   WORKFLOW_PARAMETER_VARIABLE,
@@ -6,7 +7,6 @@ import {
 import type { Workflow } from "@repo/shared/apis/workflow";
 import { CUSTOM_WORKFLOW } from "@repo/shared/workflow/custom";
 import { DIFFERENTIAL_EXPRESSION_ANALYSIS } from "@repo/shared/workflow/differentialExpressionAnalysis";
-import { StepConfig } from "../components/Step/types";
 import { STEP } from "./constants";
 
 /**

--- a/app/components/Entity/components/Section/MDXSection/mdxSection.tsx
+++ b/app/components/Entity/components/Section/MDXSection/mdxSection.tsx
@@ -1,7 +1,7 @@
+import { Section } from "@/components/Entity/components/Section/section";
 import { FluidPaper } from "@repo/shared/components/Paper/components/FluidPaper/fluidPaper";
 import { MDXRemote } from "next-mdx-remote";
 import { JSX } from "react";
-import { Section } from "../section";
 import { COMPONENTS } from "./constants";
 import { Props } from "./types";
 

--- a/app/components/Entity/components/Section/MDXSection/types.ts
+++ b/app/components/Entity/components/Section/MDXSection/types.ts
@@ -1,5 +1,5 @@
+import { SectionProps } from "@/components/Entity/components/Section/types";
 import { MDXRemoteProps, MDXRemoteSerializeResult } from "next-mdx-remote";
-import { SectionProps } from "../types";
 
 export interface Props
   extends SectionProps, Pick<MDXRemoteProps, "components"> {

--- a/app/components/Home/components/Section/components/SectionAnalytics/components/AnalyticsTools/hooks/useInteractiveAnalytics/useInteractiveAnalytics.ts
+++ b/app/components/Home/components/Section/components/SectionAnalytics/components/AnalyticsTools/hooks/useInteractiveAnalytics/useInteractiveAnalytics.ts
@@ -1,8 +1,8 @@
 import { ANALYTICS_TOOLS } from "@/components/Home/components/Section/components/SectionAnalytics/components/AnalyticsTools/common/constants";
+import { useIntersectionObserver } from "@/components/Home/components/Section/components/SectionAnalytics/components/AnalyticsTools/hooks/useIntersectionObserver/useIntersectionObserver";
 import { useSwipeInteraction } from "@/hooks/useSwipeInteraction/useSwipeInteraction";
 import { CardProps as DXCardProps } from "@databiosphere/findable-ui/lib/components/common/Card/card";
 import { RefObject, useEffect, useMemo } from "react";
-import { useIntersectionObserver } from "../useIntersectionObserver/useIntersectionObserver";
 import { ROWS } from "./common/contants";
 import { UseInteractiveAnalytics } from "./common/entities";
 

--- a/app/components/Home/components/Section/components/SectionAssemblies/sectionAssemblies.tsx
+++ b/app/components/Home/components/Section/components/SectionAssemblies/sectionAssemblies.tsx
@@ -1,9 +1,9 @@
+import { SectionViz as Sunburst } from "@/components/Home/components/Section/components/SectionViz/sunburst";
 import {
   SectionSubtitle,
   SectionTitle,
 } from "@/components/Home/components/Section/section.styles";
 import { JSX } from "react";
-import { SectionViz as Sunburst } from "../SectionViz/sunburst";
 import { Headline, Section, SectionLayout } from "./sectionAssemblies.styles";
 
 export const SectionAssemblies = (): JSX.Element => {

--- a/app/components/Home/components/Section/components/SectionHero/components/Carousel/cards/constants.ts
+++ b/app/components/Home/components/Section/components/SectionHero/components/Carousel/cards/constants.ts
@@ -1,5 +1,5 @@
+import * as MDX from "@/components/Home/components/Section/components/SectionHero/components/Carousel/content";
 import { CardProps } from "@databiosphere/findable-ui/lib/components/common/Card/card";
-import * as MDX from "../content";
 
 export const CAROUSEL_CARDS: Pick<CardProps, "text">[] = [
   {

--- a/app/components/Home/components/Section/components/SectionHero/components/Carousel/hooks/useInteractiveCarousel.ts
+++ b/app/components/Home/components/Section/components/SectionHero/components/Carousel/hooks/useInteractiveCarousel.ts
@@ -1,10 +1,10 @@
+import { CAROUSEL_CARDS } from "@/components/Home/components/Section/components/SectionHero/components/Carousel/cards/constants";
 import {
   UseSwipeInteraction,
   useSwipeInteraction,
 } from "@/hooks/useSwipeInteraction/useSwipeInteraction";
 import { CardProps } from "@databiosphere/findable-ui/lib/components/common/Card/card";
 import { useMemo } from "react";
-import { CAROUSEL_CARDS } from "../cards/constants";
 
 export interface UseInteractiveCarousel {
   activeIndex: UseSwipeInteraction["activeIndex"];

--- a/app/components/Home/components/Section/components/ga2/SectionAnalyticsAndData/components/AnalyticsToolsAndData/hooks/useInteractiveAnalyticsAndData/useInteractiveAnalyticsAndData.ts
+++ b/app/components/Home/components/Section/components/ga2/SectionAnalyticsAndData/components/AnalyticsToolsAndData/hooks/useInteractiveAnalyticsAndData/useInteractiveAnalyticsAndData.ts
@@ -1,8 +1,8 @@
 import { ANALYTICS_TOOLS } from "@/components/Home/components/Section/components/ga2/SectionAnalyticsAndData/components/AnalyticsToolsAndData/common/constants";
+import { useIntersectionObserver } from "@/components/Home/components/Section/components/ga2/SectionAnalyticsAndData/components/AnalyticsToolsAndData/hooks/useIntersectionObserver/useIntersectionObserver";
 import { useSwipeInteraction } from "@/hooks/useSwipeInteraction/useSwipeInteraction";
 import { CardProps as DXCardProps } from "@databiosphere/findable-ui/lib/components/common/Card/card";
 import { RefObject, useEffect, useMemo } from "react";
-import { useIntersectionObserver } from "../useIntersectionObserver/useIntersectionObserver";
 import { ROWS } from "./common/constants";
 import { UseInteractiveAnalyticsAndData } from "./common/entities";
 

--- a/app/components/index.ts
+++ b/app/components/index.ts
@@ -1,3 +1,4 @@
+export { Main as OrganismViewMain } from "@/views/OrganismView/components/Main/main";
 export { Alert } from "@databiosphere/findable-ui/lib/components/common/Alert/alert";
 export { DiscourseIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/DiscourseIcon/discourseIcon";
 export { GitHubIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/GitHubIcon/gitHubIcon";
@@ -16,7 +17,6 @@ export { ChipCell } from "@databiosphere/findable-ui/lib/components/Table/compon
 export { NTagCell } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/NTagCell/nTagCell";
 export { CalendarIcon } from "@repo/shared/components/CustomIcon/components/CalendarIcon/calendarIcon";
 export { Tooltip } from "@repo/shared/components/Tooltip/tooltip";
-export { Main as OrganismViewMain } from "../views/OrganismView/components/Main/main";
 export { OrganismAvatar } from "./Entity/components/OrganismAvatar/organismAvatar";
 export { MDXSection } from "./Entity/components/Section/MDXSection/mdxSection";
 export { Sections } from "./Entity/components/Sections/sections";

--- a/app/hooks/useAssistantChat.ts
+++ b/app/hooks/useAssistantChat.ts
@@ -1,3 +1,4 @@
+import { assistantAPIClient } from "@/services/assistant-api-client";
 import { apiClient } from "@repo/shared/services/api-client/api-client";
 import type {
   AnalysisSchema,
@@ -6,7 +7,6 @@ import type {
 } from "@repo/shared/services/api-client/types";
 import { HTTPError } from "ky";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { assistantAPIClient } from "../services/assistant-api-client";
 
 const SESSION_KEY = "brc-assistant-session-id";
 

--- a/app/utils/entityUtils.ts
+++ b/app/utils/entityUtils.ts
@@ -1,6 +1,6 @@
+import { EntitiesResponse } from "@/apis/catalog/brc-analytics-catalog/common/entities";
 import { EntityConfig } from "@databiosphere/findable-ui/lib/config/entities";
 import { getEntityService } from "@databiosphere/findable-ui/lib/hooks/useEntityService";
-import { EntitiesResponse } from "../apis/catalog/brc-analytics-catalog/common/entities";
 
 /**
  * Fetches entities response for the given entity config.

--- a/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.tsx
+++ b/app/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders.tsx
@@ -71,6 +71,7 @@ import {
   getGenomeSerotypeText,
   getGenomeStrainText,
 } from "@repo/shared/viewModelBuilders/viewModelBuilders";
+import { ROUTES as SITE_ROUTES } from "@routes/constants";
 import {
   BRC_DATA_CATALOG_CATEGORY_KEY,
   BRC_DATA_CATALOG_CATEGORY_LABEL,
@@ -80,7 +81,6 @@ import { LinkProps } from "next/link";
 import Router from "next/router";
 import { ComponentProps } from "react";
 import slugify from "slugify";
-import { ROUTES as SITE_ROUTES } from "../../../../../routes/constants";
 import { getPriorityColor, getPriorityLabel } from "./priority";
 
 // Transitional shim for the GA2/BRC split (monorepo-split): shared builders

--- a/app/views/AnalyzeView/analyzeView.tsx
+++ b/app/views/AnalyzeView/analyzeView.tsx
@@ -1,3 +1,5 @@
+import { Side } from "@/views/EntityView/assembly/components/Side/side";
+import { Assembly } from "@/views/WorkflowInputsView/types";
 import {
   BackPageContent,
   BackPageHero,
@@ -5,8 +7,6 @@ import {
 } from "@databiosphere/findable-ui/lib/components/Layout/components/BackPage/backPageView.styles";
 import { getEntity } from "@repo/shared/services/workflows/query";
 import { JSX } from "react";
-import { Side } from "../EntityView/assembly/components/Side/side";
-import { Assembly } from "../WorkflowInputsView/types";
 import { Main } from "./components/Main/main";
 import { Top } from "./components/Top/top";
 import { Props } from "./types";

--- a/app/views/AnalyzeWorkflowsView/analyzeWorkflowsView.tsx
+++ b/app/views/AnalyzeWorkflowsView/analyzeWorkflowsView.tsx
@@ -1,3 +1,5 @@
+import { Side } from "@/views/EntityView/assembly/components/Side/side";
+import { Assembly } from "@/views/WorkflowInputsView/types";
 import {
   BackPageContent,
   BackPageHero,
@@ -5,8 +7,6 @@ import {
 } from "@databiosphere/findable-ui/lib/components/Layout/components/BackPage/backPageView.styles";
 import { getEntity } from "@repo/shared/services/workflows/query";
 import { JSX } from "react";
-import { Side } from "../EntityView/assembly/components/Side/side";
-import { Assembly } from "../WorkflowInputsView/types";
 import { Main } from "./components/Main/main";
 import { Top } from "./components/Top/top";
 import { Props } from "./types";

--- a/app/views/AnalyzeWorkflowsView/components/Main/main.tsx
+++ b/app/views/AnalyzeWorkflowsView/components/Main/main.tsx
@@ -1,8 +1,8 @@
+import WORKFLOW_CATEGORIES from "@catalog/output/workflows.json";
 import { BackPageContentMainColumn } from "@databiosphere/findable-ui/lib/components/Layout/components/BackPage/backPageView.styles";
 import { useFeatureFlag } from "@databiosphere/findable-ui/lib/hooks/useFeatureFlag/useFeatureFlag";
 import type { WorkflowCategory } from "@repo/shared/apis/workflow";
 import { JSX } from "react";
-import WORKFLOW_CATEGORIES from "../../../../../catalog/output/workflows.json";
 import { Accordion } from "./components/Accordion/accordion";
 import { Props } from "./types";
 import { buildAssemblyWorkflows } from "./utils";

--- a/app/views/AnalyzeWorkflowsView/components/Main/utils.ts
+++ b/app/views/AnalyzeWorkflowsView/components/Main/utils.ts
@@ -1,4 +1,5 @@
 import { workflowPloidyMatchesOrganismPloidy } from "@/apis/catalog/brc-analytics-catalog/common/utils";
+import { WorkflowCategoryId } from "@catalog/schema/generated/schema";
 import {
   WORKFLOW_PARAMETER_VARIABLE,
   WORKFLOW_SCOPE,
@@ -6,7 +7,6 @@ import {
 import type { AssemblyContract } from "@repo/shared/apis/types";
 import type { Workflow, WorkflowCategory } from "@repo/shared/apis/workflow";
 import { DIFFERENTIAL_EXPRESSION_ANALYSIS } from "@repo/shared/workflow/differentialExpressionAnalysis";
-import { WorkflowCategoryId } from "../../../../../catalog/schema/generated/schema";
 
 /**
  * Builds workflow categories for the given assembly.

--- a/app/views/EntityView/assembly/components/Side/brc/side.tsx
+++ b/app/views/EntityView/assembly/components/Side/brc/side.tsx
@@ -3,13 +3,13 @@ import {
   buildAssemblyResources,
   buildOrganismDetails,
 } from "@/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders";
+import { StyledFluidPaper } from "@/views/EntityView/assembly/components/Side/side.styles";
 import { mapAssemblyToOrganism } from "@/views/WorkflowInputsView/utils";
 import { BackPageContentSideColumn } from "@databiosphere/findable-ui/lib/components/Layout/components/BackPage/backPageView.styles";
 import { AssemblyFavoriteButton } from "@repo/shared/components/Favorites/components/AssemblyFavoriteButton/assemblyFavoriteButton";
 import { AnalysisPortals } from "@repo/shared/views/EntityView/assembly/components/Side/AnalysisPortals/analysisPortals";
 import { KeyValueSection } from "@repo/shared/views/EntityView/components/KeyValueSection/keyValueSection";
 import { JSX } from "react";
-import { StyledFluidPaper } from "../side.styles";
 import { StyledSection } from "./side.styles";
 import { Props } from "./types";
 

--- a/app/views/EntityView/assembly/components/Side/ga2/side.tsx
+++ b/app/views/EntityView/assembly/components/Side/ga2/side.tsx
@@ -1,4 +1,5 @@
 import { AssemblyDetails } from "@/views/EntityView/assembly/components/Side/ga2/components/AssemblyDetails/AssemblyDetails";
+import { StyledFluidPaper } from "@/views/EntityView/assembly/components/Side/side.styles";
 import { mapAssemblyToOrganism } from "@/views/WorkflowInputsView/utils";
 import { BackPageContentSideColumn } from "@databiosphere/findable-ui/lib/components/Layout/components/BackPage/backPageView.styles";
 import { AssemblyFavoriteButton } from "@repo/shared/components/Favorites/components/AssemblyFavoriteButton/assemblyFavoriteButton";
@@ -9,7 +10,6 @@ import {
 import { AnalysisPortals } from "@repo/shared/views/EntityView/assembly/components/Side/AnalysisPortals/analysisPortals";
 import { KeyValueSection } from "@repo/shared/views/EntityView/components/KeyValueSection/keyValueSection";
 import { JSX } from "react";
-import { StyledFluidPaper } from "../side.styles";
 import { StyledSection } from "./side.styles";
 import { Props } from "./types";
 

--- a/app/views/OrganismView/components/Main/components/AssembliesSection/assembliesSection.tsx
+++ b/app/views/OrganismView/components/Main/components/AssembliesSection/assembliesSection.tsx
@@ -1,3 +1,4 @@
+import { EmptyState } from "@/views/OrganismView/components/Main/components/EmptyState/emptyState";
 import { StyledSectionTitle } from "@/views/OrganismView/components/Main/main.styles";
 import { Toolbar } from "@/views/OrganismView/components/Main/table/components/Toolbar/toolbar";
 import { useTable } from "@/views/OrganismView/components/Main/table/hooks/UseTable/hook";
@@ -9,7 +10,6 @@ import { Alert, Stack } from "@mui/material";
 import { Table } from "@repo/shared/components/Table/table";
 import type { RowData } from "@tanstack/react-table";
 import { JSX } from "react";
-import { EmptyState } from "../EmptyState/emptyState";
 import { Props } from "./types";
 
 /**

--- a/app/views/OrganismView/components/Main/components/WorkflowsSection/workflowsSection.tsx
+++ b/app/views/OrganismView/components/Main/components/WorkflowsSection/workflowsSection.tsx
@@ -1,4 +1,5 @@
 import { Accordion } from "@/views/AnalyzeWorkflowsView/components/Main/components/Accordion/accordion";
+import { EmptyState } from "@/views/OrganismView/components/Main/components/EmptyState/emptyState";
 import { StyledSectionTitle } from "@/views/OrganismView/components/Main/main.styles";
 import { buildOrganismWorkflows } from "@/views/OrganismView/components/Main/utils";
 import { useFeatureFlag } from "@databiosphere/findable-ui/lib/hooks/useFeatureFlag/useFeatureFlag";
@@ -7,7 +8,6 @@ import { Stack } from "@mui/material";
 import { ROUTES } from "@repo/shared/routes/constants";
 import { getWorkflows } from "@repo/shared/services/workflows/entities";
 import { JSX } from "react";
-import { EmptyState } from "../EmptyState/emptyState";
 import { Props } from "./types";
 
 /**

--- a/app/views/OrganismView/components/Main/utils.ts
+++ b/app/views/OrganismView/components/Main/utils.ts
@@ -1,7 +1,7 @@
 import type { Organism } from "@/views/OrganismView/types";
+import { WorkflowCategoryId } from "@catalog/schema/generated/schema";
 import { WORKFLOW_SCOPE } from "@repo/shared/apis/schema-types";
 import type { Workflow, WorkflowCategory } from "@repo/shared/apis/workflow";
-import { WorkflowCategoryId } from "../../../../../catalog/schema/generated/schema";
 
 /**
  * Builds workflow categories for the given organism.

--- a/app/views/OrganismWorkflowInputsView/organismWorkflowInputsView.tsx
+++ b/app/views/OrganismWorkflowInputsView/organismWorkflowInputsView.tsx
@@ -8,6 +8,8 @@ import { Main } from "@/components/Entity/components/ConfigureWorkflowInputs/com
 import { SideColumn } from "@/components/Entity/components/ConfigureWorkflowInputs/components/SideColumn/sideColumn";
 import { WorkflowEntityContext } from "@/components/Entity/components/ConfigureWorkflowInputs/providers/WorkflowEntity/context";
 import { buildWorkflowEntityValue } from "@/components/Entity/components/ConfigureWorkflowInputs/providers/WorkflowEntity/utils";
+import { useConfigureInputs } from "@/views/WorkflowInputsView/hooks/UseConfigureInputs/useConfigureInputs";
+import { StyledBackPageContentMainColumn } from "@/views/WorkflowInputsView/workflowInputsView.styles";
 import {
   BackPageContent,
   BackPageContentSideColumn,
@@ -17,8 +19,6 @@ import {
 import { getWorkflow } from "@repo/shared/services/workflows/entities";
 import { getEntity } from "@repo/shared/services/workflows/query";
 import { JSX, useMemo } from "react";
-import { useConfigureInputs } from "../WorkflowInputsView/hooks/UseConfigureInputs/useConfigureInputs";
-import { StyledBackPageContentMainColumn } from "../WorkflowInputsView/workflowInputsView.styles";
 import { Top } from "./components/Top/top";
 import type { Props } from "./types";
 import { mapOrganismEntityToOrganism } from "./utils";

--- a/app/views/OrganismWorkflowInputsView/utils.ts
+++ b/app/views/OrganismWorkflowInputsView/utils.ts
@@ -1,5 +1,5 @@
+import type { Organism } from "@/views/OrganismView/types";
 import type { OrganismContract } from "@repo/shared/apis/types";
-import type { Organism } from "../OrganismView/types";
 
 /**
  * Projects a BRC or GA2 organism entity onto the shared organism shape consumed by

--- a/app/views/WorkflowInputsView/hooks/UseAssistantHandoff/types.ts
+++ b/app/views/WorkflowInputsView/hooks/UseAssistantHandoff/types.ts
@@ -1,4 +1,4 @@
-import { ConfiguredInput } from "../UseConfigureInputs/types";
+import { ConfiguredInput } from "@/views/WorkflowInputsView/hooks/UseConfigureInputs/types";
 
 export interface UseAssistantHandoff {
   initialConfiguredInput: ConfiguredInput | undefined;

--- a/app/views/WorkflowInputsView/hooks/UseHandoffSync/query/ena/options/queryFn.ts
+++ b/app/views/WorkflowInputsView/hooks/UseHandoffSync/query/ena/options/queryFn.ts
@@ -2,8 +2,8 @@ import { AccessionInfo } from "@/components/Entity/components/ConfigureWorkflowI
 import { fetchENAData } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/hooks/UseENADataByAccession/request";
 import { getAccessionType } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/hooks/UseENADataByAccession/utils";
 import { BaseReadRun } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/types";
+import { QueryKey } from "@/views/WorkflowInputsView/hooks/UseHandoffSync/query/ena/types";
 import { QueryFunctionContext } from "@tanstack/react-query";
-import { QueryKey } from "../types";
 
 /**
  * Fetch ENA read-run data for handoff accessions. Reuses `fetchENAData` so

--- a/app/views/WorkflowInputsView/hooks/UseHandoffSync/useHandoffSync.ts
+++ b/app/views/WorkflowInputsView/hooks/UseHandoffSync/useHandoffSync.ts
@@ -1,5 +1,6 @@
 import { translateForSequencingStep } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/utils";
 import { StepConfig } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/types";
+import { OnConfigure } from "@/views/WorkflowInputsView/hooks/UseConfigureInputs/types";
 import { findSequencingStepKey } from "@/views/WorkflowInputsView/sequencing/utils";
 import { useCurrentPath } from "@repo/shared/hooks/UseCurrentPath/hook";
 import { SEQUENCING_SOURCE } from "@repo/shared/providers/workflowHandoff/constants";
@@ -8,7 +9,6 @@ import { useHandoffDispatch } from "@repo/shared/providers/workflowHandoff/hooks
 import { useHandoffInputs } from "@repo/shared/providers/workflowHandoff/hooks/UseHandoffInputs/hook";
 import { EntityKey } from "@repo/shared/providers/workflowHandoff/types";
 import { useEffect, useMemo } from "react";
-import { OnConfigure } from "../UseConfigureInputs/types";
 import { useHandoffEnaQuery } from "./query/ena/hook";
 import { buildEnaUpdates } from "./utils";
 

--- a/app/views/WorkflowInputsView/hooks/UseHandoffSync/utils.ts
+++ b/app/views/WorkflowInputsView/hooks/UseHandoffSync/utils.ts
@@ -4,7 +4,7 @@ import {
 } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/components/CollectionSelector/hooks/UseTable/dataTransforms";
 import { BaseReadRun } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/types";
 import { getSequencingData } from "@/components/Entity/components/ConfigureWorkflowInputs/components/Main/components/Stepper/components/Step/SequencingStep/components/ENASequencingData/utils";
-import { ConfiguredInput } from "../UseConfigureInputs/types";
+import { ConfiguredInput } from "@/views/WorkflowInputsView/hooks/UseConfigureInputs/types";
 
 /**
  * Translate raw ENA read-run data into a Partial<ConfiguredInput> in the

--- a/app/views/WorkflowInputsView/utils.ts
+++ b/app/views/WorkflowInputsView/utils.ts
@@ -3,8 +3,8 @@ import {
   getGenomeSerotypeText,
   getGenomeStrainText,
 } from "@/viewModelBuilders/catalog/brc-analytics-catalog/common/viewModelBuilders";
+import type { Organism } from "@/views/OrganismView/types";
 import type { AssemblyContract } from "@repo/shared/apis/types";
-import type { Organism } from "../OrganismView/types";
 
 /**
  * Maps an assembly to the shared organism shape consumed by the side panel, so the

--- a/app/views/WorkflowView/workflowView.tsx
+++ b/app/views/WorkflowView/workflowView.tsx
@@ -3,6 +3,7 @@ import { Main } from "@/components/Entity/components/ConfigureWorkflowInputs/com
 import { SideColumn } from "@/components/Entity/components/ConfigureWorkflowInputs/components/SideColumn/sideColumn";
 import { AssemblyContext } from "@/components/Entity/components/ConfigureWorkflowInputs/providers/Assembly/context";
 import { WorkflowEntityContext } from "@/components/Entity/components/ConfigureWorkflowInputs/providers/WorkflowEntity/context";
+import { useConfigureInputs } from "@/views/WorkflowInputsView/hooks/UseConfigureInputs/useConfigureInputs";
 import {
   BackPageContent,
   BackPageContentSideColumn,
@@ -11,7 +12,6 @@ import {
 } from "@databiosphere/findable-ui/lib/components/Layout/components/BackPage/backPageView.styles";
 import { getWorkflow } from "@repo/shared/services/workflows/entities";
 import { JSX } from "react";
-import { useConfigureInputs } from "../WorkflowInputsView/hooks/UseConfigureInputs/useConfigureInputs";
 import { Top } from "./components/Top/top";
 import { useWorkflowEntities } from "./hooks/UseWorkflowEntities/hook";
 import { useConfiguredSteps } from "./steps/hook";

--- a/app/views/WorkflowsView/types.ts
+++ b/app/views/WorkflowsView/types.ts
@@ -1,7 +1,7 @@
 import { BRCDataCatalogOrganism } from "@/apis/catalog/brc-analytics-catalog/common/entities";
 import { GA2OrganismEntity } from "@/apis/catalog/ga2/entities";
+import { Assembly } from "@/views/WorkflowInputsView/types";
 import type { Workflow, WorkflowCategory } from "@repo/shared/apis/workflow";
-import { Assembly } from "../WorkflowInputsView/types";
 
 export type BaseWorkflowAssembly = Pick<
   Assembly,

--- a/app/views/WorkflowsView/utils.ts
+++ b/app/views/WorkflowsView/utils.ts
@@ -1,4 +1,6 @@
 import { workflowMeetsAssemblyMinimum } from "@/apis/catalog/brc-analytics-catalog/common/workflowAssembly";
+import type { Assembly } from "@/views/WorkflowInputsView/types";
+import { WorkflowCategoryId } from "@catalog/schema/generated/schema";
 import type { AssemblyContract } from "@repo/shared/apis/types";
 import type {
   WorkflowAssemblyMapping,
@@ -7,8 +9,6 @@ import type {
 import { DIFFERENTIAL_EXPRESSION_ANALYSIS } from "@repo/shared/workflow/differentialExpressionAnalysis";
 import { LEXICMAP } from "@repo/shared/workflow/lexicmap";
 import { LOGAN_SEARCH } from "@repo/shared/workflow/loganSearch";
-import { WorkflowCategoryId } from "../../../catalog/schema/generated/schema";
-import type { Assembly } from "../WorkflowInputsView/types";
 import type { Organism, WorkflowAssembly, WorkflowEntity } from "./types";
 
 /**

--- a/app/views/WorkflowsView/workflowsView.tsx
+++ b/app/views/WorkflowsView/workflowsView.tsx
@@ -1,3 +1,4 @@
+import { ExploreView } from "@/views/ExploreView/exploreView";
 import { useFeatureFlag } from "@databiosphere/findable-ui/lib/hooks/useFeatureFlag/useFeatureFlag";
 import type { WorkflowAssemblyMapping } from "@repo/shared/apis/workflow";
 import {
@@ -6,7 +7,6 @@ import {
 } from "@repo/shared/services/workflows/entities";
 import { API } from "@repo/shared/services/workflows/routes";
 import { JSX, useEffect, useMemo, useState } from "react";
-import { ExploreView } from "../ExploreView/exploreView";
 import { Workflows } from "./components/Workflows/workflows";
 import { Organism } from "./types";
 import { getWorkflows } from "./utils";

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -117,6 +117,114 @@ const config = [
       "sonarjs/no-duplicate-string": "off",
     },
   },
+  // Intra-package import convention: relative imports only for same-directory
+  // and descendants (`./`); reach anything else through the package alias.
+  // Keeps a module's internal and external references to the same string
+  // (one grep finds every consumer) and stops the rule from depending on how
+  // deep a file happens to sit. Uses the typescript-eslint variant so it also
+  // catches `import type` specifiers.
+  {
+    files: ["app/**/*.{ts,tsx}"],
+    rules: {
+      "@typescript-eslint/no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["../*", "../**"],
+              message:
+                "Reach outside this directory via the @/… alias; relative imports are for ./ same-dir and descendants only.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    files: ["packages/shared/**/*.{ts,tsx}"],
+    rules: {
+      "@typescript-eslint/no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["../*", "../**"],
+              message:
+                "Reach outside this directory via the @repo/shared/… alias; relative imports are for ./ same-dir and descendants only.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    files: ["sites/brc-analytics/**/*.{ts,tsx}"],
+    rules: {
+      "@typescript-eslint/no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["../*", "../**"],
+              message:
+                "Reach outside this directory via the @brc/… alias; relative imports are for ./ same-dir and descendants only.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    files: ["sites/ga2/**/*.{ts,tsx}"],
+    rules: {
+      "@typescript-eslint/no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["../*", "../**"],
+              message:
+                "Reach outside this directory via the @ga2/… alias; relative imports are for ./ same-dir and descendants only.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    files: ["pages/**/*.{ts,tsx}"],
+    rules: {
+      "@typescript-eslint/no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["../*", "../**"],
+              message:
+                "Reach outside this directory via an alias (@pages/…, @/…); relative imports are for ./ same-dir and descendants only.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    files: ["site-config/**/*.{ts,tsx}"],
+    rules: {
+      "@typescript-eslint/no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["../*", "../**"],
+              message:
+                "Reach outside this directory via the @site-config/… alias; relative imports are for ./ same-dir and descendants only.",
+            },
+          ],
+        },
+      ],
+    },
+  },
 ];
 
 export default config;

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -131,7 +131,7 @@ const config = [
         {
           patterns: [
             {
-              group: ["../*", "../**"],
+              group: ["..", "../*", "../**"],
               message:
                 "Reach outside this directory via the @/… alias; relative imports are for ./ same-dir and descendants only.",
             },
@@ -148,7 +148,7 @@ const config = [
         {
           patterns: [
             {
-              group: ["../*", "../**"],
+              group: ["..", "../*", "../**"],
               message:
                 "Reach outside this directory via the @repo/shared/… alias; relative imports are for ./ same-dir and descendants only.",
             },
@@ -165,7 +165,7 @@ const config = [
         {
           patterns: [
             {
-              group: ["../*", "../**"],
+              group: ["..", "../*", "../**"],
               message:
                 "Reach outside this directory via the @brc/… alias; relative imports are for ./ same-dir and descendants only.",
             },
@@ -182,7 +182,7 @@ const config = [
         {
           patterns: [
             {
-              group: ["../*", "../**"],
+              group: ["..", "../*", "../**"],
               message:
                 "Reach outside this directory via the @ga2/… alias; relative imports are for ./ same-dir and descendants only.",
             },
@@ -199,7 +199,7 @@ const config = [
         {
           patterns: [
             {
-              group: ["../*", "../**"],
+              group: ["..", "../*", "../**"],
               message:
                 "Reach outside this directory via an alias (@pages/…, @/…); relative imports are for ./ same-dir and descendants only.",
             },
@@ -216,7 +216,7 @@ const config = [
         {
           patterns: [
             {
-              group: ["../*", "../**"],
+              group: ["..", "../*", "../**"],
               message:
                 "Reach outside this directory via the @site-config/… alias; relative imports are for ./ same-dir and descendants only.",
             },

--- a/packages/shared/apis/schema-types.ts
+++ b/packages/shared/apis/schema-types.ts
@@ -7,8 +7,8 @@ export {
   WorkflowParameterVariable as WORKFLOW_PARAMETER_VARIABLE,
   WorkflowPloidy as WORKFLOW_PLOIDY,
   WorkflowScope as WORKFLOW_SCOPE,
-} from "../../../catalog/schema/generated/schema";
+} from "@catalog/schema/generated/schema";
 export type {
   WorkflowCollectionSpec,
   WorkflowUrlSpec,
-} from "../../../catalog/schema/generated/schema";
+} from "@catalog/schema/generated/schema";

--- a/packages/shared/apis/types.ts
+++ b/packages/shared/apis/types.ts
@@ -1,4 +1,4 @@
-import type { OutbreakPriority as OUTBREAK_PRIORITY } from "../../../catalog/schema/generated/schema";
+import type { OutbreakPriority as OUTBREAK_PRIORITY } from "@catalog/schema/generated/schema";
 import type { ORGANISM_PLOIDY } from "./schema-types";
 
 /**

--- a/packages/shared/components/EntityDataGate/entityDataGate.tsx
+++ b/packages/shared/components/EntityDataGate/entityDataGate.tsx
@@ -1,5 +1,5 @@
+import { useEntitiesLoaded } from "@repo/shared/providers/entitiesLoaded/hook";
 import { JSX } from "react";
-import { useEntitiesLoaded } from "../../providers/entitiesLoaded/hook";
 import type { Props } from "./types";
 
 /**

--- a/packages/shared/components/Favorites/components/AssemblyFavoriteButton/assemblyFavoriteButton.tsx
+++ b/packages/shared/components/Favorites/components/AssemblyFavoriteButton/assemblyFavoriteButton.tsx
@@ -1,9 +1,9 @@
 import StarIcon from "@mui/icons-material/Star";
 import StarBorderIcon from "@mui/icons-material/StarBorder";
 import { Button, CircularProgress, Tooltip } from "@mui/material";
+import { useAssemblyFavorites } from "@repo/shared/components/Favorites/hooks/UseAssemblyFavorites/hook";
 import { useAuth } from "@repo/shared/providers/authentication/provider";
 import { JSX } from "react";
-import { useAssemblyFavorites } from "../../hooks/UseAssemblyFavorites/hook";
 import type { Props } from "./types";
 
 export function AssemblyFavoriteButton({ accession }: Props): JSX.Element {

--- a/packages/shared/components/Table/components/TableCell/components/SpeciesCell/components/TagList/tagList.tsx
+++ b/packages/shared/components/Table/components/TableCell/components/SpeciesCell/components/TagList/tagList.tsx
@@ -2,9 +2,9 @@ import { CHIP_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/chi
 import { STACK_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/stack";
 import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
 import { Chip, Stack, Typography } from "@mui/material";
+import type { Props } from "@repo/shared/components/Table/components/TableCell/components/SpeciesCell/types";
 import { Tooltip } from "@repo/shared/components/Tooltip/tooltip";
 import { Fragment, JSX } from "react";
-import type { Props } from "../../types";
 
 /**
  * Renders the species cell's minor taxonomy fields as a wrapping row of chips —

--- a/packages/shared/components/layout/SectionHero/sectionHero.styles.ts
+++ b/packages/shared/components/layout/SectionHero/sectionHero.styles.ts
@@ -2,7 +2,10 @@ import { FONT } from "@databiosphere/findable-ui/lib/styles/common/constants/fon
 import { PALETTE } from "@databiosphere/findable-ui/lib/styles/common/constants/palette";
 import { bpUpSm } from "@databiosphere/findable-ui/lib/styles/common/mixins/breakpoints";
 import styled from "@emotion/styled";
-import { sectionGrid, sectionLayout } from "../Section/section.styles";
+import {
+  sectionGrid,
+  sectionLayout,
+} from "@repo/shared/components/layout/Section/section.styles";
 import { Section } from "./components/Section/section";
 
 export const StyledSection = styled(Section)`

--- a/packages/shared/providers/authentication/provider.tsx
+++ b/packages/shared/providers/authentication/provider.tsx
@@ -1,3 +1,4 @@
+import { API_BASE_URL } from "@repo/shared/config/api";
 import {
   createContext,
   JSX,
@@ -7,7 +8,6 @@ import {
   useEffect,
   useState,
 } from "react";
-import { API_BASE_URL } from "../../config/api";
 
 interface AuthUser {
   email: string;

--- a/packages/shared/providers/workflowHandoff/actions/clearHandoff/action.ts
+++ b/packages/shared/providers/workflowHandoff/actions/clearHandoff/action.ts
@@ -1,4 +1,4 @@
-import { WorkflowHandoffState } from "../../types";
+import { WorkflowHandoffState } from "@repo/shared/providers/workflowHandoff/types";
 import { ClearHandoffPayload } from "./types";
 
 /**

--- a/packages/shared/providers/workflowHandoff/actions/clearHandoff/dispatch.ts
+++ b/packages/shared/providers/workflowHandoff/actions/clearHandoff/dispatch.ts
@@ -1,4 +1,4 @@
-import { WorkflowHandoffActionKind } from "../types";
+import { WorkflowHandoffActionKind } from "@repo/shared/providers/workflowHandoff/actions/types";
 import { ClearHandoffAction, ClearHandoffPayload } from "./types";
 
 /**

--- a/packages/shared/providers/workflowHandoff/actions/clearHandoff/types.ts
+++ b/packages/shared/providers/workflowHandoff/actions/clearHandoff/types.ts
@@ -1,5 +1,5 @@
-import { EntityKey } from "../../types";
-import { WorkflowHandoffActionKind } from "../types";
+import { WorkflowHandoffActionKind } from "@repo/shared/providers/workflowHandoff/actions/types";
+import { EntityKey } from "@repo/shared/providers/workflowHandoff/types";
 
 /**
  * Action to clear the handoff payload for an entity+path cell.

--- a/packages/shared/providers/workflowHandoff/actions/setHandoff/action.ts
+++ b/packages/shared/providers/workflowHandoff/actions/setHandoff/action.ts
@@ -1,4 +1,4 @@
-import { WorkflowHandoffState } from "../../types";
+import { WorkflowHandoffState } from "@repo/shared/providers/workflowHandoff/types";
 import { SetHandoffPayload } from "./types";
 
 /**

--- a/packages/shared/providers/workflowHandoff/actions/setHandoff/dispatch.ts
+++ b/packages/shared/providers/workflowHandoff/actions/setHandoff/dispatch.ts
@@ -1,4 +1,4 @@
-import { WorkflowHandoffActionKind } from "../types";
+import { WorkflowHandoffActionKind } from "@repo/shared/providers/workflowHandoff/actions/types";
 import { SetHandoffAction, SetHandoffPayload } from "./types";
 
 /**

--- a/packages/shared/providers/workflowHandoff/actions/setHandoff/types.ts
+++ b/packages/shared/providers/workflowHandoff/actions/setHandoff/types.ts
@@ -1,5 +1,8 @@
-import { EntityKey, HandoffInputs } from "../../types";
-import { WorkflowHandoffActionKind } from "../types";
+import { WorkflowHandoffActionKind } from "@repo/shared/providers/workflowHandoff/actions/types";
+import {
+  EntityKey,
+  HandoffInputs,
+} from "@repo/shared/providers/workflowHandoff/types";
 
 /**
  * Action to write a handoff payload for an entity+path.

--- a/packages/shared/providers/workflowHandoff/hooks/UseHandoffDispatch/hook.ts
+++ b/packages/shared/providers/workflowHandoff/hooks/UseHandoffDispatch/hook.ts
@@ -1,9 +1,9 @@
+import { clearHandoff as clearHandoffAction } from "@repo/shared/providers/workflowHandoff/actions/clearHandoff/dispatch";
+import { ClearHandoffPayload } from "@repo/shared/providers/workflowHandoff/actions/clearHandoff/types";
+import { setHandoff as setHandoffAction } from "@repo/shared/providers/workflowHandoff/actions/setHandoff/dispatch";
+import { SetHandoffPayload } from "@repo/shared/providers/workflowHandoff/actions/setHandoff/types";
+import { WorkflowHandoffContext } from "@repo/shared/providers/workflowHandoff/context";
 import { useCallback, useContext } from "react";
-import { clearHandoff as clearHandoffAction } from "../../actions/clearHandoff/dispatch";
-import { ClearHandoffPayload } from "../../actions/clearHandoff/types";
-import { setHandoff as setHandoffAction } from "../../actions/setHandoff/dispatch";
-import { SetHandoffPayload } from "../../actions/setHandoff/types";
-import { WorkflowHandoffContext } from "../../context";
 import { UseHandoffDispatch } from "./types";
 
 /**

--- a/packages/shared/providers/workflowHandoff/hooks/UseHandoffDispatch/types.ts
+++ b/packages/shared/providers/workflowHandoff/hooks/UseHandoffDispatch/types.ts
@@ -1,5 +1,5 @@
-import { ClearHandoffPayload } from "../../actions/clearHandoff/types";
-import { SetHandoffPayload } from "../../actions/setHandoff/types";
+import { ClearHandoffPayload } from "@repo/shared/providers/workflowHandoff/actions/clearHandoff/types";
+import { SetHandoffPayload } from "@repo/shared/providers/workflowHandoff/actions/setHandoff/types";
 
 /**
  * Return type for the useHandoffDispatch hook.

--- a/packages/shared/providers/workflowHandoff/hooks/UseHandoffInputs/hook.ts
+++ b/packages/shared/providers/workflowHandoff/hooks/UseHandoffInputs/hook.ts
@@ -1,7 +1,7 @@
+import { DEFAULT_HANDOFF_INPUTS } from "@repo/shared/providers/workflowHandoff/constants";
+import { WorkflowHandoffContext } from "@repo/shared/providers/workflowHandoff/context";
+import { EntityKey } from "@repo/shared/providers/workflowHandoff/types";
 import { useContext } from "react";
-import { DEFAULT_HANDOFF_INPUTS } from "../../constants";
-import { WorkflowHandoffContext } from "../../context";
-import { EntityKey } from "../../types";
 import { UseHandoffInputs } from "./types";
 
 /**

--- a/packages/shared/providers/workflowHandoff/hooks/UseHandoffInputs/types.ts
+++ b/packages/shared/providers/workflowHandoff/hooks/UseHandoffInputs/types.ts
@@ -1,4 +1,4 @@
-import { HandoffInputs } from "../../types";
+import { HandoffInputs } from "@repo/shared/providers/workflowHandoff/types";
 
 /**
  * Return type for the useHandoffInputs hook.

--- a/packages/shared/providers/workflowHandoff/hooks/UseWorkflowHandoffReducer/hook.ts
+++ b/packages/shared/providers/workflowHandoff/hooks/UseWorkflowHandoffReducer/hook.ts
@@ -1,7 +1,7 @@
+import { INITIAL_STATE } from "@repo/shared/providers/workflowHandoff/constants";
+import { workflowHandoffReducer } from "@repo/shared/providers/workflowHandoff/reducer";
+import { WorkflowHandoffContextValue } from "@repo/shared/providers/workflowHandoff/types";
 import { useReducer } from "react";
-import { INITIAL_STATE } from "../../constants";
-import { workflowHandoffReducer } from "../../reducer";
-import { WorkflowHandoffContextValue } from "../../types";
 
 /**
  * Internal hook wiring the reducer used by `WorkflowHandoffProvider`.

--- a/packages/shared/services/api-client/api-client.ts
+++ b/packages/shared/services/api-client/api-client.ts
@@ -1,5 +1,5 @@
+import { API_BASE_URL } from "@repo/shared/config/api";
 import ky, { HTTPError } from "ky";
-import { API_BASE_URL } from "../../config/api";
 import type {
   FavoriteResponse,
   SavedAnalysisDetail,

--- a/packages/shared/services/workflows/entities.ts
+++ b/packages/shared/services/workflows/entities.ts
@@ -1,5 +1,8 @@
-import type { AssemblyContract, OrganismContract } from "../../apis/types";
-import type { Workflow, WorkflowCategory } from "../../apis/workflow";
+import type {
+  AssemblyContract,
+  OrganismContract,
+} from "@repo/shared/apis/types";
+import type { Workflow, WorkflowCategory } from "@repo/shared/apis/workflow";
 import { findEntity, getEntities, getEntity } from "./query";
 
 /**

--- a/packages/shared/services/workflows/loader.ts
+++ b/packages/shared/services/workflows/loader.ts
@@ -1,6 +1,6 @@
 import { SiteConfig } from "@databiosphere/findable-ui/lib/config/entities";
-import type { Workflow, WorkflowCategory } from "../../apis/workflow";
-import { formatTrsId } from "../../workflow/utils";
+import type { Workflow, WorkflowCategory } from "@repo/shared/apis/workflow";
+import { formatTrsId } from "@repo/shared/workflow/utils";
 import { API } from "./routes";
 import { getEntitiesById, setEntitiesById, setEntitiesByType } from "./store";
 import type { EntityRoute } from "./types";

--- a/packages/shared/views/EntityView/ui/Section/section.styles.ts
+++ b/packages/shared/views/EntityView/ui/Section/section.styles.ts
@@ -1,7 +1,7 @@
 import { PALETTE } from "@databiosphere/findable-ui/lib/styles/common/constants/palette";
 import styled from "@emotion/styled";
 import { Stack } from "@mui/material";
-import { SECTION_PADDING } from "../styles";
+import { SECTION_PADDING } from "@repo/shared/views/EntityView/ui/styles";
 
 export const StyledStack = styled(Stack)`
   ${SECTION_PADDING};

--- a/packages/shared/views/docs/common/staticGeneration/types.ts
+++ b/packages/shared/views/docs/common/staticGeneration/types.ts
@@ -1,6 +1,6 @@
 import type { StaticProps as BaseStaticProps } from "@databiosphere/findable-ui/lib/utils/mdx/staticGeneration/types";
 import type { ThemeOptions } from "@mui/material";
-import type { FrontmatterProps } from "../frontmatter/types";
+import type { FrontmatterProps } from "@repo/shared/views/docs/common/frontmatter/types";
 
 export type StaticProps = BaseStaticProps<FrontmatterProps, PageStaticProps>;
 

--- a/packages/shared/workflow/custom.ts
+++ b/packages/shared/workflow/custom.ts
@@ -2,8 +2,8 @@ import {
   WORKFLOW_PARAMETER_VARIABLE,
   WORKFLOW_PLOIDY,
   WORKFLOW_SCOPE,
-} from "../apis/schema-types";
-import type { Workflow } from "../apis/workflow";
+} from "@repo/shared/apis/schema-types";
+import type { Workflow } from "@repo/shared/apis/workflow";
 
 export const CUSTOM_WORKFLOW: Workflow = {
   assemblyCountMax: 1,

--- a/packages/shared/workflow/differentialExpressionAnalysis.ts
+++ b/packages/shared/workflow/differentialExpressionAnalysis.ts
@@ -1,5 +1,8 @@
-import { WORKFLOW_PLOIDY, WORKFLOW_SCOPE } from "../apis/schema-types";
-import type { Workflow } from "../apis/workflow";
+import {
+  WORKFLOW_PLOIDY,
+  WORKFLOW_SCOPE,
+} from "@repo/shared/apis/schema-types";
+import type { Workflow } from "@repo/shared/apis/workflow";
 
 export const DIFFERENTIAL_EXPRESSION_ANALYSIS: Workflow = {
   assemblyCountMax: 1,

--- a/packages/shared/workflow/lexicmap.ts
+++ b/packages/shared/workflow/lexicmap.ts
@@ -1,5 +1,8 @@
-import { WORKFLOW_PLOIDY, WORKFLOW_SCOPE } from "../apis/schema-types";
-import type { Workflow } from "../apis/workflow";
+import {
+  WORKFLOW_PLOIDY,
+  WORKFLOW_SCOPE,
+} from "@repo/shared/apis/schema-types";
+import type { Workflow } from "@repo/shared/apis/workflow";
 
 export const LEXICMAP: Workflow = {
   assemblyCountMax: 0,

--- a/packages/shared/workflow/loganSearch.ts
+++ b/packages/shared/workflow/loganSearch.ts
@@ -1,5 +1,8 @@
-import { WORKFLOW_PLOIDY, WORKFLOW_SCOPE } from "../apis/schema-types";
-import type { Workflow } from "../apis/workflow";
+import {
+  WORKFLOW_PLOIDY,
+  WORKFLOW_SCOPE,
+} from "@repo/shared/apis/schema-types";
+import type { Workflow } from "@repo/shared/apis/workflow";
 
 export const LOGAN_SEARCH: Workflow = {
   assemblyCountMax: 0,

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -11,6 +11,12 @@ import { useFeatureFlag } from "@databiosphere/findable-ui/lib/hooks/useFeatureF
 import { ConfigProvider as DXConfigProvider } from "@databiosphere/findable-ui/lib/providers/config";
 import { ExploreStateProvider } from "@databiosphere/findable-ui/lib/providers/exploreState";
 
+import { getDefaultDescription } from "@/common/meta/utils";
+import { StyledFooter } from "@/components/Layout/components/Footer/footer.styles";
+import { config } from "@/config/config";
+import { useEntities } from "@/services/workflows/hooks/UseEntities/hook";
+import "@/styles/fonts/fonts.css";
+import { mergeAppTheme } from "@/theme/theme";
 import { LayoutDimensionsProvider } from "@databiosphere/findable-ui/lib/providers/layoutDimensions/provider";
 import { ServicesProvider } from "@databiosphere/findable-ui/lib/providers/services/provider";
 import { SystemStatusProvider } from "@databiosphere/findable-ui/lib/providers/systemStatus";
@@ -22,17 +28,11 @@ import { OgMeta } from "@repo/shared/components/OgMeta/ogMeta";
 import { AuthProvider } from "@repo/shared/providers/authentication/provider";
 import { EntitiesLoadedProvider } from "@repo/shared/providers/entitiesLoaded/provider";
 import { WorkflowHandoffProvider } from "@repo/shared/providers/workflowHandoff/provider";
+import { ROUTES } from "@routes/constants";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { NextPage } from "next";
 import type { AppProps } from "next/app";
 import { JSX, useMemo } from "react";
-import { getDefaultDescription } from "../app/common/meta/utils";
-import { StyledFooter } from "../app/components/Layout/components/Footer/footer.styles";
-import { config } from "../app/config/config";
-import { useEntities } from "../app/services/workflows/hooks/UseEntities/hook";
-import "../app/styles/fonts/fonts.css";
-import { mergeAppTheme } from "../app/theme/theme";
-import { ROUTES } from "../routes/constants";
 
 const DEFAULT_ENTITY_LIST_TYPE = "organisms";
 

--- a/pages/about/index.tsx
+++ b/pages/about/index.tsx
@@ -3,11 +3,11 @@ import { StyledPagesMain } from "@/components/Layout/components/Main/main.styles
 import { config } from "@/config/config";
 import { AboutView } from "@/views/AboutView/aboutView";
 import { BRC_CARDS, GA2_CARDS } from "@/views/AboutView/common/constants";
+import type { PageProps } from "@pages/_app";
+import { ROUTES } from "@routes/constants";
 import { APP_KEYS } from "@site-config/common/constants";
 import { GetStaticProps } from "next";
 import { JSX } from "react";
-import { ROUTES } from "../../routes/constants";
-import type { PageProps } from "../_app";
 
 export const About = (): JSX.Element => {
   const { appKey } = config();

--- a/pages/about/partner-resources/index.tsx
+++ b/pages/about/partner-resources/index.tsx
@@ -3,11 +3,11 @@ import { StyledPagesMain } from "@/components/Layout/components/Main/main.styles
 import { config } from "@/config/config";
 import { PartnerResourcesView } from "@brc/views/PartnerResourcesView/partnerResourcesView";
 import { PartnerResourcesView as PartnerResourcesViewGA2 } from "@ga2/views/PartnerResourcesView/partnerResourcesView";
+import type { PageProps } from "@pages/_app";
+import { ROUTES } from "@routes/constants";
 import { APP_KEYS } from "@site-config/common/constants";
 import { GetStaticProps } from "next";
 import { JSX } from "react";
-import { ROUTES } from "../../../routes/constants";
-import type { PageProps } from "../../_app";
 
 const Page = (): JSX.Element => {
   const { appKey } = config();

--- a/pages/about/roadmap/index.tsx
+++ b/pages/about/roadmap/index.tsx
@@ -3,11 +3,11 @@ import { StyledPagesMain } from "@/components/Layout/components/Main/main.styles
 import { config } from "@/config/config";
 import { RoadmapView } from "@brc/views/RoadmapView/roadmapView";
 import { RoadmapView as RoadmapViewGA2 } from "@ga2/views/RoadmapView/roadmapView";
+import type { PageProps } from "@pages/_app";
+import { ROUTES } from "@routes/constants";
 import { APP_KEYS } from "@site-config/common/constants";
 import { GetStaticProps } from "next";
 import { JSX } from "react";
-import { ROUTES } from "../../../routes/constants";
-import type { PageProps } from "../../_app";
 
 const Page = (): JSX.Element => {
   const { appKey } = config();

--- a/pages/about/vision/index.tsx
+++ b/pages/about/vision/index.tsx
@@ -2,10 +2,10 @@ import { BRC_PAGE_META } from "@/common/meta/brc/constants";
 import { StyledPagesMain } from "@/components/Layout/components/Main/main.styles";
 import { config } from "@/config/config";
 import { VisionView } from "@brc/views/VisionView/visionView";
+import type { PageProps } from "@pages/_app";
+import { ROUTES } from "@routes/constants";
 import { GetStaticProps } from "next";
 import { JSX } from "react";
-import { ROUTES } from "../../../routes/constants";
-import type { PageProps } from "../../_app";
 
 const Page = (): JSX.Element => {
   return <VisionView />;

--- a/pages/calendar/index.tsx
+++ b/pages/calendar/index.tsx
@@ -2,9 +2,9 @@ import { BRC_PAGE_META } from "@/common/meta/brc/constants";
 import { StyledPagesMain } from "@/components/Layout/components/Main/main.styles";
 import { config } from "@/config/config";
 import { CalendarView } from "@brc/views/CalendarView/calendarView";
+import { ROUTES } from "@routes/constants";
 import { GetStaticProps } from "next";
 import { JSX } from "react";
-import { ROUTES } from "../../routes/constants";
 
 export const Calendar = (): JSX.Element => {
   return <CalendarView />;

--- a/pages/data/workflows/[trsId]/index.tsx
+++ b/pages/data/workflows/[trsId]/index.tsx
@@ -1,6 +1,7 @@
 import { getPageMeta } from "@/common/meta/utils";
 import { config } from "@/config/config";
 import { WorkflowView } from "@/views/WorkflowView/workflowView";
+import workflowCategories from "@catalog/output/workflows.json";
 import { EntityDataGate } from "@repo/shared/components/EntityDataGate/entityDataGate";
 import { DIFFERENTIAL_EXPRESSION_ANALYSIS } from "@repo/shared/workflow/differentialExpressionAnalysis";
 import { LEXICMAP } from "@repo/shared/workflow/lexicmap";
@@ -9,7 +10,6 @@ import { formatTrsId } from "@repo/shared/workflow/utils";
 import { GetStaticPaths, GetStaticProps, GetStaticPropsContext } from "next";
 import { ParsedUrlQuery } from "querystring";
 import { JSX } from "react";
-import workflowCategories from "../../../../catalog/output/workflows.json";
 
 interface Params extends ParsedUrlQuery {
   trsId: string;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,14 +1,14 @@
+import { getPageMeta } from "@/common/meta/utils";
+import { StyledMain } from "@/components/Layout/components/Main/main.styles";
+import { config } from "@/config/config";
+import { HomeView as GA2HomeView } from "@/views/HomeView/ga2/homeView";
+import { HomeView } from "@/views/HomeView/homeView";
 import { useConfig } from "@databiosphere/findable-ui/lib/hooks/useConfig";
 import { useLayoutDimensions } from "@databiosphere/findable-ui/lib/providers/layoutDimensions/hook";
+import { APP_KEYS } from "@site-config/common/constants";
+import { AppSiteConfig } from "@site-config/common/entities";
 import { GetStaticProps } from "next";
 import { JSX } from "react";
-import { getPageMeta } from "../app/common/meta/utils";
-import { StyledMain } from "../app/components/Layout/components/Main/main.styles";
-import { config } from "../app/config/config";
-import { HomeView as GA2HomeView } from "../app/views/HomeView/ga2/homeView";
-import { HomeView } from "../app/views/HomeView/homeView";
-import { APP_KEYS } from "../site-config/common/constants";
-import { AppSiteConfig } from "../site-config/common/entities";
 
 export const Home = (): JSX.Element | null => {
   const { config } = useConfig();

--- a/pages/learn/index.tsx
+++ b/pages/learn/index.tsx
@@ -1,9 +1,9 @@
 import { BRC_PAGE_META } from "@/common/meta/brc/constants";
 import { StyledPagesMain } from "@/components/Layout/components/Main/main.styles";
 import { LearnView } from "@/views/LearnView/learnView";
+import type { PageProps } from "@pages/_app";
 import { GetStaticProps } from "next";
 import { JSX } from "react";
-import type { PageProps } from "../_app";
 
 const Page = (): JSX.Element => {
   return <LearnView />;

--- a/pages/roadmap/index.tsx
+++ b/pages/roadmap/index.tsx
@@ -1,8 +1,8 @@
 import { config } from "@/config/config";
+import { ROUTES } from "@routes/constants";
 import { GetStaticProps } from "next";
 import Head from "next/head";
 import { JSX } from "react";
-import { ROUTES } from "../../routes/constants";
 
 export default function Roadmap(): JSX.Element {
   return (

--- a/site-config/brc-analytics/dev/config.ts
+++ b/site-config/brc-analytics/dev/config.ts
@@ -1,5 +1,5 @@
+import { makeConfig } from "@site-config/brc-analytics/local/config";
 import { AppSiteConfig } from "@site-config/common/entities";
-import { makeConfig } from "../local/config";
 
 const BROWSER_URL = "https://brc-analytics.dev.clevercanary.com";
 

--- a/site-config/brc-analytics/local/config.ts
+++ b/site-config/brc-analytics/local/config.ts
@@ -9,11 +9,11 @@ import { FILTER_SORT } from "@databiosphere/findable-ui/lib/common/filters/sort/
 import { ANCHOR_TARGET } from "@databiosphere/findable-ui/lib/components/Links/common/entities";
 import { EntityConfig } from "@databiosphere/findable-ui/lib/config/entities";
 import { ROUTES } from "@repo/shared/routes/constants";
+import { ROUTES as SITE_ROUTES } from "@routes/constants";
 import { APP_KEYS } from "@site-config/common/constants";
 import { AppSiteConfig } from "@site-config/common/entities";
 import data from "catalog/output/ncbi-taxa-tree.json";
 import { createElement } from "react";
-import { ROUTES as SITE_ROUTES } from "../../../routes/constants";
 import { floating } from "./floating/floating";
 import { genomeEntityConfig } from "./index/genomeEntityConfig";
 import { organismEntityConfig } from "./index/organismEntityConfig";

--- a/site-config/brc-analytics/local/index/organismEntityConfig.ts
+++ b/site-config/brc-analytics/local/index/organismEntityConfig.ts
@@ -13,9 +13,9 @@ import {
   BRC_DATA_CATALOG_CATEGORY_KEY,
   BRC_DATA_CATALOG_CATEGORY_LABEL,
 } from "@site-config/brc-analytics/category";
+import { organismMainColumn } from "@site-config/brc-analytics/local/entity/organism/organismMainColumn";
+import { organismTop } from "@site-config/brc-analytics/local/entity/organism/organismTop";
 import { AppEntityConfig } from "@site-config/common/entities";
-import { organismMainColumn } from "../entity/organism/organismMainColumn";
-import { organismTop } from "../entity/organism/organismTop";
 import { CATEGORY_GROUPS } from "./common/category/categories";
 import { COLUMN_REGISTRY } from "./common/column/columnRegistry";
 

--- a/site-config/brc-analytics/local/index/priorityPathogensEntityConfig.ts
+++ b/site-config/brc-analytics/local/index/priorityPathogensEntityConfig.ts
@@ -1,11 +1,11 @@
 import { Outbreak } from "@/apis/catalog/brc-analytics-catalog/common/entities";
 import { SLUGIFY_OPTIONS } from "@/common/constants";
 import { EXPLORE_MODE } from "@databiosphere/findable-ui/lib/hooks/useExploreMode/types";
+import { priorityPathogenMainColumn } from "@site-config/brc-analytics/local/entity/priorityPathogen/priorityPathogenMainColumn";
+import { priorityPathogenSideColumn } from "@site-config/brc-analytics/local/entity/priorityPathogen/priorityPathogenSideColumn";
+import { priorityPathogenTop } from "@site-config/brc-analytics/local/entity/priorityPathogen/priorityPathogenTop";
 import { AppEntityConfig } from "@site-config/common/entities";
 import slugify from "slugify";
-import { priorityPathogenMainColumn } from "../entity/priorityPathogen/priorityPathogenMainColumn";
-import { priorityPathogenSideColumn } from "../entity/priorityPathogen/priorityPathogenSideColumn";
-import { priorityPathogenTop } from "../entity/priorityPathogen/priorityPathogenTop";
 
 /**
  * Entity config object responsible to config anything related to the /priority-pathogens route.

--- a/site-config/brc-analytics/local/socialMedia.ts
+++ b/site-config/brc-analytics/local/socialMedia.ts
@@ -5,7 +5,7 @@ import {
   ANCHOR_TARGET,
   REL_ATTRIBUTE,
 } from "@databiosphere/findable-ui/lib/components/Links/common/entities";
-import { ROUTES } from "../../../routes/constants";
+import { ROUTES } from "@routes/constants";
 
 export const SOCIALS = {
   CALENDAR: {

--- a/site-config/brc-analytics/prod/config.ts
+++ b/site-config/brc-analytics/prod/config.ts
@@ -1,5 +1,5 @@
+import { makeConfig } from "@site-config/brc-analytics/local/config";
 import { AppSiteConfig } from "@site-config/common/entities";
-import { makeConfig } from "../local/config";
 
 const BROWSER_URL = "https://brc-analytics.org";
 

--- a/site-config/ga2/dev/config.ts
+++ b/site-config/ga2/dev/config.ts
@@ -1,5 +1,5 @@
 import { AppSiteConfig } from "@site-config/common/entities";
-import { makeConfig } from "../local/config";
+import { makeConfig } from "@site-config/ga2/local/config";
 
 const BROWSER_URL = "https://ga2.dev.clevercanary.com";
 

--- a/site-config/ga2/local/config.ts
+++ b/site-config/ga2/local/config.ts
@@ -7,10 +7,10 @@ import { TaxonomyNode } from "@/components/Home/components/Section/components/Se
 import { ANCHOR_TARGET } from "@databiosphere/findable-ui/lib/components/Links/common/entities";
 import { EntityConfig } from "@databiosphere/findable-ui/lib/config/entities";
 import { ROUTES } from "@repo/shared/routes/constants";
+import { ROUTES as SITE_ROUTES } from "@routes/constants";
 import { APP_KEYS } from "@site-config/common/constants";
 import { AppSiteConfig } from "@site-config/common/entities";
 import data from "catalog/ga2/output/ncbi-taxa-tree.json";
-import { ROUTES as SITE_ROUTES } from "../../../routes/constants";
 import { floating } from "./floating/floating";
 import { genomeEntityConfig } from "./index/genome/genomeEntityConfig";
 import { organismEntityConfig } from "./index/organism/organismEntityConfig";

--- a/site-config/ga2/local/index/genome/categoryGroups.ts
+++ b/site-config/ga2/local/index/genome/categoryGroups.ts
@@ -1,5 +1,5 @@
 import { CategoryGroup } from "@databiosphere/findable-ui/lib/config/entities";
-import { CATEGORY_REGISTRY } from "../common/category/categoryRegistry";
+import { CATEGORY_REGISTRY } from "@site-config/ga2/local/index/common/category/categoryRegistry";
 
 export const CATEGORY_GROUPS: CategoryGroup[] = [
   {

--- a/site-config/ga2/local/index/organism/categoryGroups.ts
+++ b/site-config/ga2/local/index/organism/categoryGroups.ts
@@ -1,5 +1,5 @@
 import { CategoryGroup } from "@databiosphere/findable-ui/lib/config/entities";
-import { CATEGORY_REGISTRY } from "../common/category/categoryRegistry";
+import { CATEGORY_REGISTRY } from "@site-config/ga2/local/index/common/category/categoryRegistry";
 
 export const CATEGORY_GROUPS: CategoryGroup[] = [
   {

--- a/site-config/ga2/prod/config.ts
+++ b/site-config/ga2/prod/config.ts
@@ -1,5 +1,5 @@
 import { AppSiteConfig } from "@site-config/common/entities";
-import { makeConfig } from "../local/config";
+import { makeConfig } from "@site-config/ga2/local/config";
 
 const BROWSER_URL = "https://ga2.org";
 

--- a/sites/brc-analytics/views/CalendarView/constants.ts
+++ b/sites/brc-analytics/views/CalendarView/constants.ts
@@ -1,5 +1,5 @@
 import { Breadcrumb } from "@databiosphere/findable-ui/lib/components/common/Breadcrumbs/breadcrumbs";
-import { ROUTES } from "../../../../routes/constants";
+import { ROUTES } from "@routes/constants";
 
 export const BREADCRUMBS: Breadcrumb[] = [
   {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,9 @@
     "paths": {
       "@/*": ["app/*"],
       "@brc/*": ["sites/brc-analytics/*"],
+      "@catalog/*": ["catalog/*"],
       "@ga2/*": ["sites/ga2/*"],
+      "@pages/*": ["pages/*"],
       "@repo/shared": ["packages/shared/index.ts"],
       "@repo/shared/*": ["packages/shared/*"],
       "@routes/*": ["routes/*"],


### PR DESCRIPTION
## Summary

Standardizes intra-package imports and enforces it via lint, closing the sweep (#1572) and enforcement (#1573) tickets together (they're coupled — the rule can't pass until the existing `../` imports are normalized).

## Convention

- **Relative (`./`) only for same-directory and descendants.**
- **Alias for everything else** — no `../`.

The rule describes the *relationship* (am I reaching outside my own subtree?), not incidental file depth, so it doesn't change when files move; and a module's internal reference is the same string as an external one, so one `grep` finds every consumer.

## Changes

- **`tsconfig.json`** — added `@catalog/*` and `@pages/*` aliases (needed so the generated-schema and `_app` references have an alias target). Verified resolving in tsc, Next/webpack, esrun, and jest.
- **`eslint.config.mjs`** — `@typescript-eslint/no-restricted-imports` banning `../*`/`../**`, scoped per directory with that directory's alias in the message. The typescript-eslint variant is used so `import type` specifiers are covered too. The convention is documented in a comment right at the rule.
- **Sweep** — every `../` self-import rewritten to its alias across `app`, `packages/shared`, `sites/brc-analytics`, `sites/ga2`, `pages`, `site-config`.

## Scope note

`catalog` and `tests` are intentionally **not** covered — their esrun/Playwright tooling and the lack of a `tests` alias make them a separate, higher-risk change best done on their own.

## Verification

tsc · eslint (rule fires on both value and `import type` `../`) · prettier · `build:local` · 581 unit tests · GA2 catalog build (esrun) — all green.

Closes #1572
Closes #1573

🤖 Generated with [Claude Code](https://claude.com/claude-code)