### PR TITLE
feat: friendly 'workflow not found' page for stale/incompatible workflow urls (#1487)

### DIFF
--- a/packages/shared/components/workflow/WorkflowGate/types.ts
+++ b/packages/shared/components/workflow/WorkflowGate/types.ts
@@ -1,0 +1,7 @@
+import { type ReactNode } from "react";
+
+export interface Props {
+  children: ReactNode;
+  fallback: ReactNode;
+  trsId: string;
+}

--- a/packages/shared/components/workflow/WorkflowGate/workflowGate.tsx
+++ b/packages/shared/components/workflow/WorkflowGate/workflowGate.tsx
@@ -1,0 +1,23 @@
+import { findWorkflow } from "@repo/shared/services/workflows/entities";
+import { type JSX } from "react";
+import type { Props } from "./types";
+
+/**
+ * Gate content on the TRS ID matching a catalog workflow. Renders `children`
+ * for a known workflow and `fallback` otherwise, letting the page decide how
+ * a stale or unknown workflow URL is surfaced. Must be rendered below
+ * EntityDataGate, which guarantees the workflows cache is loaded before the
+ * lookup runs.
+ * @param props - Component props.
+ * @param props.children - Content to render when the workflow exists.
+ * @param props.fallback - Content to render for an unknown TRS ID.
+ * @param props.trsId - Workflow TRS ID.
+ * @returns Children when the workflow exists, fallback otherwise.
+ */
+export function WorkflowGate({
+  children,
+  fallback,
+  trsId,
+}: Props): JSX.Element {
+  return <>{findWorkflow(trsId) ? children : fallback}</>;
+}

--- a/packages/shared/components/workflow/WorkflowNotFound/types.ts
+++ b/packages/shared/components/workflow/WorkflowNotFound/types.ts
@@ -1,0 +1,4 @@
+export interface Props {
+  entityContext: string;
+  href: string;
+}

--- a/packages/shared/components/workflow/WorkflowNotFound/workflowNotFound.tsx
+++ b/packages/shared/components/workflow/WorkflowNotFound/workflowNotFound.tsx
@@ -1,0 +1,62 @@
+import { ButtonPrimary } from "@databiosphere/findable-ui/lib/components/common/Button/components/ButtonPrimary/buttonPrimary";
+import { AlertIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/AlertIcon/alertIcon";
+import { SectionActions } from "@databiosphere/findable-ui/lib/components/common/Section/section.styles";
+import {
+  PRIORITY,
+  StatusIcon,
+} from "@databiosphere/findable-ui/lib/components/common/StatusIcon/statusIcon";
+import {
+  ErrorLayout,
+  ErrorSection,
+  SectionContent,
+  Error as StyledError,
+} from "@databiosphere/findable-ui/lib/components/Error/error.styles";
+import { useLayoutDimensions } from "@databiosphere/findable-ui/lib/providers/layoutDimensions/hook";
+import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
+import { Typography } from "@mui/material";
+import Link from "next/link";
+import { type JSX } from "react";
+import { type Props } from "./types";
+
+/**
+ * Friendly not-found state for a stale or unknown workflow URL. Rendered in
+ * place of the configure-inputs view when the `trsId` query param doesn't
+ * match a catalog workflow, instead of surfacing the generic error page.
+ * @param props - Component props.
+ * @param props.entityContext - Noun for the entity the workflow was requested for (e.g. "assembly").
+ * @param props.href - URL of the entity's available-workflows listing.
+ * @returns Workflow not-found element.
+ */
+export const WorkflowNotFound = ({
+  entityContext,
+  href,
+}: Props): JSX.Element => {
+  const { dimensions } = useLayoutDimensions();
+  return (
+    <ErrorLayout offset={dimensions.header.height}>
+      <StyledError>
+        <ErrorSection>
+          <StatusIcon priority={PRIORITY.MEDIUM} StatusIcon={AlertIcon} />
+          <SectionContent>
+            <Typography
+              component="h1"
+              variant={TYPOGRAPHY_PROPS.VARIANT.HEADING_XLARGE}
+            >
+              Workflow not found
+            </Typography>
+            <Typography variant={TYPOGRAPHY_PROPS.VARIANT.BODY_LARGE_400}>
+              The requested workflow isn&apos;t available for this{" "}
+              {entityContext}. It may have been removed, or the link may be out
+              of date.
+            </Typography>
+          </SectionContent>
+          <SectionActions>
+            <ButtonPrimary component={Link} href={href}>
+              View Available Workflows
+            </ButtonPrimary>
+          </SectionActions>
+        </ErrorSection>
+      </StyledError>
+    </ErrorLayout>
+  );
+};

--- a/packages/shared/services/workflows/entities.ts
+++ b/packages/shared/services/workflows/entities.ts
@@ -17,6 +17,15 @@ export function findOrganism<T extends OrganismContract>(
 }
 
 /**
+ * Finds a workflow by TRS id, returning undefined when there is no match.
+ * @param trsId - TRS id.
+ * @returns Workflow, or undefined when not found.
+ */
+export function findWorkflow(trsId: string): Workflow | undefined {
+  return findEntity<Workflow>("workflows", trsId);
+}
+
+/**
  * Gets assemblies.
  * @returns Assemblies.
  */

--- a/sites/brc-analytics/pages/data/assemblies/[entityId]/analyze/workflows.tsx
+++ b/sites/brc-analytics/pages/data/assemblies/[entityId]/analyze/workflows.tsx
@@ -2,7 +2,11 @@ import { config } from "@brc/config/config";
 import { BRC_PAGE_META } from "@brc/meta/constants";
 import { buildOrganismDetails as buildBRCOrganismDetails } from "@brc/viewModelBuilders/viewModelBuilders";
 import { Side as BRCSide } from "@brc/views/EntityView/assembly/components/Side/brc/side";
+import { replaceParameters } from "@databiosphere/findable-ui/lib/utils/replaceParameters";
 import { EntityDataGate } from "@repo/shared/components/EntityDataGate/entityDataGate";
+import { WorkflowGate } from "@repo/shared/components/workflow/WorkflowGate/workflowGate";
+import { WorkflowNotFound } from "@repo/shared/components/workflow/WorkflowNotFound/workflowNotFound";
+import { ROUTES } from "@repo/shared/routes/constants";
 import { makeEntityStaticPaths } from "@repo/shared/services/staticGeneration/entity/staticPaths";
 import type {
   EntityPageParams,
@@ -34,11 +38,21 @@ const Page = ({ entityId }: EntityPageProps<never>): JSX.Element => {
   return (
     <EntityDataGate>
       {trsId ? (
-        <WorkflowInputsView
-          entityId={entityId}
-          organismBuilder={buildBRCOrganismDetails}
+        <WorkflowGate
+          fallback={
+            <WorkflowNotFound
+              entityContext="assembly"
+              href={replaceParameters(ROUTES.ANALYZE_WORKFLOWS, { entityId })}
+            />
+          }
           trsId={trsId}
-        />
+        >
+          <WorkflowInputsView
+            entityId={entityId}
+            organismBuilder={buildBRCOrganismDetails}
+            trsId={trsId}
+          />
+        </WorkflowGate>
       ) : (
         <AnalyzeWorkflowsView SideComponent={BRCSide} entityId={entityId} />
       )}

--- a/sites/brc-analytics/pages/data/organisms/[entityId]/analyze/workflows.tsx
+++ b/sites/brc-analytics/pages/data/organisms/[entityId]/analyze/workflows.tsx
@@ -1,7 +1,11 @@
 import { config } from "@brc/config/config";
 import { BRC_PAGE_META } from "@brc/meta/constants";
 import { buildOrganismDetails as buildBRCOrganismDetails } from "@brc/viewModelBuilders/viewModelBuilders";
+import { replaceParameters } from "@databiosphere/findable-ui/lib/utils/replaceParameters";
 import { EntityDataGate } from "@repo/shared/components/EntityDataGate/entityDataGate";
+import { WorkflowGate } from "@repo/shared/components/workflow/WorkflowGate/workflowGate";
+import { WorkflowNotFound } from "@repo/shared/components/workflow/WorkflowNotFound/workflowNotFound";
+import { ROUTES } from "@repo/shared/routes/constants";
 import { makeEntityStaticPaths } from "@repo/shared/services/staticGeneration/entity/staticPaths";
 import type {
   EntityPageParams,
@@ -29,11 +33,21 @@ const Page = ({ entityId }: EntityPageProps<never>): JSX.Element => {
 
   return (
     <EntityDataGate>
-      <OrganismWorkflowInputsView
-        entityId={entityId}
-        organismBuilder={buildBRCOrganismDetails}
+      <WorkflowGate
+        fallback={
+          <WorkflowNotFound
+            entityContext="organism"
+            href={replaceParameters(ROUTES.ORGANISM, { entityId })}
+          />
+        }
         trsId={trsId}
-      />
+      >
+        <OrganismWorkflowInputsView
+          entityId={entityId}
+          organismBuilder={buildBRCOrganismDetails}
+          trsId={trsId}
+        />
+      </WorkflowGate>
     </EntityDataGate>
   );
 };

--- a/sites/brc-analytics/tests/e2e/02-workflow-stepper.spec.ts
+++ b/sites/brc-analytics/tests/e2e/02-workflow-stepper.spec.ts
@@ -292,3 +292,34 @@ test.describe("Organism workflow route", () => {
     await expect(page).toHaveURL(new RegExp(`${organismPath}$`));
   });
 });
+
+test.describe("Stale workflow URL", () => {
+  test("should render the workflow not-found state for an unknown assembly trsId", async ({
+    page,
+  }) => {
+    await page.goto(buildAssemblyConfigureWorkflowUrl("not-a-real-workflow"));
+
+    await expect(
+      page.getByRole("heading", { level: 1, name: "Workflow not found" })
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "View Available Workflows" })
+    ).toBeVisible();
+  });
+
+  test("should render the workflow not-found state for an unknown organism trsId", async ({
+    page,
+  }) => {
+    await page.goto(
+      buildConfigureWorkflowUrl(
+        ROUTES.CONFIGURE_ORGANISM_WORKFLOW,
+        ORGANISM_ENTITY_ID,
+        "not-a-real-workflow"
+      )
+    );
+
+    await expect(
+      page.getByRole("heading", { level: 1, name: "Workflow not found" })
+    ).toBeVisible();
+  });
+});

--- a/sites/brc-analytics/tests/e2e/02-workflow-stepper.spec.ts
+++ b/sites/brc-analytics/tests/e2e/02-workflow-stepper.spec.ts
@@ -302,9 +302,15 @@ test.describe("Stale workflow URL", () => {
     await expect(
       page.getByRole("heading", { level: 1, name: "Workflow not found" })
     ).toBeVisible();
+    // The back-link target is the one thing each page configures — pin it.
     await expect(
       page.getByRole("link", { name: "View Available Workflows" })
-    ).toBeVisible();
+    ).toHaveAttribute(
+      "href",
+      replaceParameters(ROUTES.ANALYZE_WORKFLOWS, {
+        entityId: ASSEMBLY_ENTITY_ID,
+      })
+    );
   });
 
   test("should render the workflow not-found state for an unknown organism trsId", async ({
@@ -321,5 +327,11 @@ test.describe("Stale workflow URL", () => {
     await expect(
       page.getByRole("heading", { level: 1, name: "Workflow not found" })
     ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "View Available Workflows" })
+    ).toHaveAttribute(
+      "href",
+      replaceParameters(ROUTES.ORGANISM, { entityId: ORGANISM_ENTITY_ID })
+    );
   });
 });

