### PR TITLE
refactor: build configure-workflow urls via urlsearchparams; keep routes as pure paths (#1488)

### DIFF
--- a/packages/shared/components/workflow/WorkflowCategory/components/Workflow/workflow.tsx
+++ b/packages/shared/components/workflow/WorkflowCategory/components/Workflow/workflow.tsx
@@ -2,11 +2,10 @@ import { REL_ATTRIBUTE } from "@databiosphere/findable-ui/lib/components/Links/c
 import { Link as DXLink } from "@databiosphere/findable-ui/lib/components/Links/components/Link/link";
 import { BUTTON_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/button";
 import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
-import { replaceParameters } from "@databiosphere/findable-ui/lib/utils/replaceParameters";
 import { Button, Grid, Typography } from "@mui/material";
 import { TYPOGRAPHY_PROPS as COMPONENT_TYPOGRAPHY_PROPS } from "@repo/shared/components/workflow/WorkflowCategory/constants";
 import { ROUTES } from "@repo/shared/routes/constants";
-import { formatTrsId } from "@repo/shared/workflow/utils";
+import { buildConfigureWorkflowUrl } from "@repo/shared/routes/utils";
 import Link from "next/link";
 import { Fragment, type JSX } from "react";
 import { GRID_PROPS } from "./constants";
@@ -53,10 +52,11 @@ export const Workflow = ({
             color={BUTTON_PROPS.COLOR.PRIMARY}
             component={Link}
             disabled={!workflow.trsId}
-            href={replaceParameters(configureRoute, {
+            href={buildConfigureWorkflowUrl(
+              configureRoute,
               entityId,
-              trsId: formatTrsId(workflow.trsId),
-            })}
+              workflow.trsId
+            )}
             rel={REL_ATTRIBUTE.NO_OPENER}
             variant={BUTTON_PROPS.VARIANT.CONTAINED}
           >

--- a/packages/shared/routes/constants.ts
+++ b/packages/shared/routes/constants.ts
@@ -1,10 +1,8 @@
 export const ROUTES = {
   ANALYZE_WORKFLOWS: "/data/assemblies/{entityId}/analyze/workflows",
   CONFIGURE_CUSTOM_WORKFLOW: "/data/assemblies/{entityId}/analyze/custom",
-  CONFIGURE_ORGANISM_WORKFLOW:
-    "/data/organisms/{entityId}/analyze/workflows?trsId={trsId}",
-  CONFIGURE_WORKFLOW:
-    "/data/assemblies/{entityId}/analyze/workflows?trsId={trsId}",
+  CONFIGURE_ORGANISM_WORKFLOW: "/data/organisms/{entityId}/analyze/workflows",
+  CONFIGURE_WORKFLOW: "/data/assemblies/{entityId}/analyze/workflows",
   GENOME: "/data/assemblies/{entityId}",
   GENOMES: "/data/assemblies",
   ORGANISM: "/data/organisms/{entityId}",

--- a/packages/shared/routes/utils.ts
+++ b/packages/shared/routes/utils.ts
@@ -1,0 +1,19 @@
+import { replaceParameters } from "@databiosphere/findable-ui/lib/utils/replaceParameters";
+import { formatTrsId } from "@repo/shared/workflow/utils";
+
+/**
+ * Builds a configure-workflow URL from a pure path template, appending the
+ * workflow TRS ID as a URL-encoded query parameter.
+ * @param route - Path template with an `{entityId}` parameter.
+ * @param entityId - Entity ID.
+ * @param trsId - Workflow TRS ID (raw or already catalog-formatted).
+ * @returns Configure-workflow URL.
+ */
+export function buildConfigureWorkflowUrl(
+  route: string,
+  entityId: string,
+  trsId: string
+): string {
+  const searchParams = new URLSearchParams({ trsId: formatTrsId(trsId) });
+  return `${replaceParameters(route, { entityId })}?${searchParams}`;
+}

--- a/packages/shared/routes/utils.ts
+++ b/packages/shared/routes/utils.ts
@@ -3,7 +3,9 @@ import { formatTrsId } from "@repo/shared/workflow/utils";
 
 /**
  * Builds a configure-workflow URL from a pure path template, appending the
- * workflow TRS ID as a URL-encoded query parameter.
+ * workflow TRS ID as a query parameter. The TRS ID is normalized to catalog
+ * format via `formatTrsId` (non-alphanumerics become `-`), then URL-encoded —
+ * raw values are not preserved verbatim.
  * @param route - Path template with an `{entityId}` parameter.
  * @param entityId - Entity ID.
  * @param trsId - Workflow TRS ID (raw or already catalog-formatted).

--- a/sites/brc-analytics/tests/e2e/02-workflow-stepper.spec.ts
+++ b/sites/brc-analytics/tests/e2e/02-workflow-stepper.spec.ts
@@ -1,6 +1,4 @@
-// .js extension required: Playwright uses Node's native module resolution which
-// enforces the package exports field strictly (no auto-resolving extensions).
-import { replaceParameters } from "@databiosphere/findable-ui/lib/utils/replaceParameters.js";
+import { replaceParameters } from "@databiosphere/findable-ui/lib/utils/replaceParameters";
 import { type Locator, type Page } from "@playwright/test";
 import { sanitizeEntityId } from "@repo/shared/apis/utils";
 import { ROUTES } from "@repo/shared/routes/constants";

--- a/sites/brc-analytics/tests/e2e/02-workflow-stepper.spec.ts
+++ b/sites/brc-analytics/tests/e2e/02-workflow-stepper.spec.ts
@@ -4,6 +4,7 @@ import { replaceParameters } from "@databiosphere/findable-ui/lib/utils/replaceP
 import { type Locator, type Page } from "@playwright/test";
 import { sanitizeEntityId } from "@repo/shared/apis/utils";
 import { ROUTES } from "@repo/shared/routes/constants";
+import { buildConfigureWorkflowUrl } from "@repo/shared/routes/utils";
 import { expect, test } from "./utils/fixtures";
 
 /**
@@ -42,15 +43,16 @@ const STEP_LOAD_TIMEOUT = 15000;
 expect.configure({ timeout: STEP_LOAD_TIMEOUT });
 
 /**
- * Builds a configure-workflow URL for the given workflow TRS ID.
+ * Builds an assembly configure-workflow URL for the given workflow TRS ID.
  * @param trsId - The TRS ID of the workflow.
  * @returns The configure-workflow URL.
  */
-function buildConfigureWorkflowUrl(trsId: string): string {
-  return replaceParameters(ROUTES.CONFIGURE_WORKFLOW, {
-    entityId: ASSEMBLY_ENTITY_ID,
-    trsId,
-  });
+function buildAssemblyConfigureWorkflowUrl(trsId: string): string {
+  return buildConfigureWorkflowUrl(
+    ROUTES.CONFIGURE_WORKFLOW,
+    ASSEMBLY_ENTITY_ID,
+    trsId
+  );
 }
 
 /**
@@ -81,7 +83,7 @@ async function advancePastGtfStep(page: Page): Promise<Locator> {
 
 test.describe("Workflow Stepper", () => {
   test.describe("RNA-seq PE workflow", () => {
-    const url = buildConfigureWorkflowUrl(RNASEQ_PE_TRS_ID);
+    const url = buildAssemblyConfigureWorkflowUrl(RNASEQ_PE_TRS_ID);
 
     test.beforeEach(async ({ page }) => {
       await page.goto(url);
@@ -186,7 +188,7 @@ test.describe("Workflow Stepper", () => {
   });
 
   test.describe("ATAC-seq workflow", () => {
-    const url = buildConfigureWorkflowUrl(ATACSEQ_TRS_ID);
+    const url = buildAssemblyConfigureWorkflowUrl(ATACSEQ_TRS_ID);
 
     test.beforeEach(async ({ page }) => {
       await page.goto(url);
@@ -229,7 +231,7 @@ test.describe("Workflow Stepper", () => {
   });
 
   test.describe("page structure", () => {
-    const url = buildConfigureWorkflowUrl(RNASEQ_PE_TRS_ID);
+    const url = buildAssemblyConfigureWorkflowUrl(RNASEQ_PE_TRS_ID);
 
     test.beforeEach(async ({ page }) => {
       await page.goto(url);
@@ -264,10 +266,11 @@ test.describe("Organism workflow route", () => {
     page,
   }) => {
     await page.goto(
-      replaceParameters(ROUTES.CONFIGURE_ORGANISM_WORKFLOW, {
-        entityId: ORGANISM_ENTITY_ID,
-        trsId: ORGANISM_TRS_ID,
-      })
+      buildConfigureWorkflowUrl(
+        ROUTES.CONFIGURE_ORGANISM_WORKFLOW,
+        ORGANISM_ENTITY_ID,
+        ORGANISM_TRS_ID
+      )
     );
 
     await expect(
@@ -279,7 +282,7 @@ test.describe("Organism workflow route", () => {
     page,
   }) => {
     const workflowsPath = replaceParameters(
-      ROUTES.CONFIGURE_ORGANISM_WORKFLOW.split("?")[0],
+      ROUTES.CONFIGURE_ORGANISM_WORKFLOW,
       { entityId: ORGANISM_ENTITY_ID }
     );
     const organismPath = replaceParameters(ROUTES.ORGANISM, {

--- a/tests/routes/buildConfigureWorkflowUrl.test.ts
+++ b/tests/routes/buildConfigureWorkflowUrl.test.ts
@@ -1,0 +1,50 @@
+import { ROUTES } from "@repo/shared/routes/constants";
+import { buildConfigureWorkflowUrl } from "@repo/shared/routes/utils";
+
+describe("buildConfigureWorkflowUrl", () => {
+  test("fills the path and appends the trsId query parameter", () => {
+    expect(
+      buildConfigureWorkflowUrl(
+        ROUTES.CONFIGURE_WORKFLOW,
+        "GCA_000002825_3",
+        "workflow-github-com-iwc-workflows-rnaseq-pe-main-versions-v1-4"
+      )
+    ).toBe(
+      "/data/assemblies/GCA_000002825_3/analyze/workflows?trsId=workflow-github-com-iwc-workflows-rnaseq-pe-main-versions-v1-4"
+    );
+  });
+
+  test("builds the organism route", () => {
+    expect(
+      buildConfigureWorkflowUrl(
+        ROUTES.CONFIGURE_ORGANISM_WORKFLOW,
+        "2955291",
+        "workflow-id"
+      )
+    ).toBe("/data/organisms/2955291/analyze/workflows?trsId=workflow-id");
+  });
+
+  test("formats a raw catalog TRS ID", () => {
+    expect(
+      buildConfigureWorkflowUrl(
+        ROUTES.CONFIGURE_WORKFLOW,
+        "GCA_000002825_3",
+        "#workflow/github.com/iwc-workflows/rnaseq-pe/main/versions/v1.4"
+      )
+    ).toBe(
+      "/data/assemblies/GCA_000002825_3/analyze/workflows?trsId=workflow-github-com-iwc-workflows-rnaseq-pe-main-versions-v1-4"
+    );
+  });
+
+  test("neutralizes URL-breaking characters in the TRS ID", () => {
+    expect(
+      buildConfigureWorkflowUrl(
+        ROUTES.CONFIGURE_WORKFLOW,
+        "GCA_000002825_3",
+        "a b&c=d#e"
+      )
+    ).toBe(
+      "/data/assemblies/GCA_000002825_3/analyze/workflows?trsId=a-b-c-d-e"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1488

`CONFIGURE_WORKFLOW` / `CONFIGURE_ORGANISM_WORKFLOW` embedded a `?trsId={trsId}` query string filled by `replaceParameters` — a path tool doing raw string replacement with no URL-encoding. It only worked because every caller pre-sanitized the TRS ID via `formatTrsId`; the `.split("?")[0]` workaround in the e2e spec was the tell.

- **`ROUTES`** entries are now pure path templates — no embedded query strings.
- **New `buildConfigureWorkflowUrl(route, entityId, trsId)`** (`packages/shared/routes/utils.ts`) fills the path via `replaceParameters` and appends `?trsId=` via `URLSearchParams`. It absorbs `formatTrsId` (idempotent), so callers can pass raw catalog or pre-formatted TRS IDs — the emitted URLs are byte-identical to before for all real IDs.
- **`Workflow` component** (the only production consumer of the query-embedded templates) builds its href through the helper.
- **E2E spec** uses the shared helper; the `.split("?")[0]` workaround is gone.
- **Backend checked** (assistant handoff): `compute_handoff` already builds its query via `urlencode` — no BE change needed.

## Testing

- New unit tests for `buildConfigureWorkflowUrl`: path filling + query append, organism route, raw catalog TRS ID formatting, and URL-breaking characters (` &=#`) neutralized.
- Full unit suite passes; both site builds compile; BRC e2e 75/75 and GA2 e2e 8/8 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)