### PR TITLE
fix: add ordering to `first` calls in catalog transformations to guarantee consistency (#1546)

### DIFF
--- a/catalog/py_package/catalog_build/transform/dbt/models/taxonomy/taxonomy_assemblies.sql
+++ b/catalog/py_package/catalog_build/transform/dbt/models/taxonomy/taxonomy_assemblies.sql
@@ -3,11 +3,11 @@
 select
   t.taxonomy_id,
   {% for taxonomic_level in var("taxonomic_levels") %}
-  first(l.taxon_name) filter (l.rank = '{{taxonomic_level}}') as taxonomic_level_{{taxonomic_level}},
-  first(l.tax_id) filter (l.rank = '{{taxonomic_level}}') as taxonomic_level_{{taxonomic_level}}_id,
+  first(l.taxon_name order by l.tax_id) filter (l.rank = '{{taxonomic_level}}') as taxonomic_level_{{taxonomic_level}},
+  first(l.tax_id order by l.tax_id) filter (l.rank = '{{taxonomic_level}}') as taxonomic_level_{{taxonomic_level}}_id,
   {% endfor %}
   list(l.tax_id order by l.depth desc) as lineage_taxonomy_ids,
-  first(l.common_names) filter (l.is_query_taxon) as common_names
+  first(l.common_names order by l.tax_id) filter (l.is_query_taxon) as common_names
 from {{ source("catalog_source", "assembly_taxa") }} t
 join {{ ref("taxonomy_lineages_with_names") }} l on l.query_tax_id = t.taxonomy_id
 group by t.taxonomy_id


### PR DESCRIPTION
## Description

Adds ordering to `first` calls in `taxonomy_assemblies.sql` (the only dbt model with unordered aggregate function calls). These calls theoretically only have one row to choose from anyway, but ordering will ensure consistency if something weird happens.

## Related Issue

Closes #1546