--- a/sites/ga2/pages/data/assemblies/[entityId]/analyze/workflows.tsx
+++ b/sites/ga2/pages/data/assemblies/[entityId]/analyze/workflows.tsx
@@ -1,7 +1,11 @@
+import { replaceParameters } from "@databiosphere/findable-ui/lib/utils/replaceParameters";
 import { config } from "@ga2/config/config";
 import { GA2_PAGE_META } from "@ga2/meta/constants";
 import { Side as GA2Side } from "@ga2/views/EntityView/assembly/components/Side/ga2/side";
 import { EntityDataGate } from "@repo/shared/components/EntityDataGate/entityDataGate";
+import { WorkflowGate } from "@repo/shared/components/workflow/WorkflowGate/workflowGate";
+import { WorkflowNotFound } from "@repo/shared/components/workflow/WorkflowNotFound/workflowNotFound";
+import { ROUTES } from "@repo/shared/routes/constants";
 import { makeEntityStaticPaths } from "@repo/shared/services/staticGeneration/entity/staticPaths";
 import type {
   EntityPageParams,
@@ -25,7 +29,17 @@ const Page = ({ entityId }: EntityPageProps<never>): JSX.Element => {
   return (
     <EntityDataGate>
       {trsId ? (
-        <WorkflowInputsView entityId={entityId} trsId={trsId} />
+        <WorkflowGate
+          fallback={
+            <WorkflowNotFound
+              entityContext="assembly"
+              href={replaceParameters(ROUTES.ANALYZE_WORKFLOWS, { entityId })}
+            />
+          }
+          trsId={trsId}
+        >
+          <WorkflowInputsView entityId={entityId} trsId={trsId} />
+        </WorkflowGate>
       ) : (
         <AnalyzeWorkflowsView SideComponent={GA2Side} entityId={entityId} />
       )}

--- a/sites/ga2/pages/data/organisms/[entityId]/analyze/workflows.tsx
+++ b/sites/ga2/pages/data/organisms/[entityId]/analyze/workflows.tsx
@@ -1,6 +1,10 @@
+import { replaceParameters } from "@databiosphere/findable-ui/lib/utils/replaceParameters";
 import { config } from "@ga2/config/config";
 import { GA2_PAGE_META } from "@ga2/meta/constants";
 import { EntityDataGate } from "@repo/shared/components/EntityDataGate/entityDataGate";
+import { WorkflowGate } from "@repo/shared/components/workflow/WorkflowGate/workflowGate";
+import { WorkflowNotFound } from "@repo/shared/components/workflow/WorkflowNotFound/workflowNotFound";
+import { ROUTES } from "@repo/shared/routes/constants";
 import { makeEntityStaticPaths } from "@repo/shared/services/staticGeneration/entity/staticPaths";
 import type {
   EntityPageParams,
@@ -20,7 +24,17 @@ const Page = ({ entityId }: EntityPageProps<never>): JSX.Element => {
 
   return (
     <EntityDataGate>
-      <OrganismWorkflowInputsView entityId={entityId} trsId={trsId} />
+      <WorkflowGate
+        fallback={
+          <WorkflowNotFound
+            entityContext="organism"
+            href={replaceParameters(ROUTES.ORGANISM, { entityId })}
+          />
+        }
+        trsId={trsId}
+      >
+        <OrganismWorkflowInputsView entityId={entityId} trsId={trsId} />
+      </WorkflowGate>
     </EntityDataGate>
   );
 };

--- a/tests/components/workflowGate.test.tsx
+++ b/tests/components/workflowGate.test.tsx
@@ -1,0 +1,37 @@
+import { WorkflowGate } from "@repo/shared/components/workflow/WorkflowGate/workflowGate";
+import {
+  getEntitiesById,
+  setEntitiesById,
+} from "@repo/shared/services/workflows/store";
+import { render, screen } from "@testing-library/react";
+
+describe("WorkflowGate", () => {
+  beforeEach(() => {
+    getEntitiesById().clear();
+    const workflowsMap = new Map<string, unknown>();
+    workflowsMap.set("workflow-id", { trsId: "workflow-id" });
+    setEntitiesById("workflows", workflowsMap);
+  });
+
+  test("renders children for a known workflow", () => {
+    render(
+      <WorkflowGate fallback={<div>not found</div>} trsId="workflow-id">
+        <div>content</div>
+      </WorkflowGate>
+    );
+
+    expect(screen.getByText("content")).toBeTruthy();
+    expect(screen.queryByText("not found")).toBeNull();
+  });
+
+  test("renders the fallback for an unknown workflow", () => {
+    render(
+      <WorkflowGate fallback={<div>not found</div>} trsId="stale-workflow-id">
+        <div>content</div>
+      </WorkflowGate>
+    );
+
+    expect(screen.getByText("not found")).toBeTruthy();
+    expect(screen.queryByText("content")).toBeNull();
+  });
+});

--- a/tests/services/workflows.query.test.ts
+++ b/tests/services/workflows.query.test.ts
@@ -1,3 +1,4 @@
+import { findWorkflow } from "@repo/shared/services/workflows/entities";
 import { getEntities, getEntity } from "@repo/shared/services/workflows/query";
 import {
   getEntitiesById,
@@ -44,5 +45,23 @@ describe("workflows query", () => {
     expect(() => getEntity("assemblies", "missing")).toThrow(
       "No entity found for entity list type: assemblies and entity id: missing"
     );
+  });
+
+  test("findWorkflow returns workflow by trs id", () => {
+    const workflowsMap = new Map<string, unknown>();
+    workflowsMap.set("workflow-id", { trsId: "workflow-id" });
+
+    setEntitiesById("workflows", workflowsMap);
+
+    expect(findWorkflow("workflow-id")).toEqual({ trsId: "workflow-id" });
+  });
+
+  test("findWorkflow returns undefined for an unknown trs id", () => {
+    const workflowsMap = new Map<string, unknown>();
+    workflowsMap.set("workflow-id", { trsId: "workflow-id" });
+
+    setEntitiesById("workflows", workflowsMap);
+
+    expect(findWorkflow("stale-workflow-id")).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Closes #1487 

> **Stacked on #1663** — base is `fran/1488-configure-workflow-urlsearchparams`; GitHub will retarget to `main` when that merges. Only the last commit (`3022cc5f`) is this PR's diff.

A stale or unknown `?trsId=` on the analyze/workflows routes used to throw from `getWorkflow` and surface the generic error page ("Error / An error occurred processing your request" + raw store message). Now it renders a friendly, scoped state.

- **`findWorkflow(trsId)`** — non-throwing catalog lookup in the workflows service, mirroring `findOrganism`.
- **`WorkflowGate`** — the `EntityDataGate` idiom one level down: renders `children` when the TRS ID matches a catalog workflow, `fallback` otherwise. Rendered below `EntityDataGate`, so the store is always loaded before the lookup.
- **`WorkflowNotFound`** — friendly centered state reusing findable-ui's error-page layout primitives: amber status icon, "Workflow not found" heading, "The requested workflow isn't available for this assembly/organism. It may have been removed, or the link may be out of date.", and a "View Available Workflows" action.
- **Pages own the fallback** — all four analyze/workflows pages (BRC + GA2 × assembly/organism) pass `WorkflowNotFound` as the gate's `fallback` with a per-page back-link (assembly → compatible-workflows list, organism → organism detail). The views themselves are untouched.

Scope note: this handles the catalog-miss case (stale/hand-edited/indexed URLs). Compatibility gating for a real-but-unoffered workflow has no ready machinery in these views and the UI never links such workflows — deferred per the issue's own framing.

## Testing

- Unit: `findWorkflow` (hit/miss) and `WorkflowGate` (children/fallback) — 624 total pass.
- E2E: 2 new cases assert the not-found heading and back-link render for a garbage `trsId` on both the assembly and organism routes — BRC 81/81, GA2 8/8 pass.
- Both site builds compile; `tsc`, Prettier, ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)