### PR TITLE
fix: blog post overflows the mobile viewport: long inline code tokens don't break (#1672)

### DIFF
--- a/packages/shared/views/docs/components/Content/content.styles.ts
+++ b/packages/shared/views/docs/components/Content/content.styles.ts
@@ -12,6 +12,7 @@ const code = css`
   code {
     background-color: ${PALETTE.SMOKE_LIGHT};
     font-size: inherit;
+    overflow-wrap: anywhere;
     padding: 0 2px;
   }
 `;

--- a/sites/brc-analytics/tests/e2e/05-blog-mobile.spec.ts
+++ b/sites/brc-analytics/tests/e2e/05-blog-mobile.spec.ts
@@ -36,4 +36,17 @@ test.describe("Blog post on mobile", () => {
     ).toBeVisible();
     expect(await hasHorizontalOverflow(page)).toBe(false);
   });
+
+  test("detects the overflow when the wrap rule is neutralized", async ({
+    page,
+  }) => {
+    await page.goto(BLOG_PATH);
+
+    // Inversion check: with the fix disabled, the long tokens must overflow —
+    // proving the wrap rule is load-bearing and this spec detects its loss.
+    await page.addStyleTag({
+      content: "code { overflow-wrap: normal !important; }",
+    });
+    expect(await hasHorizontalOverflow(page)).toBe(true);
+  });
 });

--- a/sites/brc-analytics/tests/e2e/05-blog-mobile.spec.ts
+++ b/sites/brc-analytics/tests/e2e/05-blog-mobile.spec.ts
@@ -1,0 +1,36 @@
+import { devices, type Page } from "@playwright/test";
+import { expect, test } from "./utils/fixtures";
+
+const BLOG_PATH =
+  "/learn/blog/genotyping-cyclospora-assessing-current-practices";
+
+/**
+ * Returns whether the page overflows its viewport horizontally.
+ * @param page - The Playwright page.
+ * @returns True when the page scrolls horizontally.
+ */
+async function hasHorizontalOverflow(page: Page): Promise<boolean> {
+  return page.evaluate(() => {
+    const el = document.scrollingElement;
+    return !!el && el.scrollWidth > el.clientWidth;
+  });
+}
+
+test.describe("Blog post on mobile", () => {
+  test.use({ viewport: devices["iPhone 12"].viewport });
+
+  test("long inline-code tokens wrap instead of widening the page", async ({
+    page,
+  }) => {
+    await page.goto(BLOG_PATH);
+
+    // The post's references include long unbroken inline-code tokens; the
+    // page must not overflow the viewport horizontally.
+    await expect(
+      page.getByRole("heading", {
+        name: /genotyping cyclospora/i,
+      })
+    ).toBeVisible();
+    expect(await hasHorizontalOverflow(page)).toBe(false);
+  });
+});

