### PR TITLE
fix: home bullets onkeydown fires on every keypress (a11y) (#1601)

### DIFF
--- a/packages/shared/views/HomeView/components/Bullets/bullets.tsx
+++ b/packages/shared/views/HomeView/components/Bullets/bullets.tsx
@@ -22,9 +22,6 @@ export const Bullets = ({
           onClick={(): void => {
             onBullet(bullet);
           }}
-          onKeyDown={(): void => {
-            onBullet(bullet);
-          }}
         >
           <StyledDot isActive={activeBullet === bullet} />
         </Bullet>


### PR DESCRIPTION
## Summary

The home `Bullets` component (`packages/shared/views/HomeView/components/Bullets/bullets.tsx`) rendered each bullet as a MUI `ButtonBase` with **both** `onClick` and `onKeyDown` firing `onBullet`. `ButtonBase` already maps Enter/Space to a click, so the extra `onKeyDown`:

- fired `onBullet` on **every** key press — including `Tab`/arrow keys used to move focus, unexpectedly changing the active slide; and
- **double-triggered** on Enter/Space (once via `onKeyDown`, once via `ButtonBase`'s built-in click).

This removes the redundant `onKeyDown`; keyboard activation now comes solely from `ButtonBase`'s `onClick`.

Closes #1601

## Testing

- `npm run typecheck` ✓
- `npm run lint` ✓ / Prettier ✓
- Both site builds run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
