### PR TITLE
chore: use stable keys for sectioncontentcards list items (#1577)

### DIFF
--- a/packages/shared/views/docs/components/SectionContentCards/sectionContentCards.tsx
+++ b/packages/shared/views/docs/components/SectionContentCards/sectionContentCards.tsx
@@ -8,7 +8,7 @@ export const SectionContentCards = ({ cards }: Props): JSX.Element | null => {
   return (
     <StyledStack>
       {cards.map((card, i) => (
-        <SectionContentCard key={`${card.href}-${i}`} {...card} />
+        <SectionContentCard key={card.href ?? i} {...card} />
       ))}
     </StyledStack>
   );


### PR DESCRIPTION
## Summary

Keys `SectionContentCards` list items by their stable `href` instead of `\`${card.href}-${index}\`` (which folded in the array index, making keys unstable on reorder → unnecessary unmount/remount and potential state loss).

```diff
-<SectionContentCard key={`${card.href}-${i}`} {...card} />
+<SectionContentCard key={card.href ?? i} {...card} />
```

Falls back to the index only when `href` is absent (display-only cards may omit it).

Verified: tsc / eslint / prettier / 581 tests.

Closes #1577

🤖 Generated with [Claude Code](https://claude.com/claude-code)