### PR TITLE
chore: remove dead layout/detail section styles (#1585)

### DIFF
--- a/app/components/Layout/components/Detail/components/Section/section.styles.ts
+++ b/app/components/Layout/components/Detail/components/Section/section.styles.ts
@@ -1,6 +1,0 @@
-import { GridPaperSection as DXGridPaperSection } from "@databiosphere/findable-ui/lib/components/common/Section/section.styles";
-import styled from "@emotion/styled";
-
-export const GridPaperSection = styled(DXGridPaperSection)`
-  min-width: 0;
-`;


### PR DESCRIPTION
## Summary

Removes `app/components/Layout/components/Detail/components/Section/section.styles.ts` (and the now-empty `Layout/components/Detail/` directory). It exported `GridPaperSection` but had **zero importers** — the whole `Detail/` dir contained only this one styles file, with no component rendering it.

Pure dead-code removal.

## Verification
tsc (green — confirms nothing referenced it) · `build:local` compiled successfully.

Closes #1585

🤖 Generated with [Claude Code](https://claude.com/claude-code)