--- a/sites/brc-analytics/tests/e2e/05-blog-mobile.spec.ts
+++ b/sites/brc-analytics/tests/e2e/05-blog-mobile.spec.ts
@@ -5,6 +5,25 @@ const BLOG_PATH =
   "/learn/blog/genotyping-cyclospora-assessing-current-practices";
 
 /**
+ * Waits for the post to render and asserts the long unbreakable inline-code
+ * token that both cases depend on is present — so a content edit that removes
+ * it fails loudly here rather than reading as a mysterious CSS regression.
+ * @param page - The Playwright page.
+ */
+async function expectPostWithLongToken(page: Page): Promise<void> {
+  await expect(
+    page.getByRole("heading", {
+      name: /genotyping cyclospora/i,
+    })
+  ).toBeVisible();
+  await expect(
+    page.locator("code", {
+      hasText: "REFERENCE_CLUSTER_LIST/2018_gold_clusters.txt",
+    })
+  ).toBeVisible();
+}
+
+/**
  * Returns whether the page overflows its viewport horizontally.
  * @param page - The Playwright page.
  * @returns True when the page scrolls horizontally.
@@ -29,11 +48,7 @@ test.describe("Blog post on mobile", () => {
 
     // The post's references include long unbroken inline-code tokens; the
     // page must not overflow the viewport horizontally.
-    await expect(
-      page.getByRole("heading", {
-        name: /genotyping cyclospora/i,
-      })
-    ).toBeVisible();
+    await expectPostWithLongToken(page);
     expect(await hasHorizontalOverflow(page)).toBe(false);
   });
 
@@ -43,11 +58,7 @@ test.describe("Blog post on mobile", () => {
     await page.goto(BLOG_PATH);
 
     // Wait for the post to render before measuring layout.
-    await expect(
-      page.getByRole("heading", {
-        name: /genotyping cyclospora/i,
-      })
-    ).toBeVisible();
+    await expectPostWithLongToken(page);
 
     // Inversion check: with the fix disabled, the long tokens must overflow —
     // proving the wrap rule is load-bearing and this spec detects its loss.

--- a/sites/brc-analytics/tests/e2e/05-blog-mobile.spec.ts
+++ b/sites/brc-analytics/tests/e2e/05-blog-mobile.spec.ts
@@ -42,11 +42,18 @@ test.describe("Blog post on mobile", () => {
   }) => {
     await page.goto(BLOG_PATH);
 
+    // Wait for the post to render before measuring layout.
+    await expect(
+      page.getByRole("heading", {
+        name: /genotyping cyclospora/i,
+      })
+    ).toBeVisible();
+
     // Inversion check: with the fix disabled, the long tokens must overflow —
     // proving the wrap rule is load-bearing and this spec detects its loss.
     await page.addStyleTag({
       content: "code { overflow-wrap: normal !important; }",
     });
-    expect(await hasHorizontalOverflow(page)).toBe(true);
+    await expect.poll(() => hasHorizontalOverflow(page)).toBe(true);
   });
 });

--- a/sites/brc-analytics/tests/e2e/05-blog-mobile.spec.ts
+++ b/sites/brc-analytics/tests/e2e/05-blog-mobile.spec.ts
@@ -11,12 +11,15 @@ const BLOG_PATH =
  */
 async function hasHorizontalOverflow(page: Page): Promise<boolean> {
   return page.evaluate(() => {
-    const el = document.scrollingElement;
-    return !!el && el.scrollWidth > el.clientWidth;
+    const el = document.scrollingElement ?? document.documentElement;
+    // 1px tolerance absorbs scrollbar and sub-pixel rounding noise.
+    return el.scrollWidth > el.clientWidth + 1;
   });
 }
 
 test.describe("Blog post on mobile", () => {
+  // Viewport-only emulation: the assertion is pure CSS layout, and the full
+  // device descriptor sets isMobile, which Firefox doesn't support.
   test.use({ viewport: devices["iPhone 12"].viewport });
 
   test("long inline-code tokens wrap instead of widening the page", async ({


### PR DESCRIPTION
## Summary

Closes #1672

On mobile, the Cyclospora blog post rendered wider than the viewport: long unbreakable inline-code tokens (`REFERENCE_CLUSTER_LIST/2018_gold_clusters.txt`, `CYCLOSPORA_FEB_11_2020.bed` in reference #10) have no natural break points — underscores and slashes aren't line-break opportunities — so they stretched the content column past the screen edge.

**The fix** is one rule in the shared learn/docs content styles (`packages/shared/views/docs/components/Content/content.styles.ts`): `overflow-wrap: anywhere` on inline `code`, letting long tokens break mid-token instead of widening the page. It applies to all learn/docs content on both sites, not just this post.

Fenced `pre` blocks need no change — the global baseline already applies `white-space: pre-wrap` + `word-break: break-word`, so they wrap rather than overflow.

**Regression spec** (`sites/brc-analytics/tests/e2e/05-blog-mobile.spec.ts`), two cases at iPhone-12 width:
1. The post renders with no horizontal overflow (1px tolerance, `documentElement` fallback).
2. **Inversion check, committed in the spec**: with the wrap rule neutralized via an injected `overflow-wrap: normal`, the overflow must return — proving the rule is load-bearing and that the spec still has the long tokens that make case 1 meaningful.

## Verification

- Both spec cases verified against a served production build (happy path: no overflow; inverted: overflow reproduces).
- Full spec passed chromium/firefox/webkit pre-hardening; CI runs it against a clean server.
- `tsc --noEmit`, ESLint, Prettier pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)