### PR TITLE
chore: generate next types before typechecking and gitignore next env (#1452)

### DIFF
--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Run Linter (ESLint)
         run: npm run lint
       - name: Type Check
-        run: npx tsc --noEmit
+        run: npm run typecheck
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # next.js
 /.next/
+/next-env.d.ts
 
 # misc
 .DS_Store

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -21,7 +21,7 @@ echo '🐍 Formatting Python files with Ruff...'
 npm run format:python
 
 # Check TypeScript
-npx tsc --noEmit ||
+npm run typecheck ||
 (
 	echo 'TypeScript compile failed';
 	false;

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 Using Node.js version `22.12.0`, run `npm install` in the root directory of the repository to install dependencies.
 
+### Typechecking
+
+The app is written with TypeScript and Next.js. Because Next generates local-only type definitions under `.next` in order to check page routes, erroneous type errors may appear when those types become out-of-sync with new code changes. To avoid this, any typechecking should be done by running `npm run typecheck`, which will first update Next's generated types. Additionally, if type errors are reported in `.next` by another program such as an editor, it may be possible to resolve them by running the same script, or by running `npx next typegen` to only generate types.
+
 ## Using the development server
 
 The app can be run for development using `npm run dev`, and accessed at `http://localhost:3000`.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,7 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
-import "./.next/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build-prod:ga2": "./scripts/build.sh ga2 prod && ./scripts/set-version.sh && ./scripts/sync-api-ga2.sh && next build --webpack",
     "start": "npx serve out",
     "lint": "eslint .",
+    "typecheck": "next typegen && tsc --noEmit",
     "check-format": "prettier --check .",
     "format": "prettier --write . --cache",
     "format:python": "./scripts/format-python.sh",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,5 +40,5 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", ".next/dev/types"]
 }


### PR DESCRIPTION
## Description

- Added `next-env.d.ts` to the gitignore, as it's not intended to be committed and may change when Next is run
- Added a `typecheck` NPM script to use in place of `tsc --noEmit`, which generates local Next types before typechecking and thus helps avoid commits failing due to the pre-commit checks encountering outdated Next types
- Added Next dev types to the TypeScript exclude paths, since they can't be generated on their own and are effectively (see issue) the same as the main types
  - The include path is not removed because it's automatically inserted by Next
- Added note to readme to point out the NPM script

## Related Issue

Closes #1452
