### PR TITLE
fix: remove assemblyfavoritebutton from the ga2 assembly side column (#1661)

### DIFF
--- a/packages/shared/components/Favorites/components/AssemblyFavoriteButton/assemblyFavoriteButton.tsx
+++ b/packages/shared/components/Favorites/components/AssemblyFavoriteButton/assemblyFavoriteButton.tsx
@@ -6,7 +6,9 @@ import { useAuth } from "@repo/shared/providers/authentication/provider";
 import { type JSX } from "react";
 import type { Props } from "./types";
 
-export function AssemblyFavoriteButton({ accession }: Props): JSX.Element {
+export function AssemblyFavoriteButton({
+  accession,
+}: Props): JSX.Element | null {
   const {
     isAuthenticated,
     isConfigured,
@@ -16,7 +18,11 @@ export function AssemblyFavoriteButton({ accession }: Props): JSX.Element {
   const { error, isFavorited, isLoading, isToggling, toggleFavorite } =
     useAssemblyFavorites();
 
-  if (!isConfigured || isAuthLoading) {
+  // Login is not enabled on this site — a permanent state, not a loading one —
+  // so favorites can't be offered and the button renders nothing.
+  if (!isConfigured) return null;
+
+  if (isAuthLoading) {
     return <CircularProgress size={20} />;
   }
 

--- a/sites/brc-analytics/views/EntityView/assembly/components/Side/brc/side.tsx
+++ b/sites/brc-analytics/views/EntityView/assembly/components/Side/brc/side.tsx
@@ -1,6 +1,7 @@
 import { buildOrganismDetails } from "@brc/viewModelBuilders/viewModelBuilders";
 import { BackPageContentSideColumn } from "@databiosphere/findable-ui/lib/components/Layout/components/BackPage/backPageView.styles";
 import { AssemblyFavoriteButton } from "@repo/shared/components/Favorites/components/AssemblyFavoriteButton/assemblyFavoriteButton";
+import { useAuth } from "@repo/shared/providers/authentication/provider";
 import {
   buildAssemblyDetails,
   buildAssemblyResources,
@@ -20,12 +21,17 @@ import { type Props } from "./types";
  * @returns JSX element representing the side column content.
  */
 export const Side = ({ assembly }: Props): JSX.Element => {
+  const { isConfigured } = useAuth();
   return (
     <BackPageContentSideColumn>
       <StyledFluidPaper>
-        <StyledSection>
-          <AssemblyFavoriteButton accession={assembly.accession} />
-        </StyledSection>
+        {/* Without auth configured the favorite button renders nothing; skip
+            the section too so it doesn't leave an empty padded strip. */}
+        {isConfigured && (
+          <StyledSection>
+            <AssemblyFavoriteButton accession={assembly.accession} />
+          </StyledSection>
+        )}
         <KeyValueSection
           {...buildOrganismDetails(mapAssemblyToOrganism(assembly))}
           title="Organism Details"

--- a/sites/ga2/views/EntityView/assembly/components/Side/ga2/side.styles.ts
+++ b/sites/ga2/views/EntityView/assembly/components/Side/ga2/side.styles.ts
@@ -1,6 +1,0 @@
-import styled from "@emotion/styled";
-import { Section } from "@repo/shared/views/EntityView/ui/Section/section";
-
-export const StyledSection = styled(Section)`
-  align-items: flex-start;
-`;

--- a/sites/ga2/views/EntityView/assembly/components/Side/ga2/side.tsx
+++ b/sites/ga2/views/EntityView/assembly/components/Side/ga2/side.tsx
@@ -1,6 +1,5 @@
 import { BackPageContentSideColumn } from "@databiosphere/findable-ui/lib/components/Layout/components/BackPage/backPageView.styles";
 import { AssemblyDetails } from "@ga2/views/EntityView/assembly/components/Side/ga2/components/AssemblyDetails/AssemblyDetails";
-import { AssemblyFavoriteButton } from "@repo/shared/components/Favorites/components/AssemblyFavoriteButton/assemblyFavoriteButton";
 import {
   buildAssemblyResources,
   buildOrganismDetails,
@@ -10,7 +9,6 @@ import { KeyValueSection } from "@repo/shared/views/EntityView/components/KeyVal
 import { StyledFluidPaper } from "@repo/shared/views/EntityView/ui/FluidPaper/fluidPaper.styles";
 import { mapAssemblyToOrganism } from "@repo/shared/views/WorkflowInputsView/utils";
 import { type JSX } from "react";
-import { StyledSection } from "./side.styles";
 import { type Props } from "./types";
 
 /**
@@ -23,9 +21,6 @@ export const Side = ({ assembly }: Props): JSX.Element => {
   return (
     <BackPageContentSideColumn>
       <StyledFluidPaper>
-        <StyledSection>
-          <AssemblyFavoriteButton accession={assembly.accession} />
-        </StyledSection>
         <KeyValueSection
           {...buildOrganismDetails(mapAssemblyToOrganism(assembly))}
           title="Organism Details"


### PR DESCRIPTION
## Summary

Closes #1661

The GA2 assembly detail side column rendered `AssemblyFavoriteButton`, but GA2 has no favorites/auth wiring — `isConfigured` in the auth provider is just `loginEnabled`, which GA2's config never sets, so the button rendered a permanent `CircularProgress` spinner.

- Removes the `AssemblyFavoriteButton` render and import from `sites/ga2/.../Side/ga2/side.tsx`.
- Deletes the local `side.styles.ts` (`StyledSection`) — it existed solely to wrap the button.
- **Component-level fix (review follow-up)**: the shared `AssemblyFavoriteButton` conflated two states behind one spinner. Now `!isConfigured` (permanent — login not enabled on the site) renders `null`, while `isAuthLoading` (transient) keeps the spinner. This also fixes the same live spinner on **BRC**'s assembly detail pages, where `NEXT_PUBLIC_LOGIN_ENABLED` is unset on every deployed environment.
- BRC's `Side` gates the button's `StyledSection` wrapper on the same `isConfigured` signal, so a nulled button doesn't leave an empty padded strip.
- The shared component and BRC's usage remain wired for the day login is enabled — the sign-in affordance returns automatically.

## Verification

- No `Favorites` imports remain under `sites/ga2/`.
- `tsc --noEmit`, Prettier + ESLint pass (pre-commit hook).
- Full unit suite passes; BRC + GA2 builds compile; BRC e2e 75/75, GA2 e2e 8/8 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)